### PR TITLE
internal/dinosql/testdata/ondeck: add Makefile

### DIFF
--- a/internal/dinosql/testdata/ondeck/Makefile
+++ b/internal/dinosql/testdata/ondeck/Makefile
@@ -1,0 +1,17 @@
+ifeq ($(GOBIN),)
+GOBIN = $(firstword $(subst :, ,$(GOPATH)))/bin
+endif
+
+SQLC := $(GOBIN)/sqlc
+SQL_FILES = $(shell find ./query -type f -name '*.sql')
+
+$(SQLC):
+	go get github.com/kyleconroy/sqlc/cmd/sqlc
+
+prepared/db.go:
+prepared/models.go:
+db.go:
+models.go: $(SQL_FILES) sqlc.json | $(SQLC)
+	$(SQLC) generate
+
+sql: db.go models.go prepared/models.go prepared/db.go


### PR DESCRIPTION
This is an example of how to set up sqlc targets with Make to
automatically regenerate the files when an input changes.