### PR TITLE
Don't allow equal query and schema paths

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -127,6 +127,11 @@ var genCmd = &cobra.Command{
 		output := map[string]string{}
 
 		for i, pkg := range settings.Packages {
+			if pkg.Schema == pkg.Queries {
+				fmt.Fprintf(os.Stderr, "package[%d]: schema and query path must not be identical\n", i)
+				os.Exit(1)
+			}
+
 			name := pkg.Name
 
 			if pkg.Path == "" {


### PR DESCRIPTION
At the moment (without PR https://github.com/kyleconroy/sqlc/pull/178), this config file causes sqlc to panic:

```json
{
  "version": "1",
  "packages": [
    {
      "name": "db",
      "emit_json_tags": true,
      "emit_prepared_queries": false,
      "path": "db",
      "queries": "db.sql",
      "schema": "db.sql"
    }
  ]
}
```

sqlc can't handle the situation where the `queries` value is equal to the `schema` value. 

While https://github.com/kyleconroy/sqlc/pull/178 fixes the panic from a technical point of view and prevents sqlc from panicking in other situations, this PR checks if the paths are the same and informs the user if necessary.