### PR TITLE
internal/dinosql: Support the pg_temp schema

### DIFF
--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -108,6 +108,11 @@ func ParseCatalog(schema string) (core.Catalog, error) {
 			}
 		}
 	}
+
+	// The pg_temp schema is scoped to the current session. Remove it from the
+	// catalog so that other queries can not read from it.
+	delete(c.Schemas, "pg_temp")
+
 	if len(merr.Errs) > 0 {
 		return c, merr
 	}

--- a/internal/pg/catalog.go
+++ b/internal/pg/catalog.go
@@ -5,6 +5,15 @@ func NewCatalog() Catalog {
 		Schemas: map[string]Schema{
 			"public":     NewSchema(),
 			"pg_catalog": pgCatalog(),
+			// Likewise, the current session's temporary-table schema, pg_temp_nnn, is
+			// always searched if it exists. It can be explicitly listed in the path by
+			// using the alias pg_temp. If it is not listed in the path then it is
+			// searched first (even before pg_catalog). However, the temporary schema is
+			// only searched for relation (table, view, sequence, etc) and data type
+			// names. It is never searched for function or operator names.
+			//
+			// https://www.postgresql.org/docs/current/runtime-config-client.html
+			"pg_temp": NewSchema(),
 		},
 	}
 }


### PR DESCRIPTION
The schema is removed from the catalog so that queries can not
reference it, since it will be empty in a new session.

Fixes #181 