### PR TITLE
parser: Support function calls in expressions

### DIFF
--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -642,6 +642,22 @@ func TestQueries(t *testing.T) {
 				},
 			},
 		},
+		{
+			"lower",
+			`
+			CREATE TABLE foo (bar text not null, bat text not null);
+			SELECT bar FROM foo WHERE bar = $1 AND LOWER(bat) = $2;
+			`,
+			Query{
+				Columns: []core.Column{
+					{Name: "bar", DataType: "text", NotNull: true},
+				},
+				Params: []Parameter{
+					{1, core.Column{Name: "bar", DataType: "text", NotNull: true}},
+					{2, core.Column{Name: "bat", DataType: "text", NotNull: true}},
+				},
+			},
+		},
 	} {
 		test := tc
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
While this is a fix for #103, it's not a long term solution. We need to be smarter about determining the type of parameters.

Fixes #103 