### PR TITLE
internal/dinosql: Implement robust expansion

### DIFF
--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -666,32 +666,13 @@ func (r Result) GoQueries() []GoQuery {
 			continue
 		}
 
-		code := query.SQL
-
-		// TODO: Will horribly break sometimes
-		if query.NeedsEdit {
-			var cols []string
-			find := "*"
-			for _, c := range query.Columns {
-				if c.Scope != "" {
-					find = c.Scope + ".*"
-				}
-				name := c.Name
-				if c.Scope != "" {
-					name = c.Scope + "." + name
-				}
-				cols = append(cols, name)
-			}
-			code = strings.Replace(query.SQL, find, strings.Join(cols, ", "), 1)
-		}
-
 		gq := GoQuery{
 			Cmd:          query.Cmd,
 			ConstantName: lowerTitle(query.Name),
 			FieldName:    lowerTitle(query.Name) + "Stmt",
 			MethodName:   query.Name,
 			SourceName:   query.Filename,
-			SQL:          code,
+			SQL:          query.SQL,
 			Comments:     query.Comments,
 		}
 

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -167,8 +167,7 @@ type Query struct {
 	Comments []string
 
 	// XXX: Hack
-	NeedsEdit bool
-	Filename  string
+	Filename string
 }
 
 type Result struct {

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -558,13 +558,22 @@ func expandStmt(c core.Catalog, raw nodes.RawStmt, node nodes.Node) ([]edit, err
 }
 
 func editQuery(raw string, a []edit) (string, error) {
+	if len(a) == 0 {
+		return raw, nil
+	}
 	sort.Slice(a, func(i, j int) bool { return a[i].Location > a[j].Location })
-	// TODO: Check bounds
 	s := raw
 	for _, edit := range a {
-		// fmt.Printf("edit q %q\n", s)
-		// fmt.Printf("edit e %q\n", edit)
 		start := edit.Location
+		if start > len(s) {
+			return "", fmt.Errorf("edit start location is out of bounds")
+		}
+		if len(edit.New) <= 0 {
+			return "", fmt.Errorf("empty edit contents")
+		}
+		if len(edit.Old) <= 0 {
+			return "", fmt.Errorf("empty edit contents")
+		}
 		stop := edit.Location + len(edit.Old) - 1 // Assumes edit.New is non-empty
 		if stop < len(s) {
 			s = s[:start] + edit.New + s[stop+1:]
@@ -572,7 +581,6 @@ func editQuery(raw string, a []edit) (string, error) {
 			s = s[:start] + edit.New
 		}
 	}
-	// fmt.Printf("edit fixed %q\n", s)
 	return s, nil
 }
 

--- a/internal/dinosql/parser_test.go
+++ b/internal/dinosql/parser_test.go
@@ -26,10 +26,10 @@ func TestPluck(t *testing.T) {
 	}
 
 	expected := []string{
-		"SELECT * FROM venue WHERE slug = $1 AND city = $2",
-		"SELECT * FROM venue WHERE slug = $1",
-		"SELECT * FROM venue LIMIT $1",
-		"SELECT * FROM venue OFFSET $1",
+		"\nSELECT * FROM venue WHERE slug = $1 AND city = $2",
+		"\nSELECT * FROM venue WHERE slug = $1",
+		"\nSELECT * FROM venue LIMIT $1",
+		"\nSELECT * FROM venue OFFSET $1",
 	}
 
 	for i, stmt := range tree.Statements {
@@ -218,5 +218,23 @@ func TestParseMetadata(t *testing.T) {
 		if _, _, err := parseMetadata(query); err == nil {
 			t.Errorf("expected invalid metadata: %q", query)
 		}
+	}
+}
+
+func TestExpand(t *testing.T) {
+	// pretend that foo has two columns, a and b
+	raw := `SELECT *, *, foo.* FROM foo`
+	expected := `SELECT a, b, a, b, foo.a, foo.b FROM foo`
+	edits := []edit{
+		{7, "*", "a, b"},
+		{10, "*", "a, b"},
+		{13, "foo.*", "foo.a, foo.b"},
+	}
+	actual, err := editQuery(raw, edits)
+	if err != nil {
+		t.Error(err)
+	}
+	if expected != actual {
+		t.Errorf("mismatch:\nexpected: %s\n  acutal: %s", expected, actual)
 	}
 }

--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -781,6 +781,38 @@ func TestQueries(t *testing.T) {
 				SQL: "WITH cte AS (SELECT a, b FROM foo) SELECT c, d FROM bar",
 			},
 		},
+		{
+			"star-expansion-from-cte",
+			`
+			CREATE TABLE foo (a text, b text);
+			CREATE TABLE bar (c text, d text);
+			WITH cte AS (SELECT * FROM foo) SELECT * FROM cte;
+			`,
+			Query{
+				Columns: []core.Column{
+					{Name: "a", DataType: "text"},
+					{Name: "b", DataType: "text"},
+				},
+				SQL: "WITH cte AS (SELECT a, b FROM foo) SELECT a, b FROM cte",
+			},
+		},
+		{
+			"star-expansion-join",
+			`
+			CREATE TABLE foo (a text, b text);
+			CREATE TABLE bar (c text, d text);
+			SELECT * FROM foo, bar;
+			`,
+			Query{
+				Columns: []core.Column{
+					{Name: "a", DataType: "text", Table: public("foo")},
+					{Name: "b", DataType: "text", Table: public("foo")},
+					{Name: "c", DataType: "text", Table: public("bar")},
+					{Name: "d", DataType: "text", Table: public("bar")},
+				},
+				SQL: "SELECT a, b, c, d FROM foo, bar",
+			},
+		},
 	} {
 		test := tc
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Expands `SELECT *` into the correct columns, no matter the location

Fixes #173 