### PR TITLE
internal/catalog: Parse unnamed function arguments

### DIFF
--- a/internal/catalog/build.go
+++ b/internal/catalog/build.go
@@ -353,8 +353,12 @@ func Update(c *pg.Catalog, stmt nodes.Node) error {
 		args := make([]pg.Argument, arity)
 		for i, item := range n.Parameters.Items {
 			arg := item.(nodes.FunctionParameter)
+			var name string
+			if arg.Name != nil {
+				name = *arg.Name
+			}
 			args[i] = pg.Argument{
-				Name:       *arg.Name,
+				Name:       name,
 				DataType:   join(arg.ArgType.Names, "."),
 				HasDefault: arg.Defexpr != nil,
 			}

--- a/internal/catalog/build_test.go
+++ b/internal/catalog/build_test.go
@@ -324,6 +324,13 @@ func TestUpdate(t *testing.T) {
 		},
 		{
 			`
+			DROP FUNCTION IF EXISTS bar(text);
+			DROP FUNCTION IF EXISTS bar(text) CASCADE;
+			`,
+			pg.NewCatalog(),
+		},
+		{
+			`
 			CREATE TABLE venues (id SERIAL PRIMARY KEY);
 			ALTER TABLE venues DROP CONSTRAINT venues_id_pkey;
 			`,
@@ -336,6 +343,31 @@ func TestUpdate(t *testing.T) {
 								Name: "venues",
 								Columns: []pg.Column{
 									{Name: "id", DataType: "serial", NotNull: true, Table: pg.FQN{Schema: "public", Rel: "venues"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{ // first argument has no name
+			`
+			CREATE FUNCTION foo(TEXT) RETURNS bool AS $$ SELECT true $$ LANGUAGE sql;
+			`,
+			pg.Catalog{
+				Schemas: map[string]pg.Schema{
+					"public": {
+						Funcs: map[string][]pg.Function{
+							"foo": []pg.Function{
+								{
+									Name: "foo",
+									Arguments: []pg.Argument{
+										{
+											Name:     "",
+											DataType: "text",
+										},
+									},
+									ReturnType: "bool",
 								},
 							},
 						},


### PR DESCRIPTION
Arguments to SQL functions are not required to have a name.

Also add a test for `DROP FUNCTION [IF EXISTS]`