### PR TITLE
parseQuery: Return either a query or an error

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -127,11 +127,6 @@ var genCmd = &cobra.Command{
 		output := map[string]string{}
 
 		for i, pkg := range settings.Packages {
-			if pkg.Schema == pkg.Queries {
-				fmt.Fprintf(os.Stderr, "package[%d]: schema and query path must not be identical\n", i)
-				os.Exit(1)
-			}
-
 			name := pkg.Name
 
 			if pkg.Path == "" {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -127,6 +127,11 @@ var genCmd = &cobra.Command{
 		output := map[string]string{}
 
 		for i, pkg := range settings.Packages {
+			if pkg.Schema == pkg.Queries {
+				fmt.Fprintf(os.Stderr, "package[%d]: schema and query path must not be identical\n", i)
+				os.Exit(1)
+			}
+
 			name := pkg.Name
 
 			if pkg.Path == "" {

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -371,7 +371,7 @@ func parseQuery(c core.Catalog, stmt nodes.Node, source string) (*Query, error) 
 	}
 	raw, ok := stmt.(nodes.RawStmt)
 	if !ok {
-		return nil, nil
+		return nil, errors.New("node is not a statement")
 	}
 	switch n := raw.Stmt.(type) {
 	case nodes.SelectStmt:
@@ -382,7 +382,7 @@ func parseQuery(c core.Catalog, stmt nodes.Node, source string) (*Query, error) 
 		}
 	case nodes.UpdateStmt:
 	default:
-		return nil, nil
+		return nil, fmt.Errorf("parseQuery: unsupported statement type: %T", n)
 	}
 
 	rawSQL, err := pluckQuery(source, raw)

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -371,7 +371,7 @@ func parseQuery(c core.Catalog, stmt nodes.Node, source string) (*Query, error) 
 	}
 	raw, ok := stmt.(nodes.RawStmt)
 	if !ok {
-		return nil, errors.New("node is not a statement")
+		return nil, errors.New("node is not a statement - feel free to file an issue on GitHub")
 	}
 	switch n := raw.Stmt.(type) {
 	case nodes.SelectStmt:
@@ -382,7 +382,7 @@ func parseQuery(c core.Catalog, stmt nodes.Node, source string) (*Query, error) 
 		}
 	case nodes.UpdateStmt:
 	default:
-		return nil, fmt.Errorf("parseQuery: unsupported statement type: %T", n)
+		return nil, fmt.Errorf("parseQuery: unsupported statement type: %T - feel free to file an issue on GitHub", n)
 	}
 
 	rawSQL, err := pluckQuery(source, raw)

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -371,7 +371,7 @@ func parseQuery(c core.Catalog, stmt nodes.Node, source string) (*Query, error) 
 	}
 	raw, ok := stmt.(nodes.RawStmt)
 	if !ok {
-		return nil, errors.New("node is not a statement - feel free to file an issue on GitHub")
+		return nil, errors.New("node is not a statement")
 	}
 	switch n := raw.Stmt.(type) {
 	case nodes.SelectStmt:
@@ -382,7 +382,7 @@ func parseQuery(c core.Catalog, stmt nodes.Node, source string) (*Query, error) 
 		}
 	case nodes.UpdateStmt:
 	default:
-		return nil, fmt.Errorf("parseQuery: unsupported statement type: %T - feel free to file an issue on GitHub", n)
+		return nil, fmt.Errorf("parseQuery: unsupported statement type: %T", n)
 	}
 
 	rawSQL, err := pluckQuery(source, raw)


### PR DESCRIPTION
This fixes https://github.com/kyleconroy/sqlc/issues/174 and https://github.com/kyleconroy/sqlc/issues/176.

`parseQuery` used to return a `nil` query and a `nil` error, however the code relies on the assumption that the query is always valid if the error is not `nil` (as explained [here](https://github.com/kyleconroy/sqlc/issues/176#issue-538122582)).

This assumption gets correct with this change. `parseQuery` returns either a query _or_ and error. There's no `return nil, nil` anymore.