### PR TITLE
internal/dinosql: Prepare() with no GoQueries still valid

### DIFF
--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -688,7 +688,11 @@ func New(db dbtx) *Queries {
 {{if .EmitPreparedQueries}}
 func Prepare(ctx context.Context, db dbtx) (*Queries, error) {
 	q := Queries{db: db}
-	var err error{{range .GoQueries}}
+	var err error
+	{{- if eq (len .GoQueries) 0 }}
+	_ = err
+	{{- end }}
+	{{- range .GoQueries }}
 	if q.{{.FieldName}}, err = db.PrepareContext(ctx, {{.ConstantName}}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Assign the error value to _ if no queries exist, so the file still
compiles. This is an edge case so I'm not sure it's worth thinking
more about.

Fixes #94.