### PR TITLE
parser: Add support for mathmatical operators

### DIFF
--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -690,6 +690,19 @@ func TestQueries(t *testing.T) {
 				},
 			},
 		},
+		{
+			"mathmatical-operator",
+			`
+			CREATE TABLE foo (num integer not null);
+			SELECT *, num / 1024 as division FROM foo;
+			`,
+			Query{
+				Columns: []core.Column{
+					{Name: "num", DataType: "pg_catalog.int4", NotNull: true, Table: public("foo")},
+					{Name: "division", DataType: "pg_catalog.int4", NotNull: true},
+				},
+			},
+		},
 	} {
 		test := tc
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/postgres/types.go
+++ b/internal/postgres/types.go
@@ -14,3 +14,28 @@ func IsComparisonOperator(s string) bool {
 	}
 	return true
 }
+
+func IsMathematicalOperator(s string) bool {
+	switch s {
+	case "+":
+	case "-":
+	case "*":
+	case "/":
+	case "%":
+	case "^":
+	case "|/":
+	case "||/":
+	case "!":
+	case "!!":
+	case "@":
+	case "&":
+	case "|":
+	case "#":
+	case "~":
+	case "<<":
+	case ">>":
+	default:
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Also, don't leave out expressions we haven't added. Instead, generate a
column with an "any" type.

Fixes #122