### PR TITLE
internal: allow CTE to be used with UPDATE

### DIFF
--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -675,6 +675,7 @@ func sourceTables(c core.Catalog, node nodes.Node) ([]core.Table, error) {
 			Items: []nodes.Node{*n.Relation},
 		}
 	case nodes.UpdateStmt:
+		with = n.WithClause
 		list = nodes.List{
 			Items: append(n.FromClause.Items, *n.Relation),
 		}

--- a/internal/pg/errors.go
+++ b/internal/pg/errors.go
@@ -1,6 +1,8 @@
 package pg
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type Error struct {
 	Message  string


### PR DESCRIPTION
Previously we only populated the CTE field if the outer query was
a SELECT, but there's no reason you can't use a CTE with an UPDATE.

Fixes #267.