### PR TITLE
internal/dinosql: Add support for timestamptz

### DIFF
--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -537,7 +537,7 @@ func (r Result) goInnerType(col core.Column) string {
 	case "bytea", "blob", "pg_catalog.bytea":
 		return "[]byte"
 
-	case "pg_catalog.timestamp", "pg_catalog.timestamptz":
+	case "pg_catalog.timestamp", "pg_catalog.timestamptz", "timestamptz":
 		if notNull {
 			return "time.Time"
 		}

--- a/internal/dinosql/gen_test.go
+++ b/internal/dinosql/gen_test.go
@@ -75,3 +75,23 @@ func TestColumnsToStruct(t *testing.T) {
 		t.Errorf("struct mismatch: \n%s", diff)
 	}
 }
+
+func TestInnerType(t *testing.T) {
+	r := Result{}
+	for _, tc := range []struct {
+		col      pg.Column
+		expected string
+	}{
+		{
+			pg.Column{Name: "created", DataType: "timestamptz", NotNull: true},
+			"time.Time",
+		},
+	} {
+		tt := tc
+		t.Run(tt.col.Name+"-"+tt.col.DataType, func(t *testing.T) {
+			if diff := cmp.Diff(tt.expected, r.goType(tt.col)); diff != "" {
+				t.Errorf("struct mismatch: \n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
> The SQL standard requires that writing just timestamp be equivalent to
> timestamp without time zone, and PostgreSQL honors that behavior.
> timestamptz is accepted as an abbreviation for timestamp with time zone;
> this is a PostgreSQL extension.

Fixes #168 