### PR TITLE
Generating correct LIMIT and OFFSET field names

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -127,11 +127,6 @@ var genCmd = &cobra.Command{
 		output := map[string]string{}
 
 		for i, pkg := range settings.Packages {
-			if pkg.Schema == pkg.Queries {
-				fmt.Fprintf(os.Stderr, "package[%d]: schema and query path must not be identical\n", i)
-				os.Exit(1)
-			}
-
 			name := pkg.Name
 
 			if pkg.Path == "" {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -127,6 +127,11 @@ var genCmd = &cobra.Command{
 		output := map[string]string{}
 
 		for i, pkg := range settings.Packages {
+			if pkg.Schema == pkg.Queries {
+				fmt.Fprintf(os.Stderr, "package[%d]: schema and query path must not be identical\n", i)
+				os.Exit(1)
+			}
+
 			name := pkg.Name
 
 			if pkg.Path == "" {

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -371,7 +371,7 @@ func parseQuery(c core.Catalog, stmt nodes.Node, source string) (*Query, error) 
 	}
 	raw, ok := stmt.(nodes.RawStmt)
 	if !ok {
-		return nil, nil
+		return nil, errors.New("node is not a statement")
 	}
 	switch n := raw.Stmt.(type) {
 	case nodes.SelectStmt:
@@ -382,7 +382,7 @@ func parseQuery(c core.Catalog, stmt nodes.Node, source string) (*Query, error) 
 		}
 	case nodes.UpdateStmt:
 	default:
-		return nil, nil
+		return nil, fmt.Errorf("parseQuery: unsupported statement type: %T", n)
 	}
 
 	rawSQL, err := pluckQuery(source, raw)

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -987,8 +987,12 @@ func (p *paramSearch) Visit(node nodes.Node) Visitor {
 		p.parent = node
 
 	case nodes.SelectStmt:
-		p.limitCount = n.LimitCount
-		p.limitOffset = n.LimitOffset
+		if n.LimitCount != nil {
+			p.limitCount = n.LimitCount
+		}
+		if n.LimitOffset != nil {
+			p.limitOffset = n.LimitOffset
+		}
 
 	case nodes.TypeCast:
 		p.parent = node

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -371,7 +371,7 @@ func parseQuery(c core.Catalog, stmt nodes.Node, source string) (*Query, error) 
 	}
 	raw, ok := stmt.(nodes.RawStmt)
 	if !ok {
-		return nil, errors.New("node is not a statement")
+		return nil, errors.New("node is not a statement - feel free to file an issue on GitHub")
 	}
 	switch n := raw.Stmt.(type) {
 	case nodes.SelectStmt:
@@ -382,7 +382,7 @@ func parseQuery(c core.Catalog, stmt nodes.Node, source string) (*Query, error) 
 		}
 	case nodes.UpdateStmt:
 	default:
-		return nil, fmt.Errorf("parseQuery: unsupported statement type: %T", n)
+		return nil, fmt.Errorf("parseQuery: unsupported statement type: %T - feel free to file an issue on GitHub", n)
 	}
 
 	rawSQL, err := pluckQuery(source, raw)

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -371,7 +371,7 @@ func parseQuery(c core.Catalog, stmt nodes.Node, source string) (*Query, error) 
 	}
 	raw, ok := stmt.(nodes.RawStmt)
 	if !ok {
-		return nil, errors.New("node is not a statement - feel free to file an issue on GitHub")
+		return nil, errors.New("node is not a statement")
 	}
 	switch n := raw.Stmt.(type) {
 	case nodes.SelectStmt:
@@ -382,7 +382,7 @@ func parseQuery(c core.Catalog, stmt nodes.Node, source string) (*Query, error) 
 		}
 	case nodes.UpdateStmt:
 	default:
-		return nil, fmt.Errorf("parseQuery: unsupported statement type: %T - feel free to file an issue on GitHub", n)
+		return nil, fmt.Errorf("parseQuery: unsupported statement type: %T", n)
 	}
 
 	rawSQL, err := pluckQuery(source, raw)


### PR DESCRIPTION
Fixes https://github.com/kyleconroy/sqlc/issues/201.

A query like this caused incorrect field names for `LIMIT` and `OFFSET`:

```sql
-- name: GetFoo :one
SELECT
    (SELECT 1) AS baz
FROM foo
WHERE
	bar = $1
LIMIT $2
OFFSET $3;
```
The generated struct used to look like this:

```go
type GetFooParams struct {
	Bar   string `json:"bar"`
	Bar_2 string `json:"bar_2"`
	Bar_3 string `json:"bar_3"`
}
```

This happened because `LIMIT` and `OFFSET` are `nil` for the subquery but they've been assigned to the `paramSearch` though.
