### PR TITLE
Add a few types, export DBTX

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,19 +203,19 @@ func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
 	return items, nil
 }
 
-type dbtx interface {
+type DBTX interface {
 	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
 	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
 	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
-func New(db dbtx) *Queries {
+func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
 type Queries struct {
-	db dbtx
+	db DBTX
 }
 
 func (q *Queries) WithTx(tx *sql.Tx) *Queries {

--- a/examples/any.md
+++ b/examples/any.md
@@ -36,17 +36,17 @@ type Author struct {
 	BirthYear int
 }
 
-type dbtx interface {
+type DBTX interface {
 	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
 	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
-func New(db dbtx) *Queries {
+func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
 type Queries struct {
-	db dbtx
+	db DBTX
 }
 
 const listAuthors = `-- name: ListAuthorsByIDs :many

--- a/examples/delete.md
+++ b/examples/delete.md
@@ -18,16 +18,16 @@ import (
 	"database/sql"
 )
 
-type dbtx interface {
+type DBTX interface {
 	ExecContext(context.Context, string, ...interface{}) error
 }
 
-func New(db dbtx) *Queries {
+func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
 type Queries struct {
-	db dbtx
+	db DBTX
 }
 
 const deleteAuthor = `-- name: DeleteAuthor :exec

--- a/examples/insert.md
+++ b/examples/insert.md
@@ -18,16 +18,16 @@ import (
 	"database/sql"
 )
 
-type dbtx interface {
+type DBTX interface {
 	ExecContext(context.Context, string, ...interface{}) error
 }
 
-func New(db dbtx) *Queries {
+func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
 type Queries struct {
-	db dbtx
+	db DBTX
 }
 
 const createAuthor = `-- name: CreateAuthor :exec

--- a/examples/prepared_query.md
+++ b/examples/prepared_query.md
@@ -25,16 +25,16 @@ type Record struct {
 	ID int
 }
 
-type dbtx interface {
+type DBTX interface {
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
 	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
-func New(db dbtx) *Queries {
+func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
-func Prepare(ctx context.Context, db dbtx) (*Queries, error) {
+func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	q := Queries{db: db}
 	var err error
 	if q.getRecordStmt, err = db.PrepareContext(ctx, getRecord); err != nil {
@@ -55,7 +55,7 @@ func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, ar
 }
 
 type Queries struct {
-	db            dbtx
+	db            DBTX
 	tx            *sql.Tx
 	getRecordStmt *sql.Stmt
 }

--- a/examples/query_count.md
+++ b/examples/query_count.md
@@ -23,17 +23,17 @@ import (
 	"database/sql"
 )
 
-type dbtx interface {
+type DBTX interface {
 	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
 	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
-func New(db dbtx) *Queries {
+func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
 type Queries struct {
-	db dbtx
+	db DBTX
 }
 
 const countAuthors = `-- name: CountAuthors :one

--- a/examples/query_one.md
+++ b/examples/query_one.md
@@ -53,17 +53,17 @@ type Author struct {
 	BirthYear int
 }
 
-type dbtx interface {
+type DBTX interface {
 	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
 	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
-func New(db dbtx) *Queries {
+func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
 type Queries struct {
-	db dbtx
+	db DBTX
 }
 
 const getAuthor = `-- name: GetAuthor :one
@@ -141,16 +141,16 @@ import (
 	"database/sql"
 )
 
-type dbtx interface {
+type DBTX interface {
 	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
-func New(db dbtx) *Queries {
+func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
 type Queries struct {
-	db dbtx
+	db DBTX
 }
 
 const getBioForAuthor = `-- name: GetBioForAuthor :one

--- a/examples/returning.md
+++ b/examples/returning.md
@@ -36,17 +36,17 @@ type Author struct {
 	Bio string
 }
 
-type dbtx interface {
+type DBTX interface {
 	ExecContext(context.Context, string, ...interface{}) error
 	QueryRowContext(context.Context, string, ...interface{}) error
 }
 
-func New(db dbtx) *Queries {
+func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
 type Queries struct {
-	db dbtx
+	db DBTX
 }
 
 const delete = `-- name: Delete :exec

--- a/examples/transactions.md
+++ b/examples/transactions.md
@@ -24,16 +24,16 @@ type Record struct {
 	ID int
 }
 
-type dbtx interface {
+type DBTX interface {
 	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
-func New(db dbtx) *Queries {
+func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
 type Queries struct {
-	db dbtx
+	db DBTX
 }
 
 func (*Queries) WithTx(tx *sql.Tx) *Queries {

--- a/examples/update.md
+++ b/examples/update.md
@@ -19,16 +19,16 @@ import (
 	"database/sql"
 )
 
-type dbtx interface {
+type DBTX interface {
 	ExecContext(context.Context, string, ...interface{}) error
 }
 
-func New(db dbtx) *Queries {
+func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
 type Queries struct {
-	db dbtx
+	db DBTX
 }
 
 const updateAuthor = `-- name: UpdateAuthor :exec

--- a/internal/dinosql/testdata/ondeck/db.go
+++ b/internal/dinosql/testdata/ondeck/db.go
@@ -7,19 +7,19 @@ import (
 	"database/sql"
 )
 
-type dbtx interface {
+type DBTX interface {
 	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
 	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
 	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
-func New(db dbtx) *Queries {
+func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
 type Queries struct {
-	db dbtx
+	db DBTX
 }
 
 func (q *Queries) WithTx(tx *sql.Tx) *Queries {

--- a/internal/dinosql/testdata/ondeck/prepared/db.go
+++ b/internal/dinosql/testdata/ondeck/prepared/db.go
@@ -8,18 +8,18 @@ import (
 	"fmt"
 )
 
-type dbtx interface {
+type DBTX interface {
 	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
 	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
 	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
-func New(db dbtx) *Queries {
+func New(db DBTX) *Queries {
 	return &Queries{db: db}
 }
 
-func Prepare(ctx context.Context, db dbtx) (*Queries, error) {
+func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	q := Queries{db: db}
 	var err error
 	if q.createCityStmt, err = db.PrepareContext(ctx, createCity); err != nil {
@@ -144,7 +144,7 @@ func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, ar
 }
 
 type Queries struct {
-	db                   dbtx
+	db                   DBTX
 	tx                   *sql.Tx
 	createCityStmt       *sql.Stmt
 	createVenueStmt      *sql.Stmt


### PR DESCRIPTION
This change includes several enhancements:
1. Add the `blob` type
2. Add the `inet` type and import for the `"net"` package as necessary
3. Fixes the "uses" functions so that they work with array columns
4. Export the `DBTX` interface. The unexported type didn't play well with [wire](https://github.com/google/wire) which needs concrete types which requires them to be exported. That said, since this interface is always the same, maybe there should be a type directly exported by sqlc, e.g. `"github.com/kyleconroy/sqlc.DBTX"` instead.
5. Fixes some minor lint issues