### PR TITLE
internal/dinosql: Add DATE support

### DIFF
--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -552,7 +552,19 @@ func (r Result) goInnerType(col core.Column) string {
 	case "bytea", "blob", "pg_catalog.bytea":
 		return "[]byte"
 
-	case "pg_catalog.timestamp", "pg_catalog.timestamptz", "timestamptz", "date":
+	case "date":
+		if notNull {
+			return "time.Time"
+		}
+		return "sql.NullTime"
+
+	case "pg_catalog.time", "pg_catalog.timetz":
+		if notNull {
+			return "time.Time"
+		}
+		return "sql.NullTime"
+
+	case "pg_catalog.timestamp", "pg_catalog.timestamptz", "timestamptz":
 		if notNull {
 			return "time.Time"
 		}

--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -552,7 +552,7 @@ func (r Result) goInnerType(col core.Column) string {
 	case "bytea", "blob", "pg_catalog.bytea":
 		return "[]byte"
 
-	case "pg_catalog.timestamp", "pg_catalog.timestamptz", "timestamptz":
+	case "pg_catalog.timestamp", "pg_catalog.timestamptz", "timestamptz", "date":
 		if notNull {
 			return "time.Time"
 		}

--- a/internal/dinosql/gen_test.go
+++ b/internal/dinosql/gen_test.go
@@ -97,6 +97,7 @@ func TestInnerType(t *testing.T) {
 		"integer":         "int32",
 		"int":             "int32",
 		"pg_catalog.int4": "int32",
+		"date":            "time.Time",
 	}
 	for k, v := range types {
 		dbType := k
@@ -117,6 +118,7 @@ func TestNullInnerType(t *testing.T) {
 		"integer":         "sql.NullInt32",
 		"int":             "sql.NullInt32",
 		"pg_catalog.int4": "sql.NullInt32",
+		"date":            "sql.NullTime",
 	}
 	for k, v := range types {
 		dbType := k

--- a/internal/dinosql/gen_test.go
+++ b/internal/dinosql/gen_test.go
@@ -93,11 +93,16 @@ func TestColumnsToStruct(t *testing.T) {
 func TestInnerType(t *testing.T) {
 	r := Result{}
 	types := map[string]string{
-		"timestamptz":     "time.Time",
 		"integer":         "int32",
 		"int":             "int32",
 		"pg_catalog.int4": "int32",
-		"date":            "time.Time",
+		// Date/Time Types https://www.postgresql.org/docs/current/datatype-datetime.html
+		"date":                   "time.Time",
+		"pg_catalog.time":        "time.Time",
+		"pg_catalog.timetz":      "time.Time",
+		"pg_catalog.timestamp":   "time.Time",
+		"pg_catalog.timestamptz": "time.Time",
+		"timestamptz":            "time.Time",
 	}
 	for k, v := range types {
 		dbType := k
@@ -114,11 +119,16 @@ func TestInnerType(t *testing.T) {
 func TestNullInnerType(t *testing.T) {
 	r := Result{}
 	types := map[string]string{
-		"timestamptz":     "sql.NullTime",
 		"integer":         "sql.NullInt32",
 		"int":             "sql.NullInt32",
 		"pg_catalog.int4": "sql.NullInt32",
-		"date":            "sql.NullTime",
+		// Date/Time Types https://www.postgresql.org/docs/current/datatype-datetime.html
+		"date":                   "sql.NullTime",
+		"pg_catalog.time":        "sql.NullTime",
+		"pg_catalog.timetz":      "sql.NullTime",
+		"pg_catalog.timestamp":   "sql.NullTime",
+		"pg_catalog.timestamptz": "sql.NullTime",
+		"timestamptz":            "sql.NullTime",
 	}
 	for k, v := range types {
 		dbType := k

--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -814,14 +814,28 @@ func TestQueries(t *testing.T) {
 			},
 		},
 		{
-			"date",
+			"datetimes",
 			`
-			CREATE TABLE users ( birthday DATE );
-			SELECT birthday FROM users;
+			CREATE TABLE users (
+				d       DATE,
+				t       TIME,
+				t_notz  TIME WITHOUT TIME ZONE,
+				t_tz    TIME WITH TIME ZONE,
+				ts      TIMESTAMP,
+				ts_notz TIMESTAMP WITHOUT TIME ZONE,
+				ts_tz   TIMESTAMP WITH TIME ZONE
+			);
+			SELECT * FROM users;
 			`,
 			Query{
 				Columns: []core.Column{
-					{Table: public("users"), Name: "birthday", DataType: "date"},
+					{Table: public("users"), Name: "d", DataType: "date"},
+					{Table: public("users"), Name: "t", DataType: "pg_catalog.time"},
+					{Table: public("users"), Name: "t_notz", DataType: "pg_catalog.time"},
+					{Table: public("users"), Name: "t_tz", DataType: "pg_catalog.timetz"},
+					{Table: public("users"), Name: "ts", DataType: "pg_catalog.timestamp"},
+					{Table: public("users"), Name: "ts_notz", DataType: "pg_catalog.timestamp"},
+					{Table: public("users"), Name: "ts_tz", DataType: "pg_catalog.timestamptz"},
 				},
 			},
 		},

--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -813,6 +813,18 @@ func TestQueries(t *testing.T) {
 				SQL: "SELECT a, b, c, d FROM foo, bar",
 			},
 		},
+		{
+			"date",
+			`
+			CREATE TABLE users ( birthday DATE );
+			SELECT birthday FROM users;
+			`,
+			Query{
+				Columns: []core.Column{
+					{Table: public("users"), Name: "birthday", DataType: "date"},
+				},
+			},
+		},
 	} {
 		test := tc
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Generate the correct types for `DATE`, `TIME [WITHOUT TIME ZONE]`, `TIME WITH TIME ZONE`

Fixes #195 