### PR TITLE
Implement per-column type overrides.

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,31 @@ Each override document has the following keys:
 - `null`:
   - If true, use this type when a column in nullable. Defaults to `false`.
 
+### Per-Column Type Overrides
+
+Sometimes you would like to override the Go type used in model or query generation for
+a specific field of a table and not on a type basis as described in the previous section.
+
+You may accomplish this by specifying the `overrides` field on any `package` object. In this
+example, just a specific column, `authors.id`, is mapped to `ksuid.KSUID` type:
+
+```
+{
+  "version": "1",
+  "packages": [
+    {
+      "overrides": [
+        {
+          "column": "authors.id",
+          "go_type": "github.com/segmentio/ksuid.KSUID"
+        }
+      ]
+      ...
+    }
+  ]
+}
+```
+
 ### Renaming Struct Fields
 
 Struct field names are generated from column names using a simple algorithm:

--- a/README.md
+++ b/README.md
@@ -324,8 +324,7 @@ instead.
   "packages": [...],
   "overrides": [
       {
-          "go_type": "uuid.UUID",
-          "package": "github.com/gofrs/uuid",
+          "go_type": "github.com/gofrs/uuid.UUID",
           "postgres_type": "uuid"
       }
   ]
@@ -336,9 +335,7 @@ Each override document has the following keys:
 - `postgres_type`:
   - The PostgreSQL type to override. Find the full list of supported types in [gen.go](https://github.com/kyleconroy/sqlc/blob/master/internal/dinosql/gen.go#L438).
 - `go_type`:
-  - The Go type, with package name, to use in the generated code.
-- `package`:
-  - The full import path for the package.
+  - A fully qualified name to a Go type to use in the generated code.
 - `null`:
   - If true, use this type when a column in nullable. Defaults to `false`.
 
@@ -347,25 +344,40 @@ Each override document has the following keys:
 Sometimes you would like to override the Go type used in model or query generation for
 a specific field of a table and not on a type basis as described in the previous section.
 
-You may accomplish this by specifying the `overrides` field on any `package` object. In this
-example, just a specific column, `authors.id`, is mapped to `ksuid.KSUID` type:
+This may be configured by specifying the `column` property in the override definition. `column`
+should be of the form `table.column` buy you may be even more specify by specifying `schema.table.column`
+or `catalog.schema.table.column`.
+
+```
+{
+  "version": "1",
+  "packages": [...],
+  "overrides": [
+    {
+      "column": "authors.id",
+      "go_type": "github.com/segmentio/ksuid.KSUID"
+    }
+  ]
+}
+```
+
+### Package Level Overrides
+
+Overrides can be configured globally, as demonstrated in the previous sections, or they can be configured on a per-package which
+scopes the override behavior to just a single package:
 
 ```
 {
   "version": "1",
   "packages": [
     {
-      "overrides": [
-        {
-          "column": "authors.id",
-          "go_type": "github.com/segmentio/ksuid.KSUID"
-        }
-      ]
       ...
+      "overrides": [...]
     }
-  ]
+  ],
 }
 ```
+
 
 ### Renaming Struct Fields
 

--- a/internal/catalog/build.go
+++ b/internal/catalog/build.go
@@ -151,6 +151,7 @@ func Update(c *pg.Catalog, stmt nodes.Node) error {
 						DataType: join(d.TypeName.Names, "."),
 						NotNull:  isNotNull(d),
 						IsArray:  isArray(d.TypeName),
+						Table:    fqn,
 					})
 
 				case nodes.AT_AlterColumnType:
@@ -197,6 +198,7 @@ func Update(c *pg.Catalog, stmt nodes.Node) error {
 					DataType: join(n.TypeName.Names, "."),
 					NotNull:  isNotNull(n),
 					IsArray:  isArray(n.TypeName),
+					Table:    fqn,
 				})
 			}
 		}

--- a/internal/catalog/build_test.go
+++ b/internal/catalog/build_test.go
@@ -105,7 +105,7 @@ func TestUpdate(t *testing.T) {
 						Tables: map[string]pg.Table{
 							"foo": pg.Table{
 								Name:    "foo",
-								Columns: []pg.Column{{Name: "bar", DataType: "text", NotNull: true}},
+								Columns: []pg.Column{{Name: "bar", DataType: "text", NotNull: true, Table: pg.FQN{Schema: "public", Rel: "foo"}}},
 							},
 						},
 					},
@@ -123,7 +123,7 @@ func TestUpdate(t *testing.T) {
 							"foo": pg.Table{
 								Name: "foo",
 								Columns: []pg.Column{
-									{Name: "bar", DataType: "text", IsArray: true, NotNull: true},
+									{Name: "bar", DataType: "text", IsArray: true, NotNull: true, Table: pg.FQN{Schema: "public", Rel: "foo"}},
 								},
 							},
 						},
@@ -142,7 +142,7 @@ func TestUpdate(t *testing.T) {
 						Tables: map[string]pg.Table{
 							"foo": pg.Table{
 								Name:    "foo",
-								Columns: []pg.Column{{Name: "bar", DataType: "text"}},
+								Columns: []pg.Column{{Name: "bar", DataType: "text", Table: pg.FQN{Schema: "public", Rel: "foo"}}},
 							},
 						},
 					},
@@ -160,7 +160,7 @@ func TestUpdate(t *testing.T) {
 						Tables: map[string]pg.Table{
 							"foo": pg.Table{
 								Name:    "foo",
-								Columns: []pg.Column{{Name: "bar", DataType: "text"}},
+								Columns: []pg.Column{{Name: "bar", DataType: "text", Table: pg.FQN{Schema: "public", Rel: "foo"}}},
 							},
 						},
 					},
@@ -178,7 +178,7 @@ func TestUpdate(t *testing.T) {
 						Tables: map[string]pg.Table{
 							"foo": pg.Table{
 								Name:    "foo",
-								Columns: []pg.Column{{Name: "baz", DataType: "text"}},
+								Columns: []pg.Column{{Name: "baz", DataType: "text", Table: pg.FQN{Schema: "public", Rel: "foo"}}},
 							},
 						},
 					},
@@ -196,7 +196,7 @@ func TestUpdate(t *testing.T) {
 						Tables: map[string]pg.Table{
 							"foo": pg.Table{
 								Name:    "foo",
-								Columns: []pg.Column{{Name: "bar", DataType: "bool"}},
+								Columns: []pg.Column{{Name: "bar", DataType: "bool", Table: pg.FQN{Schema: "public", Rel: "foo"}}},
 							},
 						},
 					},
@@ -335,7 +335,7 @@ func TestUpdate(t *testing.T) {
 							"venues": pg.Table{
 								Name: "venues",
 								Columns: []pg.Column{
-									{Name: "id", DataType: "serial", NotNull: true},
+									{Name: "id", DataType: "serial", NotNull: true, Table: pg.FQN{Schema: "public", Rel: "venues"}},
 								},
 							},
 						},

--- a/internal/dinosql/config.go
+++ b/internal/dinosql/config.go
@@ -3,23 +3,94 @@ package dinosql
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
-)
+	"strings"
 
-type PackageSettings struct {
-	Name                string `json:"name"`
-	Path                string `json:"path"`
-	Schema              string `json:"schema"`
-	Queries             string `json:"queries"`
-	EmitPreparedQueries bool   `json:"emit_prepared_queries"`
-	EmitJSONTags        bool   `json:"emit_json_tags"`
-}
+	"github.com/kyleconroy/sqlc/internal/pg"
+)
 
 type GenerateSettings struct {
 	Version   string            `json:"version"`
 	Packages  []PackageSettings `json:"packages"`
-	Overrides []TypeOverride    `json:"overrides,omitempty"`
+	Overrides []Override        `json:"overrides,omitempty"`
 	Rename    map[string]string `json:"rename,omitempty"`
+}
+
+type PackageSettings struct {
+	Name                string     `json:"name"`
+	Path                string     `json:"path"`
+	Schema              string     `json:"schema"`
+	Queries             string     `json:"queries"`
+	EmitPreparedQueries bool       `json:"emit_prepared_queries"`
+	EmitJSONTags        bool       `json:"emit_json_tags"`
+	Overrides           []Override `json:"overrides"`
+}
+
+type Override struct {
+	// name of the golang type to use, e.g. `github.com/segmentio/ksuid.KSUID`
+	GoType string `json:"go_type"`
+
+	// fully qualified name of the Go type, e.g. `github.com/segmentio/ksuid.KSUID`
+	PostgresType string `json:"postgres_type"`
+
+	// True if the GoType should override if the maching postgres type is nullable
+	Null bool `json:"null"`
+
+	// fully qualified name of the column, e.g. `accounts.id`
+	Column string `json:"column"`
+
+	columnName string
+	table      pg.FQN
+	goTypeName string
+	goPackage  string
+}
+
+func (o *Override) Parse() error {
+	// validate option combinations
+	switch {
+	case o.Column != "" && o.PostgresType != "":
+		return fmt.Errorf("Override specifying both `column` (%q) and `postgres_type` (%q) is not valid.", o.Column, o.PostgresType)
+	case o.Column == "" && o.PostgresType == "":
+		return fmt.Errorf("Override must specify one of either `column` or `postgres_type`")
+	}
+
+	// validate Column
+	if o.Column != "" {
+		colParts := strings.Split(o.Column, ".")
+		switch len(colParts) {
+		case 2:
+			o.columnName = colParts[1]
+			o.table = pg.FQN{Schema: "public", Rel: colParts[0]}
+		case 3:
+			o.columnName = colParts[2]
+			o.table = pg.FQN{Schema: colParts[0], Rel: colParts[1]}
+		case 4:
+			o.columnName = colParts[3]
+			o.table = pg.FQN{Catalog: colParts[0], Schema: colParts[1], Rel: colParts[2]}
+		default:
+			return fmt.Errorf("Override `column` specifier %q is not the proper format, expected '[catalog.][schema.]colname.tablename'", o.Column)
+		}
+	}
+
+	// validate GoType
+	lastDot := strings.LastIndex(o.GoType, ".")
+	if lastDot == -1 {
+		return fmt.Errorf("Package override `go_type` specificier %q is not the proper format, expected 'package.type', e.g. 'github.com/segmentio/ksuid.KSUID'", o.GoType)
+	}
+	lastSlash := strings.LastIndex(o.GoType, "/")
+	if lastSlash == -1 {
+		return fmt.Errorf("Package override `go_type` specificier %q is not the proper format, expected 'package.type', e.g. 'github.com/segmentio/ksuid.KSUID'", o.GoType)
+	}
+	o.goTypeName = o.GoType[lastSlash+1:]
+	o.goPackage = o.GoType[:lastDot]
+	isPointer := o.GoType[0] == '*'
+	if isPointer {
+		o.goPackage = o.goPackage[1:]
+		o.goTypeName = "*" + o.goTypeName
+	}
+
+	return nil
 }
 
 var ErrMissingVersion = errors.New("no version number")
@@ -41,6 +112,18 @@ func ParseConfig(rd io.Reader) (GenerateSettings, error) {
 	}
 	if len(config.Packages) == 0 {
 		return config, ErrNoPackages
+	}
+	for i := range config.Overrides {
+		if err := config.Overrides[i].Parse(); err != nil {
+			return config, err
+		}
+	}
+	for j := range config.Packages {
+		for i := range config.Packages[j].Overrides {
+			if err := config.Packages[j].Overrides[i].Parse(); err != nil {
+				return config, err
+			}
+		}
 	}
 	return config, nil
 }

--- a/internal/dinosql/gen_test.go
+++ b/internal/dinosql/gen_test.go
@@ -35,9 +35,30 @@ func TestColumnsToStruct(t *testing.T) {
 			DataType: "bytea",
 			NotNull:  true,
 		},
+		{
+			Name:     "retyped",
+			DataType: "text",
+			NotNull:  true,
+		},
+	}
+
+	// all of the columns are on the 'foo' table
+	for i := range cols {
+		cols[i].Table = pg.FQN{Schema: "public", Rel: "foo"}
 	}
 
 	r := Result{}
+
+	// set up column-based override test
+	o := Override{
+		GoType: "example.com/pkg.CustomType",
+		Column: "foo.retyped",
+	}
+	o.Parse()
+	r.packageSettings = PackageSettings{
+		Overrides: []Override{o},
+	}
+
 	actual := r.columnsToStruct("Foo", cols)
 	expected := &GoStruct{
 		Name: "Foo",
@@ -47,6 +68,7 @@ func TestColumnsToStruct(t *testing.T) {
 			{Name: "Count_2", Type: "int64", Tags: map[string]string{"json:": "count_2"}},
 			{Name: "Tags", Type: "[]string", Tags: map[string]string{"json:": "tags"}},
 			{Name: "ByteSeq", Type: "[]byte", Tags: map[string]string{"json:": "byte_seq"}},
+			{Name: "Retyped", Type: "pkg.CustomType", Tags: map[string]string{"json:": "retyped"}},
 		},
 	}
 	if diff := cmp.Diff(expected, actual); diff != "" {

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -168,6 +168,11 @@ type Result struct {
 	Settings GenerateSettings
 	Queries  []*Query
 	Catalog  core.Catalog
+
+	// XXX: this is hack so that all of the functions used during Generate can access
+	// package settings during that process without threading them through every function
+	// call. we should probably have another type just for generation instead of reusing Result
+	packageSettings PackageSettings
 }
 
 func ParseQueries(c core.Catalog, settings GenerateSettings, pkg PackageSettings) (*Result, error) {
@@ -967,6 +972,7 @@ func resolveCatalogRefs(c core.Catalog, rvs []nodes.RangeVar, args []paramRef) (
 								DataType: c.DataType,
 								NotNull:  c.NotNull,
 								IsArray:  c.IsArray,
+								Table:    c.Table,
 							},
 						})
 					}
@@ -1000,6 +1006,7 @@ func resolveCatalogRefs(c core.Catalog, rvs []nodes.RangeVar, args []paramRef) (
 						DataType: c.DataType,
 						NotNull:  c.NotNull,
 						IsArray:  c.IsArray,
+						Table:    c.Table,
 					},
 				})
 			} else {
@@ -1027,11 +1034,4 @@ func resolveCatalogRefs(c core.Catalog, rvs []nodes.RangeVar, args []paramRef) (
 		}
 	}
 	return a, nil
-}
-
-type TypeOverride struct {
-	Package      string `json:"package"`
-	PostgresType string `json:"postgres_type"`
-	GoType       string `json:"go_type"`
-	Null         bool   `json:"null"`
 }

--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -85,7 +85,7 @@ func TestQueries(t *testing.T) {
 			`,
 			Query{
 				Params: []Parameter{
-					{1, core.Column{Name: "slug", DataType: "text", NotNull: true}},
+					{1, core.Column{Table: public("city"), Name: "slug", DataType: "text", NotNull: true}},
 				},
 				Columns: []core.Column{
 					{Table: public("city"), Name: "slug", DataType: "text", NotNull: true},
@@ -106,8 +106,8 @@ func TestQueries(t *testing.T) {
 			`,
 			Query{
 				Params: []Parameter{
-					{1, core.Column{Name: "name", DataType: "text", NotNull: true}},
-					{2, core.Column{Name: "slug", DataType: "text", NotNull: true}},
+					{1, core.Column{Table: public("city"), Name: "name", DataType: "text", NotNull: true}},
+					{2, core.Column{Table: public("city"), Name: "slug", DataType: "text", NotNull: true}},
 				},
 				Columns: []core.Column{
 					{Table: public("city"), Name: "slug", DataType: "text", NotNull: true},
@@ -122,8 +122,8 @@ func TestQueries(t *testing.T) {
 			`,
 			Query{
 				Params: []Parameter{
-					{1, core.Column{Name: "slug", DataType: "text", NotNull: true}},
-					{2, core.Column{Name: "name", DataType: "text", NotNull: true}},
+					{1, core.Column{Table: public("city"), Name: "slug", DataType: "text", NotNull: true}},
+					{2, core.Column{Table: public("city"), Name: "name", DataType: "text", NotNull: true}},
 				},
 			},
 		},
@@ -147,7 +147,7 @@ func TestQueries(t *testing.T) {
 					{Table: public("venue"), Name: "songkick_id", DataType: "text"},
 				},
 				Params: []Parameter{
-					{1, core.Column{Name: "city", DataType: "text", NotNull: true}},
+					{1, core.Column{Table: public("venue"), Name: "city", DataType: "text", NotNull: true}},
 				},
 			},
 		},
@@ -159,7 +159,7 @@ func TestQueries(t *testing.T) {
 			`,
 			Query{
 				Params: []Parameter{
-					{1, core.Column{Name: "slug", DataType: "text", NotNull: true}},
+					{1, core.Column{Table: public("venue"), Name: "slug", DataType: "text", NotNull: true}},
 				},
 			},
 		},
@@ -182,8 +182,8 @@ func TestQueries(t *testing.T) {
 					{Table: public("venue"), Name: "songkick_id", DataType: "text"},
 				},
 				Params: []Parameter{
-					{1, core.Column{Name: "slug", DataType: "text", NotNull: true}},
-					{2, core.Column{Name: "city", DataType: "text", NotNull: true}},
+					{1, core.Column{Table: public("venue"), Name: "slug", DataType: "text", NotNull: true}},
+					{2, core.Column{Table: public("venue"), Name: "city", DataType: "text", NotNull: true}},
 				},
 			},
 		},
@@ -211,11 +211,11 @@ func TestQueries(t *testing.T) {
 					{Table: public("venue"), Name: "id", DataType: "serial", NotNull: true},
 				},
 				Params: []Parameter{
-					{1, core.Column{NotNull: true, DataType: "text", Name: "slug"}},
-					{2, core.Column{NotNull: true, DataType: "pg_catalog.varchar", Name: "name"}},
-					{3, core.Column{NotNull: true, DataType: "text", Name: "city"}},
-					{4, core.Column{NotNull: true, DataType: "pg_catalog.varchar", Name: "spotify_playlist"}},
-					{5, core.Column{NotNull: true, DataType: "status", Name: "status"}},
+					{1, core.Column{Table: public("venue"), NotNull: true, DataType: "text", Name: "slug"}},
+					{2, core.Column{Table: public("venue"), NotNull: true, DataType: "pg_catalog.varchar", Name: "name"}},
+					{3, core.Column{Table: public("venue"), NotNull: true, DataType: "text", Name: "city"}},
+					{4, core.Column{Table: public("venue"), NotNull: true, DataType: "pg_catalog.varchar", Name: "spotify_playlist"}},
+					{5, core.Column{Table: public("venue"), NotNull: true, DataType: "status", Name: "status"}},
 				},
 			},
 		},
@@ -232,8 +232,8 @@ func TestQueries(t *testing.T) {
 					{Table: public("venue"), Name: "id", DataType: "serial", NotNull: true},
 				},
 				Params: []Parameter{
-					{1, core.Column{DataType: "text", Name: "slug", NotNull: true}},
-					{2, core.Column{DataType: "pg_catalog.varchar", Name: "name", NotNull: true}},
+					{1, core.Column{Table: public("venue"), DataType: "text", Name: "slug", NotNull: true}},
+					{2, core.Column{Table: public("venue"), DataType: "pg_catalog.varchar", Name: "name", NotNull: true}},
 				},
 			},
 		},
@@ -262,7 +262,7 @@ func TestQueries(t *testing.T) {
 			WHERE f.bar = b.id AND b.id = $1;
 			`,
 			Query{
-				Params: []Parameter{{1, core.Column{Name: "id", DataType: "serial", NotNull: true}}},
+				Params: []Parameter{{1, core.Column{Table: public("bar"), Name: "id", DataType: "serial", NotNull: true}}},
 			},
 		},
 		{
@@ -281,8 +281,8 @@ func TestQueries(t *testing.T) {
 					{Table: public("foo"), Name: "id", DataType: "serial", NotNull: true},
 				},
 				Params: []Parameter{
-					{1, core.Column{Name: "id", DataType: "serial", NotNull: true}},
-					{2, core.Column{Name: "id", DataType: "serial", NotNull: true}},
+					{1, core.Column{Table: public("bar"), Name: "id", DataType: "serial", NotNull: true}},
+					{2, core.Column{Table: public("foo"), Name: "id", DataType: "serial", NotNull: true}},
 				},
 			},
 		},
@@ -331,7 +331,7 @@ func TestQueries(t *testing.T) {
 			`,
 			Query{
 				Params: []Parameter{
-					{1, core.Column{Name: "ready", DataType: "bool", NotNull: true}},
+					{1, core.Column{Table: public("bar"), Name: "ready", DataType: "bool", NotNull: true}},
 				},
 				Columns: []core.Column{
 					{Name: "count", DataType: "bigint", NotNull: true},
@@ -346,8 +346,8 @@ func TestQueries(t *testing.T) {
 			`,
 			Query{
 				Params: []Parameter{
-					{1, core.Column{Name: "slug", DataType: "text", NotNull: true}},
-					{2, core.Column{Name: "name", DataType: "text", NotNull: true}},
+					{1, core.Column{Table: public("foo"), Name: "slug", DataType: "text", NotNull: true}},
+					{2, core.Column{Table: public("foo"), Name: "name", DataType: "text", NotNull: true}},
 				},
 			},
 		},
@@ -359,8 +359,8 @@ func TestQueries(t *testing.T) {
 			`,
 			Query{
 				Params: []Parameter{
-					{1, core.Column{Name: "slug", DataType: "text", NotNull: true}},
-					{2, core.Column{Name: "name", DataType: "text", NotNull: true}},
+					{1, core.Column{Table: public("foo"), Name: "slug", DataType: "text", NotNull: true}},
+					{2, core.Column{Table: public("foo"), Name: "name", DataType: "text", NotNull: true}},
 				},
 			},
 		},
@@ -375,8 +375,8 @@ func TestQueries(t *testing.T) {
 			`,
 			Query{
 				Params: []Parameter{
-					{1, core.Column{Name: "meta", DataType: "text", NotNull: true}},
-					{2, core.Column{Name: "ready", DataType: "bool", NotNull: true}},
+					{1, core.Column{Table: public("foo"), Name: "meta", DataType: "text", NotNull: true}},
+					{2, core.Column{Table: public("bar"), Name: "ready", DataType: "bool", NotNull: true}},
 				},
 			},
 		},
@@ -457,7 +457,7 @@ func TestQueries(t *testing.T) {
 					{Table: public("foo"), Name: "email", DataType: "text", NotNull: true},
 				},
 				Params: []Parameter{
-					{1, core.Column{Name: "login", DataType: "text", NotNull: true}},
+					{1, core.Column{Table: public("bar"), Name: "login", DataType: "text", NotNull: true}},
 				},
 			},
 		},
@@ -489,7 +489,7 @@ func TestQueries(t *testing.T) {
 					{Table: public("foo"), Name: "barid", DataType: "serial", NotNull: true, Scope: "foo"},
 				},
 				Params: []Parameter{
-					{1, core.Column{Name: "owner", DataType: "text", NotNull: true}},
+					{1, core.Column{Table: public("bar"), Name: "owner", DataType: "text", NotNull: true}},
 				},
 			},
 		},
@@ -554,8 +554,8 @@ func TestQueries(t *testing.T) {
 					{Table: public("bar"), Name: "id", DataType: "serial", NotNull: true},
 				},
 				Params: []Parameter{
-					{1, core.Column{Name: "id", DataType: "serial", NotNull: true}},
-					{2, core.Column{Name: "id", DataType: "serial", NotNull: true}},
+					{1, core.Column{Table: public("bar"), Name: "id", DataType: "serial", NotNull: true}},
+					{2, core.Column{Table: public("bar"), Name: "id", DataType: "serial", NotNull: true}},
 				},
 			},
 		},
@@ -610,7 +610,7 @@ func TestQueries(t *testing.T) {
 					},
 				},
 				Params: []Parameter{
-					{1, core.Column{Name: "id", DataType: "serial", NotNull: true}},
+					{1, core.Column{Table: core.FQN{Schema: "foo", Rel: "bar"}, Name: "id", DataType: "serial", NotNull: true}},
 				},
 			},
 		},
@@ -629,8 +629,8 @@ func TestQueries(t *testing.T) {
 					},
 				},
 				Params: []Parameter{
-					{1, core.Column{Name: "id", DataType: "serial", NotNull: true}},
-					{2, core.Column{Name: "name", DataType: "text", NotNull: true}},
+					{1, core.Column{Table: core.FQN{Schema: "foo", Rel: "bar"}, Name: "id", DataType: "serial", NotNull: true}},
+					{2, core.Column{Table: core.FQN{Schema: "foo", Rel: "bar"}, Name: "name", DataType: "text", NotNull: true}},
 				},
 			},
 		},
@@ -643,8 +643,8 @@ func TestQueries(t *testing.T) {
 			`,
 			Query{
 				Params: []Parameter{
-					{1, core.Column{Name: "id", DataType: "serial", NotNull: true}},
-					{2, core.Column{Name: "name", DataType: "text", NotNull: true}},
+					{1, core.Column{Table: core.FQN{Schema: "foo", Rel: "bar"}, Name: "id", DataType: "serial", NotNull: true}},
+					{2, core.Column{Table: core.FQN{Schema: "foo", Rel: "bar"}, Name: "name", DataType: "text", NotNull: true}},
 				},
 			},
 		},
@@ -657,7 +657,7 @@ func TestQueries(t *testing.T) {
 			`,
 			Query{
 				Params: []Parameter{
-					{1, core.Column{Name: "id", DataType: "serial", NotNull: true}},
+					{1, core.Column{Table: core.FQN{Schema: "foo", Rel: "bar"}, Name: "id", DataType: "serial", NotNull: true}},
 				},
 			},
 		},
@@ -672,8 +672,8 @@ func TestQueries(t *testing.T) {
 					{Table: public("foo"), Name: "bar", DataType: "text", NotNull: true},
 				},
 				Params: []Parameter{
-					{1, core.Column{Name: "bar", DataType: "text", NotNull: true}},
-					{2, core.Column{Name: "bat", DataType: "text", NotNull: true}},
+					{1, core.Column{Table: public("foo"), Name: "bar", DataType: "text", NotNull: true}},
+					{2, core.Column{Table: public("foo"), Name: "bat", DataType: "text", NotNull: true}},
 				},
 			},
 		},


### PR DESCRIPTION
Often a user may want to override the Go type used for model
generation and query generation, but it's not a 1-to-1 mapping
of SQL types to Go type. Instead, the override to use depends
entirely on the column of a particular table. This commit adds the
functionality to override types of generated columns in models and query
parameters by adding a new 'overrides' configuration settings object
on a per-package basis.

This required tracking down a number of places where the column's Table
FQN wasn't properly propagated through to the the model or query
parameter Column. This change necessitated updating a bunch of tests to
match.

Lastly, I've added a test to prove the functionality works (in addition
to testing it on a large code base) and added a documentation section in
the README.