### PR TITLE
Set stdout correctly

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -29,7 +29,7 @@ func Do(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int 
 
 	rootCmd.SetArgs(args)
 	rootCmd.SetIn(stdin)
-	rootCmd.SetErr(stderr)
+	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(stderr)
 
 	err := rootCmd.Execute()


### PR DESCRIPTION
The `cmd.Do` function takes a writer to use as standard out, but doesn't
use it. Instead, there's a duplicate call to `cobra.Command.SetErr`.
This patch replaces one of the duplicates with `SetOut`.