### PR TITLE
internal/dinosql: Add support for numeric types

### DIFF
--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -551,6 +551,14 @@ func (r Result) goInnerType(col core.Column) string {
 		}
 		return "sql.NullFloat64" // TODO: Change to sql.NullFloat32 after updating the go.mod file
 
+	case "pg_catalog.numeric":
+		// The Go standard library does not have a decimal type. lib/pq returns these types as ???
+		// https://github.com/lib/pq/issues/648
+		if notNull {
+			return "string"
+		}
+		return "sql.NullString"
+
 	case "bool", "pg_catalog.bool":
 		if notNull {
 			return "bool"

--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -552,7 +552,9 @@ func (r Result) goInnerType(col core.Column) string {
 		return "sql.NullFloat64" // TODO: Change to sql.NullFloat32 after updating the go.mod file
 
 	case "pg_catalog.numeric":
-		// The Go standard library does not have a decimal type. lib/pq returns these types as ???
+		// Since the Go standard library does not have a decimal type, lib/pq
+		// returns numerics as strings.
+		//
 		// https://github.com/lib/pq/issues/648
 		if notNull {
 			return "string"

--- a/internal/dinosql/gen_test.go
+++ b/internal/dinosql/gen_test.go
@@ -93,11 +93,19 @@ func TestColumnsToStruct(t *testing.T) {
 func TestInnerType(t *testing.T) {
 	r := Result{}
 	types := map[string]string{
-		"integer":         "int32",
-		"int":             "int32",
-		"pg_catalog.int4": "int32",
-		"string":          "string",
-		// Date/Time Types https://www.postgresql.org/docs/current/datatype-datetime.html
+		// Numeric Types
+		// https://www.postgresql.org/docs/current/datatype-numeric.html
+		"integer":            "int32",
+		"int":                "int32",
+		"pg_catalog.int4":    "int32",
+		"pg_catalog.numeric": "string",
+
+		// Character Types
+		// https://www.postgresql.org/docs/current/datatype-character.html
+		"string": "string",
+
+		// Date/Time Types
+		// https://www.postgresql.org/docs/current/datatype-datetime.html
 		"date":                   "time.Time",
 		"pg_catalog.time":        "time.Time",
 		"pg_catalog.timetz":      "time.Time",
@@ -120,11 +128,19 @@ func TestInnerType(t *testing.T) {
 func TestNullInnerType(t *testing.T) {
 	r := Result{}
 	types := map[string]string{
-		"integer":         "sql.NullInt32",
-		"int":             "sql.NullInt32",
-		"pg_catalog.int4": "sql.NullInt32",
-		"string":          "sql.NullString",
-		// Date/Time Types https://www.postgresql.org/docs/current/datatype-datetime.html
+		// Numeric Types
+		// https://www.postgresql.org/docs/current/datatype-numeric.html
+		"integer":            "sql.NullInt32",
+		"int":                "sql.NullInt32",
+		"pg_catalog.int4":    "sql.NullInt32",
+		"pg_catalog.numeric": "sql.NullString",
+
+		// Character Types
+		// https://www.postgresql.org/docs/current/datatype-character.html
+		"string": "sql.NullString",
+
+		// Date/Time Types
+		// https://www.postgresql.org/docs/current/datatype-datetime.html
 		"date":                   "sql.NullTime",
 		"pg_catalog.time":        "sql.NullTime",
 		"pg_catalog.timetz":      "sql.NullTime",


### PR DESCRIPTION
Since the Go standard library does not have a decimal type, lib/pq returns decimals and numerics as strings. You'll need to use a decimal library to properly support these values.

https://github.com/lib/pq/issues/648

Fixes #227 

