### PR TITLE
gen: Ignore empty override settings

### DIFF
--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -445,10 +445,10 @@ func (r Result) goInnerType(col core.Column) string {
 
 	// package overrides have a higher precedence
 	for _, oride := range append(r.Settings.Overrides, r.packageSettings.Overrides...) {
-		if oride.PostgresType == columnType && oride.Null != notNull {
+		if oride.PostgresType != "" && oride.PostgresType == columnType && oride.Null != notNull {
 			return oride.goTypeName
 		}
-		if oride.columnName == col.Name && oride.table == col.Table {
+		if oride.Column != "" && oride.columnName == col.Name && oride.table == col.Table {
 			return oride.goTypeName
 		}
 	}


### PR DESCRIPTION
The previous `goInnerType` assumed that the column name and table would
be non-empty. For computed columns, this is not true. Make sure to check
if the override setting (PostgresType or Column) is non-empty before
applying an override.

I discovered this with a query that was cast a parameter to a boolean. The generated code assigned the parameter a type of `uuid.UUID`.

```sql
SELECT * from authors
WHERE $3::bool
ORDER BY id
LIMIT $2;
```