### PR TITLE
MySQL support improvements

### DIFF
--- a/examples/booktest/mysql/query.sql.go
+++ b/examples/booktest/mysql/query.sql.go
@@ -17,26 +17,15 @@ type BooksByTitleYearParams struct {
 	Yr    int
 }
 
-type BooksByTitleYearRow struct {
-	BookID    int
-	AuthorID  int
-	Isbn      string
-	BookType  BookTypeType
-	Title     string
-	Yr        int
-	Available time.Time
-	Tags      string
-}
-
-func (q *Queries) BooksByTitleYear(ctx context.Context, arg BooksByTitleYearParams) ([]BooksByTitleYearRow, error) {
+func (q *Queries) BooksByTitleYear(ctx context.Context, arg BooksByTitleYearParams) ([]Book, error) {
 	rows, err := q.db.QueryContext(ctx, booksByTitleYear, arg.Title, arg.Yr)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []BooksByTitleYearRow
+	var items []Book
 	for rows.Next() {
-		var i BooksByTitleYearRow
+		var i Book
 		if err := rows.Scan(
 			&i.BookID,
 			&i.AuthorID,
@@ -109,14 +98,9 @@ const getAuthor = `-- name: GetAuthor :one
 select author_id, name from authors where author_id = ?
 `
 
-type GetAuthorRow struct {
-	AuthorID int
-	Name     string
-}
-
-func (q *Queries) GetAuthor(ctx context.Context, author_id int) (GetAuthorRow, error) {
+func (q *Queries) GetAuthor(ctx context.Context, author_id int) (Author, error) {
 	row := q.db.QueryRowContext(ctx, getAuthor, author_id)
-	var i GetAuthorRow
+	var i Author
 	err := row.Scan(&i.AuthorID, &i.Name)
 	return i, err
 }
@@ -125,20 +109,9 @@ const getBook = `-- name: GetBook :one
 select book_id, author_id, isbn, book_type, title, yr, available, tags from books where book_id = ?
 `
 
-type GetBookRow struct {
-	BookID    int
-	AuthorID  int
-	Isbn      string
-	BookType  BookTypeType
-	Title     string
-	Yr        int
-	Available time.Time
-	Tags      string
-}
-
-func (q *Queries) GetBook(ctx context.Context, book_id int) (GetBookRow, error) {
+func (q *Queries) GetBook(ctx context.Context, book_id int) (Book, error) {
 	row := q.db.QueryRowContext(ctx, getBook, book_id)
-	var i GetBookRow
+	var i Book
 	err := row.Scan(
 		&i.BookID,
 		&i.AuthorID,

--- a/internal/mysql/README.md
+++ b/internal/mysql/README.md
@@ -1,4 +1,4 @@
-# MySQL Support
+# Experimental MySQL Support
 
 ## Missing Features
 

--- a/internal/mysql/functions.go
+++ b/internal/mysql/functions.go
@@ -7,10 +7,13 @@ import (
 // converts MySQL function name to MySQL return type
 func functionReturnType(f string) string {
 	switch f {
-	case "avg", "count", "instr", "sum", "min", "max", "length", "char_length":
+	case "avg", "count", "instr", "sum", "min", "max", "length", "char_length",
+		"ceil", "floor", "mod":
 		return "int"
 	case "concat", "left", "replace", "substring", "trim", "find_in_set", "format", "group_concat":
 		return "varchar"
+	case "abs", "round", "truncate":
+		return "decimal"
 	default:
 		panic(fmt.Sprintf("unknown mysql function type [%v]", f))
 	}

--- a/internal/mysql/param_test.go
+++ b/internal/mysql/param_test.go
@@ -83,7 +83,7 @@ func TestSelectParamSearcher(t *testing.T) {
 		}
 		selectStm, ok := tree.(*sqlparser.Select)
 
-		tableAliasMap, err := parseFrom(selectStm.From, false)
+		tableAliasMap, _, err := parseFrom(selectStm.From, false)
 		if err != nil {
 			t.Errorf("Failed to parse table name alias's: %v", err)
 		}


### PR DESCRIPTION
This PR contains additional improvements to MySQL support

- now supports unqualified column expressions in the `SELECT` expression for the "left-most" table in the `FROM` expression. This is consistent with the MySQL specification.
- adds support for more MySQL datatypes and function return types
- adds logic to reuse `structs` when all fields are selected from a table

On a separate note, _please consider not squashing the commit history_. As the project grows and new collaborators seek to contribute, a rich git history along with its associated metadata is very helpful! I also personally find it incredibly useful as I navigate a project.