### PR TITLE
dinosql/internal: Add lower and upper functions

### DIFF
--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -577,7 +577,7 @@ func (r Result) goInnerType(col core.Column) string {
 		}
 		return "sql.NullTime"
 
-	case "text", "pg_catalog.varchar", "pg_catalog.bpchar":
+	case "text", "pg_catalog.varchar", "pg_catalog.bpchar", "string":
 		if notNull {
 			return "string"
 		}

--- a/internal/dinosql/gen_test.go
+++ b/internal/dinosql/gen_test.go
@@ -96,6 +96,7 @@ func TestInnerType(t *testing.T) {
 		"integer":         "int32",
 		"int":             "int32",
 		"pg_catalog.int4": "int32",
+		"string":          "string",
 		// Date/Time Types https://www.postgresql.org/docs/current/datatype-datetime.html
 		"date":                   "time.Time",
 		"pg_catalog.time":        "time.Time",
@@ -122,6 +123,7 @@ func TestNullInnerType(t *testing.T) {
 		"integer":         "sql.NullInt32",
 		"int":             "sql.NullInt32",
 		"pg_catalog.int4": "sql.NullInt32",
+		"string":          "sql.NullString",
 		// Date/Time Types https://www.postgresql.org/docs/current/datatype-datetime.html
 		"date":                   "sql.NullTime",
 		"pg_catalog.time":        "sql.NullTime",

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -1246,15 +1246,21 @@ func resolveCatalogRefs(c core.Catalog, rvs []nodes.RangeVar, args []paramRef) (
 							DataType: "any",
 						},
 					})
+					continue
 				}
 				if i >= len(fun.Arguments) {
 					return nil, fmt.Errorf("incorrect number of arguments to %s", fun.Name)
 				}
+				arg := fun.Arguments[i]
+				name := arg.Name
+				if name == "" {
+					name = fun.Name
+				}
 				a = append(a, Parameter{
 					Number: ref.ref.Number,
 					Column: core.Column{
-						Name:     fun.Arguments[i].Name,
-						DataType: fun.Arguments[i].DataType,
+						Name:     name,
+						DataType: arg.DataType,
 						NotNull:  true,
 					},
 				})

--- a/internal/dinosql/query_test.go
+++ b/internal/dinosql/query_test.go
@@ -675,6 +675,23 @@ func TestQueries(t *testing.T) {
 			},
 		},
 		{
+			"lower-switched-order",
+			`
+			CREATE TABLE foo (bar text not null, bat text not null);
+			SELECT bar FROM foo WHERE bar = $1 AND bat = LOWER($2);
+			`,
+			Query{
+				Columns: []core.Column{
+					{Table: public("foo"), Name: "bar", DataType: "text", NotNull: true},
+				},
+				Params: []Parameter{
+					{1, core.Column{Table: public("foo"), Name: "bar", DataType: "text", NotNull: true}},
+					{2, core.Column{Name: "lower", DataType: "string", NotNull: true}},
+				},
+			},
+		},
+
+		{
 			"identical-tables",
 			`
 			CREATE TABLE foo (id text not null);

--- a/internal/pg/functions_string.go
+++ b/internal/pg/functions_string.go
@@ -1,0 +1,30 @@
+package pg
+
+// String Functions and Operators
+//
+// https://www.postgresql.org/docs/current/functions-string.html
+//
+// Table 9.9. SQL String Functions and Operators
+func stringFunctions() []Function {
+	return []Function{
+		argN("position", 2),
+		{
+			Name:       "lower",
+			ReturnType: "text",
+			Arguments: []Argument{
+				{
+					DataType: "string",
+				},
+			},
+		},
+		{
+			Name:       "upper",
+			ReturnType: "text",
+			Arguments: []Argument{
+				{
+					DataType: "string",
+				},
+			},
+		},
+	}
+}

--- a/internal/pg/pg_catalog.go
+++ b/internal/pg/pg_catalog.go
@@ -44,10 +44,6 @@ func pgCatalog() Schema {
 		// https://www.postgresql.org/docs/current/functions-math.html#FUNCTIONS-MATH-RANDOM-TABLE
 		argN("random", 0),
 
-		// Table 9.8. SQL String Functions and Operators
-		// https://www.postgresql.org/docs/current/functions-string.html#FUNCTIONS-STRING-SQL
-		argN("position", 2),
-
 		// Table 9.52. General-Purpose Aggregate Functions
 		// https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-AGGREGATE-TABLE
 		{
@@ -77,6 +73,7 @@ func pgCatalog() Schema {
 		},
 	}
 
+	fs = append(fs, stringFunctions()...)
 	fs = append(fs, advisoryLockFunctions()...)
 
 	s.Funcs = make(map[string][]Function, len(fs))


### PR DESCRIPTION
Fixes #214 

Adding support for advisory locks in #212 broke code generation for the queries that used functions with parameter references. This change restores some of that functionality. The only difference is the name of the field on the parameter struct.

```sql
SELECT * FROM company_users WHERE company_slug = $1 AND email = LOWER($2);
```

used to generate

```
type Params struct {
    CompanySlug string
    Email string
}
```

but will now generate

```
type Params struct {
    CompanySlug string
    Lower string
}
```

I know that's not ideal, but I thought it would be better to provide a hot fix.

