### PR TITLE
internal/dinosql: fix multiline comment rendering

### DIFF
--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -894,7 +894,8 @@ type {{.Ret.Type}} struct { {{- range .Ret.Struct.Fields}}
 {{end}}
 
 {{if eq .Cmd ":one"}}
-{{range .Comments}}//{{.}}{{end}}
+{{range .Comments}}//{{.}}
+{{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ({{.Ret.Type}}, error) {
   	{{- if $.EmitPreparedQueries}}
 	row := q.queryRow(ctx, q.{{.FieldName}}, {{.ConstantName}}, {{.Arg.Params}})
@@ -908,7 +909,8 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ({{.Ret.Ty
 {{end}}
 
 {{if eq .Cmd ":many"}}
-{{range .Comments}}//{{.}}{{end}}
+{{range .Comments}}//{{.}}
+{{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ([]{{.Ret.Type}}, error) {
   	{{- if $.EmitPreparedQueries}}
 	rows, err := q.query(ctx, q.{{.FieldName}}, {{.ConstantName}}, {{.Arg.Params}})
@@ -938,7 +940,8 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ([]{{.Ret.
 {{end}}
 
 {{if eq .Cmd ":exec"}}
-{{range .Comments}}//{{.}}{{end}}
+{{range .Comments}}//{{.}}
+{{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) error {
   	{{- if $.EmitPreparedQueries}}
 	_, err := q.exec(ctx, q.{{.FieldName}}, {{.ConstantName}}, {{.Arg.Params}})
@@ -950,7 +953,8 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) error {
 {{end}}
 
 {{if eq .Cmd ":execrows"}}
-{{range .Comments}}//{{.}}{{end}}
+{{range .Comments}}//{{.}}
+{{end -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) (int64, error) {
   	{{- if $.EmitPreparedQueries}}
 	result, err := q.exec(ctx, q.{{.FieldName}}, {{.ConstantName}}, {{.Arg.Params}})

--- a/internal/dinosql/testdata/ondeck/city.sql.go
+++ b/internal/dinosql/testdata/ondeck/city.sql.go
@@ -22,7 +22,9 @@ type CreateCityParams struct {
 	Slug string `json:"slug"`
 }
 
-// Create a new city. The slug must be unique
+// Create a new city. The slug must be unique.
+// This is the second line of the comment
+// This is the third line
 func (q *Queries) CreateCity(ctx context.Context, arg CreateCityParams) (City, error) {
 	row := q.db.QueryRowContext(ctx, createCity, arg.Name, arg.Slug)
 	var i City

--- a/internal/dinosql/testdata/ondeck/prepared/city.sql.go
+++ b/internal/dinosql/testdata/ondeck/prepared/city.sql.go
@@ -22,7 +22,9 @@ type CreateCityParams struct {
 	Slug string
 }
 
-// Create a new city. The slug must be unique
+// Create a new city. The slug must be unique.
+// This is the second line of the comment
+// This is the third line
 func (q *Queries) CreateCity(ctx context.Context, arg CreateCityParams) (City, error) {
 	row := q.queryRow(ctx, q.createCityStmt, createCity, arg.Name, arg.Slug)
 	var i City

--- a/internal/dinosql/testdata/ondeck/query/city.sql
+++ b/internal/dinosql/testdata/ondeck/query/city.sql
@@ -9,7 +9,9 @@ FROM city
 WHERE slug = $1;
 
 -- name: CreateCity :one
--- Create a new city. The slug must be unique
+-- Create a new city. The slug must be unique.
+-- This is the second line of the comment
+-- This is the third line
 INSERT INTO city (
     name,
     slug


### PR DESCRIPTION
Previously if a SQL comment spanned multiple lines they'd all be run
together like this:

// Comment line one// Comment line two //Comment line three

Instead, print each comment line on its own Go line. Update the tests
to expose the problem and also test that it's fixed properly.