### PR TITLE
internal/dinosql: Error on duplicate query names

### DIFF
--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -222,7 +222,6 @@ func ParseQueries(c core.Catalog, settings GenerateSettings, pkg PackageSettings
 			continue
 		}
 		for _, stmt := range tree.Statements {
-			// line, col := location(source, stmt)
 			query, err := parseQuery(c, stmt, source)
 			if err == errUnsupportedStatementType {
 				continue
@@ -231,14 +230,16 @@ func ParseQueries(c core.Catalog, settings GenerateSettings, pkg PackageSettings
 				merr.Add(filename, source, location(stmt), err)
 				continue
 			}
-			if _, exists := set[query.Name]; exists {
-				merr.Add(filename, source, location(stmt), fmt.Errorf("duplicate query name: %s", query.Name))
-				continue
+			if query.Name != "" {
+				if _, exists := set[query.Name]; exists {
+					merr.Add(filename, source, location(stmt), fmt.Errorf("duplicate query name: %s", query.Name))
+					continue
+				}
+				set[query.Name] = struct{}{}
 			}
 			query.Filename = filepath.Base(filename)
 			if query != nil {
 				q = append(q, query)
-				set[query.Name] = struct{}{}
 			}
 		}
 	}

--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -202,6 +202,7 @@ func ParseQueries(c core.Catalog, settings GenerateSettings, pkg PackageSettings
 
 	merr := NewParserErr()
 	var q []*Query
+	set := map[string]struct{}{}
 	for _, filename := range files {
 		if !strings.HasSuffix(filename, ".sql") {
 			continue
@@ -230,9 +231,14 @@ func ParseQueries(c core.Catalog, settings GenerateSettings, pkg PackageSettings
 				merr.Add(filename, source, location(stmt), err)
 				continue
 			}
+			if _, exists := set[query.Name]; exists {
+				merr.Add(filename, source, location(stmt), fmt.Errorf("duplicate query name: %s", query.Name))
+				continue
+			}
 			query.Filename = filepath.Base(filename)
 			if query != nil {
 				q = append(q, query)
+				set[query.Name] = struct{}{}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #220 

Repeating a duplicate query name will now result in the following error:

```
# package db
query.sql:1:1: duplicate query name: GetReportByID
```