### PR TITLE
use %w for wrapping errors in fmt.Errorf

### DIFF
--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -1156,7 +1156,7 @@ func Generate(r Generateable, settings GenerateSettings) (map[string]string, err
 		code, err := format.Source(b.Bytes())
 		if err != nil {
 			fmt.Println(b.String())
-			return fmt.Errorf("source error: %s", err)
+			return fmt.Errorf("source error: %w", err)
 		}
 		if !strings.HasSuffix(name, ".go") {
 			name += ".go"


### PR DESCRIPTION
This corrects all the places where fmt.Errorf wasn't already using the %w
directive for wrapping errors. A small quality of life change.

Found all of these with

    ag --no-heading 'fmt\.Errorf\(.*, err'  | grep -v '%w'