### PR TITLE
A few quality of life improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ in the directory where the `sqlc` command is run.
 
 Each package document has the following keys:
 - `name`:
-  - The package name to use for the generated code
+  - The package name to use for the generated code. Defaults to `path` basename
 - `emit_json_tags`:
   - If true, add JSON tags to generated structs. Defaults to `false`.
 - `emit_prepared_queries`:
@@ -291,9 +291,9 @@ Each package document has the following keys:
 - `path`:
   - Output directory for generated code
 - `queries`:
-  - Directory of SQL queries stored in `.sql` files
+  - Directory of SQL queries or path to single SQL file
 - `schema`:
-  - Directory of SQL migrations, stored in `.sql` files
+  - Directory of SQL migrations or path to single SQL file
 
 ## Downloads
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -98,7 +98,7 @@ var genCmd = &cobra.Command{
 		}
 
 		for _, pkg := range settings.Packages {
-			c, err := dinosql.ParseCatalog(pkg.MigrationDir)
+			c, err := dinosql.ParseCatalog(pkg.Schema)
 			if err != nil {
 				return err
 			}
@@ -146,7 +146,7 @@ var checkCmd = &cobra.Command{
 		}
 
 		for _, pkg := range settings.Packages {
-			c, err := dinosql.ParseCatalog(pkg.MigrationDir)
+			c, err := dinosql.ParseCatalog(pkg.Schema)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -111,6 +111,9 @@ var genCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
+
+			os.MkdirAll(pkg.Path, 0755)
+
 			for name, source := range files {
 				filename := filepath.Join(pkg.Path, name)
 				if err := ioutil.WriteFile(filename, []byte(source), 0644); err != nil {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -110,6 +111,10 @@ var genCmd = &cobra.Command{
 			files, err := dinosql.Generate(q, settings, pkg)
 			if err != nil {
 				return err
+			}
+
+			if pkg.Path == "" {
+				return errors.New("package path must be set")
 			}
 
 			os.MkdirAll(pkg.Path, 0755)

--- a/internal/dinosql/checks_test.go
+++ b/internal/dinosql/checks_test.go
@@ -14,7 +14,7 @@ func TestFuncs(t *testing.T) {
 		pg.NewCatalog(),
 		GenerateSettings{},
 		PackageSettings{
-			QueryDir: filepath.Join("testdata", "funcs"),
+			Queries: filepath.Join("testdata", "funcs"),
 		},
 	)
 	if err != nil {

--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"go/format"
 	"log"
+	"path/filepath"
 	"sort"
 	"strings"
 	"text/template"
@@ -890,7 +891,7 @@ func Generate(r *Result, global GenerateSettings, settings PackageSettings) (map
 
 	pkg := settings.Name
 	if pkg == "" {
-		return nil, fmt.Errorf("package must have a name")
+		pkg = filepath.Base(settings.Path)
 	}
 
 	dbFile := template.Must(template.New("table").Funcs(funcMap).Parse(dbTmpl))

--- a/internal/dinosql/parser_test.go
+++ b/internal/dinosql/parser_test.go
@@ -124,7 +124,7 @@ func TestParseSchema(t *testing.T) {
 	}
 
 	q, err := ParseQueries(c, GenerateSettings{}, PackageSettings{
-		QueryDir: filepath.Join("testdata", "ondeck", "query"),
+		Queries: filepath.Join("testdata", "ondeck", "query"),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/dinosql/testdata/ondeck/sqlc.json
+++ b/internal/dinosql/testdata/ondeck/sqlc.json
@@ -7,7 +7,6 @@
       "queries": "./query"
     },
     {
-      "name": "prepared",
       "path": "prepared",
       "schema": "./schema",
       "queries": "./query",


### PR DESCRIPTION
- `name` in the package config is now optional
- return an error if package path is empty
- `schema` and `queries` can point to individual files
- the package path is automatically created if it does not exist

Fixes #67 