### PR TITLE
Generating correct LIMIT and OFFSET field names

### DIFF
--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -990,8 +990,12 @@ func (p *paramSearch) Visit(node nodes.Node) Visitor {
 		p.parent = node
 
 	case nodes.SelectStmt:
-		p.limitCount = n.LimitCount
-		p.limitOffset = n.LimitOffset
+		if n.LimitCount != nil {
+			p.limitCount = n.LimitCount
+		}
+		if n.LimitOffset != nil {
+			p.limitOffset = n.LimitOffset
+		}
 
 	case nodes.TypeCast:
 		p.parent = node


### PR DESCRIPTION
Fixes https://github.com/kyleconroy/sqlc/issues/201.

A query like this caused incorrect field names for `LIMIT` and `OFFSET`:

```sql
-- name: GetFoo :one
SELECT
    (SELECT 1) AS baz
FROM foo
WHERE
	bar = $1
LIMIT $2
OFFSET $3;
```
The generated struct used to look like this:

```go
type GetFooParams struct {
	Bar   string `json:"bar"`
	Bar_2 string `json:"bar_2"`
	Bar_3 string `json:"bar_3"`
}
```

This happened because `LIMIT` and `OFFSET` are `nil` for the subquery but they've been assigned to the `paramSearch` though.