### PR TITLE
internal/dinosql: strip leading "go-" or trailing "-go" from import

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Each override document has the following keys:
 - `go_type`:
   - A fully qualified name to a Go type to use in the generated code.
 - `null`:
-  - If true, use this type when a column in nullable. Defaults to `false`.
+  - If true, use this type when a column is nullable. Defaults to `false`.
 
 ### Per-Column Type Overrides
 

--- a/internal/dinosql/config.go
+++ b/internal/dinosql/config.go
@@ -102,13 +102,24 @@ func (o *Override) Parse() error {
 	// validate GoType
 	lastDot := strings.LastIndex(o.GoType, ".")
 	if lastDot == -1 {
-		return fmt.Errorf("Package override `go_type` specificier %q is not the proper format, expected 'package.type', e.g. 'github.com/segmentio/ksuid.KSUID'", o.GoType)
+		return fmt.Errorf("Package override `go_type` specifier %q is not the proper format, expected 'package.type', e.g. 'github.com/segmentio/ksuid.KSUID'", o.GoType)
 	}
 	lastSlash := strings.LastIndex(o.GoType, "/")
 	if lastSlash == -1 {
-		return fmt.Errorf("Package override `go_type` specificier %q is not the proper format, expected 'package.type', e.g. 'github.com/segmentio/ksuid.KSUID'", o.GoType)
+		return fmt.Errorf("Package override `go_type` specifier %q is not the proper format, expected 'package.type', e.g. 'github.com/segmentio/ksuid.KSUID'", o.GoType)
 	}
-	o.goTypeName = o.GoType[lastSlash+1:]
+	typename := o.GoType[lastSlash+1:]
+	if strings.HasPrefix(typename, "go-") {
+		// a package name beginning with "go-" will give syntax errors in
+		// generated code. We should do the right thing and get the actual
+		// import name, but in lieu of that, stripping the leading "go-" may get
+		// us what we want.
+		typename = typename[len("go-"):]
+	}
+	if strings.HasSuffix(typename, "-go") {
+		typename = typename[:len(typename)-len("-go")]
+	}
+	o.goTypeName = typename
 	o.goPackage = o.GoType[:lastDot]
 	isPointer := o.GoType[0] == '*'
 	if isPointer {


### PR DESCRIPTION
If I try to import from a package named "go-x" or "x-go" it will
generate a syntax error. We should do the right thing and determine
what the package name is and set it to that, but in lieu of that,
a good guess for the import name is just stripping that prefix or
suffix.

Updates #261.