### PR TITLE
parser: Error on mismatched INSERT input

### DIFF
--- a/internal/dinosql/checks.go
+++ b/internal/dinosql/checks.go
@@ -33,7 +33,6 @@ func validateParamRef(n nodes.Node) error {
 			}
 		}
 	}
-
 	return nil
 }
 
@@ -94,4 +93,30 @@ func validateFuncCall(c *pg.Catalog, n nodes.Node) error {
 	visitor := funcCallVisitor{catalog: c}
 	Walk(&visitor, n)
 	return visitor.err
+}
+
+func validateInsertStmt(stmt nodes.InsertStmt) error {
+	sel, ok := stmt.SelectStmt.(nodes.SelectStmt)
+	if !ok {
+		return nil
+	}
+	if len(sel.ValuesLists) != 1 {
+		return nil
+	}
+
+	colsLen := len(stmt.Cols.Items)
+	valsLen := len(sel.ValuesLists[0])
+	switch {
+	case colsLen > valsLen:
+		return pg.Error{
+			Code:    "42601",
+			Message: "INSERT has more target columns than expressions",
+		}
+	case colsLen < valsLen:
+		return pg.Error{
+			Code:    "42601",
+			Message: "INSERT has more expressions than target columns",
+		}
+	}
+	return nil
 }

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -317,7 +317,7 @@ func parseMetadata(t string) (string, string, error) {
 		if !strings.HasPrefix(line, "-- name:") {
 			continue
 		}
-		part := strings.Split(line, " ")
+		part := strings.Split(strings.TrimSpace(line), " ")
 		if len(part) == 2 {
 			return "", "", fmt.Errorf("missing query type [':one', ':many', ':exec', ':execrows']: %s", line)
 		}
@@ -371,10 +371,13 @@ func parseQuery(c core.Catalog, stmt nodes.Node, source string) (*Query, error) 
 	if !ok {
 		return nil, nil
 	}
-	switch raw.Stmt.(type) {
+	switch n := raw.Stmt.(type) {
 	case nodes.SelectStmt:
 	case nodes.DeleteStmt:
 	case nodes.InsertStmt:
+		if err := validateInsertStmt(n); err != nil {
+			return nil, err
+		}
 	case nodes.UpdateStmt:
 	default:
 		return nil, nil

--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -867,12 +867,26 @@ func TestInvalidQueries(t *testing.T) {
 			`,
 			`query "InsertFoo" specifies parameter ":one" without containing a RETURNING clause`,
 		},
+		{
+			`
+			CREATE TABLE foo (bar text not null, baz text not null);
+			INSERT INTO foo (bar, baz) VALUES ($1);
+			`,
+			`INSERT has more target columns than expressions`,
+		},
+		{
+			`
+			CREATE TABLE foo (bar text not null, baz text not null);
+			INSERT INTO foo (bar) VALUES ($1, $2);
+			`,
+			`INSERT has more expressions than target columns`,
+		},
 	} {
 		test := tc
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			_, err := parseSQL(test.stmt)
 			if err == nil {
-				t.Errorf("expected err, got nil")
+				t.Fatalf("expected err, got nil")
 			}
 			if diff := cmp.Diff(test.msg, err.Error()); diff != "" {
 				t.Errorf("error message differs: \n%s", diff)


### PR DESCRIPTION
Error if the length of the target columns do not match the length of the
value expressions.

Trim space off comments before splitting. Trailing whitespace should not
causing parsing metadata to fail.

Fixes #56 