### PR TITLE
fix scanning into enums

### DIFF
--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -851,6 +851,11 @@ const (
 	{{.Name}} {{.Type}} = "{{.Value}}"
 	{{- end}}
 )
+
+func (e *{{.Name}}) Scan(src interface{}) error {
+	*e = {{.Name}}(src.([]byte))
+	return nil
+}
 {{end}}
 
 {{range .Structs}}

--- a/internal/dinosql/testdata/ondeck/db_test.go
+++ b/internal/dinosql/testdata/ondeck/db_test.go
@@ -19,7 +19,7 @@ import (
 func id() string {
 	bytes := make([]byte, 10)
 	for i := 0; i < 10; i++ {
-		bytes[i] = byte(65 + rand.Intn(25)) //A=65 and Z = 65+25
+		bytes[i] = byte(65 + rand.Intn(25)) // A=65 and Z = 65+25
 	}
 	return string(bytes)
 }
@@ -115,6 +115,7 @@ func TestQueries(t *testing.T) {
 		City:            city.Slug,
 		SpotifyPlaylist: "spotify:uri",
 		Status:          StatusOpen,
+		Statuses:        []Status{StatusOpen, StatusClosed},
 		Tags:            []string{"rock", "punk"},
 	})
 	if err != nil {

--- a/internal/dinosql/testdata/ondeck/models.go
+++ b/internal/dinosql/testdata/ondeck/models.go
@@ -14,6 +14,11 @@ const (
 	StatusClosed Status = "closed"
 )
 
+func (e *Status) Scan(src interface{}) error {
+	*e = Status(src.([]byte))
+	return nil
+}
+
 type City struct {
 	Slug string `json:"slug"`
 	Name string `json:"name"`

--- a/internal/dinosql/testdata/ondeck/models.go
+++ b/internal/dinosql/testdata/ondeck/models.go
@@ -27,6 +27,7 @@ type City struct {
 type Venue struct {
 	ID              int32          `json:"id"`
 	Status          Status         `json:"status"`
+	Statuses        []Status       `json:"statuses"`
 	Slug            string         `json:"slug"`
 	Name            string         `json:"name"`
 	City            string         `json:"city"`

--- a/internal/dinosql/testdata/ondeck/prepared/models.go
+++ b/internal/dinosql/testdata/ondeck/prepared/models.go
@@ -27,6 +27,7 @@ type City struct {
 type Venue struct {
 	ID              int32
 	Status          Status
+	Statuses        []Status
 	Slug            string
 	Name            string
 	City            string

--- a/internal/dinosql/testdata/ondeck/prepared/models.go
+++ b/internal/dinosql/testdata/ondeck/prepared/models.go
@@ -14,6 +14,11 @@ const (
 	StatusClosed Status = "closed"
 )
 
+func (e *Status) Scan(src interface{}) error {
+	*e = Status(src.([]byte))
+	return nil
+}
+
 type City struct {
 	Slug string
 	Name string

--- a/internal/dinosql/testdata/ondeck/prepared/venue.sql.go
+++ b/internal/dinosql/testdata/ondeck/prepared/venue.sql.go
@@ -17,6 +17,7 @@ INSERT INTO venue (
     created_at,
     spotify_playlist,
     status,
+    statuses,
     tags
 ) VALUES (
     $1,
@@ -25,7 +26,8 @@ INSERT INTO venue (
     NOW(),
     $4,
     $5,
-    $6
+    $6,
+    $7
 ) RETURNING id
 `
 
@@ -35,6 +37,7 @@ type CreateVenueParams struct {
 	City            string
 	SpotifyPlaylist string
 	Status          Status
+	Statuses        []Status
 	Tags            []string
 }
 
@@ -45,6 +48,7 @@ func (q *Queries) CreateVenue(ctx context.Context, arg CreateVenueParams) (int32
 		arg.City,
 		arg.SpotifyPlaylist,
 		arg.Status,
+		pq.Array(arg.Statuses),
 		pq.Array(arg.Tags),
 	)
 	var id int32
@@ -63,7 +67,7 @@ func (q *Queries) DeleteVenue(ctx context.Context, slug string) error {
 }
 
 const getVenue = `-- name: GetVenue :one
-SELECT id, status, slug, name, city, spotify_playlist, songkick_id, tags, created_at
+SELECT id, status, statuses, slug, name, city, spotify_playlist, songkick_id, tags, created_at
 FROM venue
 WHERE slug = $1 AND city = $2
 `
@@ -79,6 +83,7 @@ func (q *Queries) GetVenue(ctx context.Context, arg GetVenueParams) (Venue, erro
 	err := row.Scan(
 		&i.ID,
 		&i.Status,
+		pq.Array(&i.Statuses),
 		&i.Slug,
 		&i.Name,
 		&i.City,
@@ -91,7 +96,7 @@ func (q *Queries) GetVenue(ctx context.Context, arg GetVenueParams) (Venue, erro
 }
 
 const listVenues = `-- name: ListVenues :many
-SELECT id, status, slug, name, city, spotify_playlist, songkick_id, tags, created_at
+SELECT id, status, statuses, slug, name, city, spotify_playlist, songkick_id, tags, created_at
 FROM venue
 WHERE city = $1
 ORDER BY name
@@ -109,6 +114,7 @@ func (q *Queries) ListVenues(ctx context.Context, city string) ([]Venue, error) 
 		if err := rows.Scan(
 			&i.ID,
 			&i.Status,
+			pq.Array(&i.Statuses),
 			&i.Slug,
 			&i.Name,
 			&i.City,

--- a/internal/dinosql/testdata/ondeck/query/venue.sql
+++ b/internal/dinosql/testdata/ondeck/query/venue.sql
@@ -21,6 +21,7 @@ INSERT INTO venue (
     created_at,
     spotify_playlist,
     status,
+    statuses,
     tags
 ) VALUES (
     $1,
@@ -29,7 +30,8 @@ INSERT INTO venue (
     NOW(),
     $4,
     $5,
-    $6
+    $6,
+    $7
 ) RETURNING id;
 
 -- name: UpdateVenueName :one

--- a/internal/dinosql/testdata/ondeck/schema/0002_venue.sql
+++ b/internal/dinosql/testdata/ondeck/schema/0002_venue.sql
@@ -4,6 +4,7 @@ CREATE TABLE venues (
     id               SERIAL primary key,
     dropped          text,
     status           status       not null,
+    statuses         status[],
     slug             text         not null,
     name             varchar(255) not null,
     city             text         not null references city(slug),


### PR DESCRIPTION
The enum issue may only be because I am using a column with an array of enums.
Also, `Scan()` can panic if it's not passed a `[]byte`. I can have it return an error instead, but that requires importing `fmt` or `errors`, wasn't sure if it was worth the trouble. Thoughts?