### PR TITLE
pg: Add location to errors

### DIFF
--- a/internal/dinosql/checks.go
+++ b/internal/dinosql/checks.go
@@ -9,16 +9,6 @@ import (
 	nodes "github.com/lfittl/pg_query_go/nodes"
 )
 
-type Error struct {
-	Message string
-	Code    string
-	Hint    string
-}
-
-func (e Error) Error() string {
-	return e.Message
-}
-
 func validateParamRef(n nodes.Node) error {
 	var allrefs []nodes.ParamRef
 
@@ -37,7 +27,7 @@ func validateParamRef(n nodes.Node) error {
 
 	for i := 1; i <= len(seen); i += 1 {
 		if _, ok := seen[i]; !ok {
-			return Error{
+			return pg.Error{
 				Code:    "42P18",
 				Message: fmt.Sprintf("could not determine data type of parameter $%d", i),
 			}
@@ -90,10 +80,11 @@ func (v *funcCallVisitor) Visit(node nodes.Node) Visitor {
 		sig = append(sig, "unknown")
 	}
 
-	v.err = Error{
-		Code:    "42883",
-		Message: fmt.Sprintf("function %s(%s) does not exist", fqn.Rel, strings.Join(sig, ", ")),
-		Hint:    "No function matches the given name and argument types. You might need to add explicit type casts.",
+	v.err = pg.Error{
+		Code:     "42883",
+		Message:  fmt.Sprintf("function %s(%s) does not exist", fqn.Rel, strings.Join(sig, ", ")),
+		Hint:     "No function matches the given name and argument types. You might need to add explicit type casts.",
+		Location: funcCall.Location,
 	}
 
 	return nil

--- a/internal/dinosql/parser_test.go
+++ b/internal/dinosql/parser_test.go
@@ -35,7 +35,7 @@ func TestPluck(t *testing.T) {
 	for i, stmt := range tree.Statements {
 		switch n := stmt.(type) {
 		case nodes.RawStmt:
-			q, _, _, err := pluckQuery(pluck, n)
+			q, err := pluckQuery(pluck, n)
 			if err != nil {
 				t.Error(err)
 				continue
@@ -80,10 +80,7 @@ func TestLineColumn(t *testing.T) {
 		{tree.Statements[5], 10, 12},
 	} {
 		raw := test.node.(nodes.RawStmt)
-		_, line, column, err := pluckQuery(lineColumn, raw)
-		if err != nil {
-			t.Fatal(err)
-		}
+		line, column := lineno(lineColumn, raw.StmtLocation)
 		if line != test.line {
 			t.Errorf("expected stmt %d to be on line %d, not %d", i, test.line, line)
 		}

--- a/internal/pg/errors.go
+++ b/internal/pg/errors.go
@@ -3,9 +3,10 @@ package pg
 import "fmt"
 
 type Error struct {
-	Message string
-	Code    string
-	Hint    string
+	Message  string
+	Code     string
+	Hint     string
+	Location int
 }
 
 func (e Error) Error() string {


### PR DESCRIPTION
Annotate error messages with node location, if available

```sql
CREATE TABLE foo (bar text);

SELECT *
FROM bar;
```

```text
# Before
# package db
queriy.sql:3:1: relation "bar" does not exist

# After
# package db
queriy.sql:4:6: relation "bar" does not exist
```
