### PR TITLE
internal/dinosql: Return parser errors first

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -161,7 +161,7 @@ var genCmd = &cobra.Command{
 						fmt.Fprintf(os.Stderr, "%s:%d:%d: %s\n", fileErr.Filename, fileErr.Line, fileErr.Column, fileErr.Err)
 					}
 				} else {
-					fmt.Fprintf(os.Stderr, "error parsing schema: %s\n", err)
+					fmt.Fprintf(os.Stderr, "error parsing queries: %s\n", err)
 				}
 				errored = true
 				continue

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -236,11 +236,11 @@ func ParseQueries(c core.Catalog, settings GenerateSettings, pkg PackageSettings
 			}
 		}
 	}
-	if len(q) == 0 {
-		return nil, fmt.Errorf("path %s contains no queries", pkg.Queries)
-	}
 	if len(merr.Errs) > 0 {
 		return nil, merr
+	}
+	if len(q) == 0 {
+		return nil, fmt.Errorf("path %s contains no queries", pkg.Queries)
 	}
 	return &Result{Catalog: c, Queries: q, Settings: settings}, nil
 }


### PR DESCRIPTION
I added a new check that returns an error when a package contains no queries. However, I mistakenly put this check before the check for parser errors. Moving the error below the `merr.Errs` ensures that the reported error message makes sense.

Fixes #206 