### PR TITLE
internal/dinosql: Override columns with array type

### DIFF
--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -467,6 +467,12 @@ func (r Result) Structs() []GoStruct {
 }
 
 func (r Result) goType(col core.Column) string {
+	// package overrides have a higher precedence
+	for _, oride := range append(r.Settings.Overrides, r.packageSettings.Overrides...) {
+		if oride.Column != "" && oride.columnName == col.Name && oride.table == col.Table {
+			return oride.goTypeName
+		}
+	}
 	typ := r.goInnerType(col)
 	if col.IsArray {
 		return "[]" + typ
@@ -481,9 +487,6 @@ func (r Result) goInnerType(col core.Column) string {
 	// package overrides have a higher precedence
 	for _, oride := range append(r.Settings.Overrides, r.packageSettings.Overrides...) {
 		if oride.PostgresType != "" && oride.PostgresType == columnType && oride.Null != notNull {
-			return oride.goTypeName
-		}
-		if oride.Column != "" && oride.columnName == col.Name && oride.table == col.Table {
 			return oride.goTypeName
 		}
 	}

--- a/internal/dinosql/gen_test.go
+++ b/internal/dinosql/gen_test.go
@@ -40,6 +40,11 @@ func TestColumnsToStruct(t *testing.T) {
 			DataType: "text",
 			NotNull:  true,
 		},
+		{
+			Name:     "languages",
+			DataType: "text",
+			IsArray:  true,
+		},
 	}
 
 	// all of the columns are on the 'foo' table
@@ -55,8 +60,16 @@ func TestColumnsToStruct(t *testing.T) {
 		Column: "foo.retyped",
 	}
 	o.Parse()
+
+	// set up column-based array override test
+	oa := Override{
+		GoType: "github.com/lib/pq.StringArray",
+		Column: "foo.languages",
+	}
+	oa.Parse()
+
 	r.packageSettings = PackageSettings{
-		Overrides: []Override{o},
+		Overrides: []Override{o, oa},
 	}
 
 	actual := r.columnsToStruct("Foo", cols)
@@ -69,6 +82,7 @@ func TestColumnsToStruct(t *testing.T) {
 			{Name: "Tags", Type: "[]string", Tags: map[string]string{"json:": "tags"}},
 			{Name: "ByteSeq", Type: "[]byte", Tags: map[string]string{"json:": "byte_seq"}},
 			{Name: "Retyped", Type: "pkg.CustomType", Tags: map[string]string{"json:": "retyped"}},
+			{Name: "Languages", Type: "pq.StringArray", Tags: map[string]string{"json:": "languages"}},
 		},
 	}
 	if diff := cmp.Diff(expected, actual); diff != "" {


### PR DESCRIPTION
This is a short-term fix for #172. Longer term, we're going to need to decide how to apply overrides to array types.

Fixes #172 