### PR TITLE
improves MySQL query metadata parsing

### DIFF
--- a/internal/dinosql/parser_test.go
+++ b/internal/dinosql/parser_test.go
@@ -121,7 +121,7 @@ func TestParseMetadata(t *testing.T) {
 		`-- name: CreateFoo :one something`,
 		`-- name: `,
 	} {
-		if _, _, err := parseMetadata(query); err == nil {
+		if _, _, err := ParseMetadata(query, CommentSyntaxDash); err == nil {
 			t.Errorf("expected invalid metadata: %q", query)
 		}
 	}

--- a/internal/mysql/param_test.go
+++ b/internal/mysql/param_test.go
@@ -118,7 +118,7 @@ func TestInsertParamSearcher(t *testing.T) {
 
 	tests := []testCase{
 		testCase{
-			input: "INSERT INTO users (first_name, last_name) VALUES (?, ?)",
+			input: "/* name: InsertNewUser :exec */\nINSERT INTO users (first_name, last_name) VALUES (?, ?)",
 			output: []*Param{
 				&Param{
 					OriginalName: ":v1",

--- a/internal/mysql/test_data/queries.sql
+++ b/internal/mysql/test_data/queries.sql
@@ -10,8 +10,8 @@ CREATE TABLE teachers (
 /* name: GetTeachersByID :one */
 SELECT * FROM teachers WHERE id = ?;
 
--- name: GetSomeTeachers :one
+/* name: GetSomeTeachers :one */
 SELECT school_id, id FROM teachers WHERE school_lng > ? AND school_lat < ?;
 
--- name: TeachersByID :one
+/* name: TeachersByID :one */
 SELECT id, school_lat FROM teachers WHERE id = ? LIMIT 10;


### PR DESCRIPTION
## Current behaviour on `master` (defect)
```sql
/* naame: CreateAuthor :exec */
INSERT INTO authors (name) VALUES (?);
```
This query fails silently and does not generate a `go` query.

## Implementation Notes
Given the similarity of metadata syntax between `mysql` and `pg`, it seems appropriate to consolidate the logic. 