### PR TITLE
Add version to configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ in the directory where the `sqlc` command is run.
 
 ```json
 {
+  "version": "1",
   "packages": [
     {
       "name": "db",

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -75,7 +75,7 @@ var initCmd = &cobra.Command{
 		if _, err := os.Stat("sqlc.json"); !os.IsNotExist(err) {
 			return nil
 		}
-		blob, err := json.MarshalIndent(dinosql.GenerateSettings{}, "  ", "")
+		blob, err := json.MarshalIndent(dinosql.GenerateSettings{Version: "1"}, "", "  ")
 		if err != nil {
 			return err
 		}

--- a/internal/dinosql/config.go
+++ b/internal/dinosql/config.go
@@ -18,8 +18,8 @@ type PackageSettings struct {
 type GenerateSettings struct {
 	Version   string            `json:"version"`
 	Packages  []PackageSettings `json:"packages"`
-	Overrides []TypeOverride    `json:"overrides"`
-	Rename    map[string]string `json:"rename"`
+	Overrides []TypeOverride    `json:"overrides,omitempty"`
+	Rename    map[string]string `json:"rename,omitempty"`
 }
 
 var ErrMissingVersion = errors.New("no version number")

--- a/internal/dinosql/config.go
+++ b/internal/dinosql/config.go
@@ -1,0 +1,46 @@
+package dinosql
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+)
+
+type PackageSettings struct {
+	Name                string `json:"name"`
+	Path                string `json:"path"`
+	Schema              string `json:"schema"`
+	Queries             string `json:"queries"`
+	EmitPreparedQueries bool   `json:"emit_prepared_queries"`
+	EmitJSONTags        bool   `json:"emit_json_tags"`
+}
+
+type GenerateSettings struct {
+	Version   string            `json:"version"`
+	Packages  []PackageSettings `json:"packages"`
+	Overrides []TypeOverride    `json:"overrides"`
+	Rename    map[string]string `json:"rename"`
+}
+
+var ErrMissingVersion = errors.New("no version number")
+var ErrUnknownVersion = errors.New("invalid version number")
+var ErrNoPackages = errors.New("no packages")
+
+func ParseConfig(rd io.Reader) (GenerateSettings, error) {
+	dec := json.NewDecoder(rd)
+	dec.DisallowUnknownFields()
+	var config GenerateSettings
+	if err := dec.Decode(&config); err != nil {
+		return config, err
+	}
+	if config.Version == "" {
+		return config, ErrMissingVersion
+	}
+	if config.Version != "1" {
+		return config, ErrUnknownVersion
+	}
+	if len(config.Packages) == 0 {
+		return config, ErrNoPackages
+	}
+	return config, nil
+}

--- a/internal/dinosql/config_test.go
+++ b/internal/dinosql/config_test.go
@@ -1,0 +1,63 @@
+package dinosql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const missingVersion = `{
+}`
+
+const missingPackages = `{
+  "version": "1"
+}`
+
+const unknownVersion = `{
+  "version": "foo"
+}`
+
+const unknownFields = `{
+  "foo": "bar"
+}`
+
+func TestBadConfigs(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  string
+		json string
+	}{
+		{
+			"missing version",
+			"no version number",
+			missingVersion,
+		},
+		{
+			"missing packages",
+			"no packages",
+			missingPackages,
+		},
+		{
+			"unknown version",
+			"invalid version number",
+			unknownVersion,
+		},
+		{
+			"unknown fields",
+			"json: unknown field \"foo\"",
+			unknownFields,
+		},
+	} {
+		tt := test
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseConfig(strings.NewReader(tt.json))
+			if err == nil {
+				t.Fatalf("expected err; got nil")
+			}
+			if diff := cmp.Diff(err.Error(), tt.err); diff != "" {
+				t.Errorf("differed (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -997,18 +997,3 @@ type TypeOverride struct {
 	GoType       string `json:"go_type"`
 	Null         bool   `json:"null"`
 }
-
-type PackageSettings struct {
-	Name                string `json:"name"`
-	Path                string `json:"path"`
-	Schema              string `json:"schema"`
-	Queries             string `json:"queries"`
-	EmitPreparedQueries bool   `json:"emit_prepared_queries"`
-	EmitJSONTags        bool   `json:"emit_json_tags"`
-}
-
-type GenerateSettings struct {
-	Packages  []PackageSettings `json:"packages"`
-	Overrides []TypeOverride    `json:"overrides"`
-	Rename    map[string]string `json:"rename"`
-}

--- a/internal/dinosql/testdata/ondeck/sqlc.json
+++ b/internal/dinosql/testdata/ondeck/sqlc.json
@@ -1,4 +1,5 @@
 {
+  "version": "1",
   "packages": [
     {
       "name": "ondeck",


### PR DESCRIPTION
Configuration files must now have a version set. 

```
{
  "version": "1",
  "packages": [...]
}
```

Thanks to @inconshreveable for the suggestion. This will be an annoying update for the early adopters, but I think it's worth the pain for all future sqlc users.

Fixes #113 