### PR TITLE
gen: Create consistent JSON tags

### DIFF
--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -556,9 +556,23 @@ func (r Result) columnsToStruct(name string, columns []core.Column) *GoStruct {
 	return &gs
 }
 
+func argName(name string) string {
+	out := ""
+	for i, p := range strings.Split(name, "_") {
+		if i == 0 {
+			out += strings.ToLower(p)
+		} else if p == "id" {
+			out += "ID"
+		} else {
+			out += strings.Title(p)
+		}
+	}
+	return out
+}
+
 func paramName(p Parameter) string {
 	if p.Column.Name != "" {
-		return p.Column.Name
+		return argName(p.Column.Name)
 	}
 	return fmt.Sprintf("dollar_%d", p.Number)
 }

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -804,20 +804,6 @@ func search(root nodes.Node, f func(nodes.Node) bool) nodes.List {
 	return ns.list
 }
 
-func argName(name string) string {
-	out := ""
-	for i, p := range strings.Split(name, "_") {
-		if i == 0 {
-			out += strings.ToLower(p)
-		} else if p == "id" {
-			out += "ID"
-		} else {
-			out += strings.Title(p)
-		}
-	}
-	return out
-}
-
 func resolveCatalogRefs(c core.Catalog, rvs []nodes.RangeVar, args []paramRef) ([]Parameter, error) {
 	aliasMap := map[string]core.FQN{}
 	// TODO: Deprecate defaultTable
@@ -939,7 +925,7 @@ func resolveCatalogRefs(c core.Catalog, rvs []nodes.RangeVar, args []paramRef) (
 						a = append(a, Parameter{
 							Number: ref.ref.Number,
 							Column: core.Column{
-								Name:     argName(key),
+								Name:     key,
 								DataType: c.DataType,
 								NotNull:  c.NotNull,
 								IsArray:  c.IsArray,
@@ -972,7 +958,7 @@ func resolveCatalogRefs(c core.Catalog, rvs []nodes.RangeVar, args []paramRef) (
 				a = append(a, Parameter{
 					Number: ref.ref.Number,
 					Column: core.Column{
-						Name:     argName(key),
+						Name:     key,
 						DataType: c.DataType,
 						NotNull:  c.NotNull,
 						IsArray:  c.IsArray,

--- a/internal/dinosql/parser_test.go
+++ b/internal/dinosql/parser_test.go
@@ -165,7 +165,8 @@ func TestParseSchema(t *testing.T) {
 	}
 
 	q, err := ParseQueries(c, GenerateSettings{}, PackageSettings{
-		Queries: filepath.Join("testdata", "ondeck", "query"),
+		Queries:      filepath.Join("testdata", "ondeck", "query"),
+		EmitJSONTags: true,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -173,7 +174,8 @@ func TestParseSchema(t *testing.T) {
 
 	t.Run("default", func(t *testing.T) {
 		output, err := Generate(q, GenerateSettings{}, PackageSettings{
-			Name: "ondeck",
+			Name:         "ondeck",
+			EmitJSONTags: true,
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -214,7 +214,7 @@ func TestQueries(t *testing.T) {
 					{1, core.Column{NotNull: true, DataType: "text", Name: "slug"}},
 					{2, core.Column{NotNull: true, DataType: "pg_catalog.varchar", Name: "name"}},
 					{3, core.Column{NotNull: true, DataType: "text", Name: "city"}},
-					{4, core.Column{NotNull: true, DataType: "pg_catalog.varchar", Name: "spotifyPlaylist"}},
+					{4, core.Column{NotNull: true, DataType: "pg_catalog.varchar", Name: "spotify_playlist"}},
 					{5, core.Column{NotNull: true, DataType: "status", Name: "status"}},
 				},
 			},

--- a/internal/dinosql/testdata/ondeck/city.sql.go
+++ b/internal/dinosql/testdata/ondeck/city.sql.go
@@ -18,8 +18,8 @@ INSERT INTO city (
 `
 
 type CreateCityParams struct {
-	Name string
-	Slug string
+	Name string `json:"name"`
+	Slug string `json:"slug"`
 }
 
 func (q *Queries) CreateCity(ctx context.Context, arg CreateCityParams) (City, error) {
@@ -78,8 +78,8 @@ WHERE slug = $1
 `
 
 type UpdateCityNameParams struct {
-	Slug string
-	Name string
+	Slug string `json:"slug"`
+	Name string `json:"name"`
 }
 
 func (q *Queries) UpdateCityName(ctx context.Context, arg UpdateCityNameParams) error {

--- a/internal/dinosql/testdata/ondeck/models.go
+++ b/internal/dinosql/testdata/ondeck/models.go
@@ -15,18 +15,18 @@ const (
 )
 
 type City struct {
-	Slug string
-	Name string
+	Slug string `json:"slug"`
+	Name string `json:"name"`
 }
 
 type Venue struct {
-	ID              int32
-	Status          Status
-	Slug            string
-	Name            string
-	City            string
-	SpotifyPlaylist string
-	SongkickID      sql.NullString
-	Tags            []string
-	CreatedAt       time.Time
+	ID              int32          `json:"id"`
+	Status          Status         `json:"status"`
+	Slug            string         `json:"slug"`
+	Name            string         `json:"name"`
+	City            string         `json:"city"`
+	SpotifyPlaylist string         `json:"spotify_playlist"`
+	SongkickID      sql.NullString `json:"songkick_id"`
+	Tags            []string       `json:"tags"`
+	CreatedAt       time.Time      `json:"created_at"`
 }

--- a/internal/dinosql/testdata/ondeck/sqlc.json
+++ b/internal/dinosql/testdata/ondeck/sqlc.json
@@ -4,7 +4,8 @@
       "name": "ondeck",
       "path": ".",
       "schema": "./schema",
-      "queries": "./query"
+      "queries": "./query",
+      "emit_json_tags": true
     },
     {
       "path": "prepared",

--- a/internal/dinosql/testdata/ondeck/venue.sql.go
+++ b/internal/dinosql/testdata/ondeck/venue.sql.go
@@ -30,12 +30,12 @@ INSERT INTO venue (
 `
 
 type CreateVenueParams struct {
-	Slug            string
-	Name            string
-	City            string
-	SpotifyPlaylist string
-	Status          Status
-	Tags            []string
+	Slug            string   `json:"slug"`
+	Name            string   `json:"name"`
+	City            string   `json:"city"`
+	SpotifyPlaylist string   `json:"spotify_playlist"`
+	Status          Status   `json:"status"`
+	Tags            []string `json:"tags"`
 }
 
 func (q *Queries) CreateVenue(ctx context.Context, arg CreateVenueParams) (int32, error) {
@@ -69,8 +69,8 @@ WHERE slug = $1 AND city = $2
 `
 
 type GetVenueParams struct {
-	Slug string
-	City string
+	Slug string `json:"slug"`
+	City string `json:"city"`
 }
 
 func (q *Queries) GetVenue(ctx context.Context, arg GetVenueParams) (Venue, error) {
@@ -138,8 +138,8 @@ RETURNING id
 `
 
 type UpdateVenueNameParams struct {
-	Slug string
-	Name string
+	Slug string `json:"slug"`
+	Name string `json:"name"`
 }
 
 func (q *Queries) UpdateVenueName(ctx context.Context, arg UpdateVenueNameParams) (int32, error) {
@@ -159,8 +159,8 @@ ORDER BY 1
 `
 
 type VenueCountByCityRow struct {
-	City  string
-	Count int64
+	City  string `json:"city"`
+	Count int64  `json:"count"`
 }
 
 func (q *Queries) VenueCountByCity(ctx context.Context) ([]VenueCountByCityRow, error) {


### PR DESCRIPTION
A field's JSON tag value should be the name of the column as it appears
in the database.

Fixes #108 