### PR TITLE
internal/dinosql: Overrides can now be basic types

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 
 Your favorite PostgreSQL / Go features are supported:
 - SQL
+  - [Query annotations](./docs/annotations.md)
+  - [Transactions](./docs/transactions.md)
+  - [Prepared queries](./docs/prepared_query.md)
   - [SELECT](./docs/query_one.md)
   - [NULL](./docs/null.md)
   - [COUNT](./docs/query_count.md)
@@ -237,8 +240,6 @@ Your favorite PostgreSQL / Go features are supported:
   - [DELETE](./docs/delete.md)
   - [RETURNING](./docs/returning.md)
   - [ANY](./docs/any.md)
-  - [Transactions](./docs/transactions.md)
-  - [Prepared queries](./docs/prepared_query.md)
 - PostgreSQL Types
   - [Arrays](./docs/arrays.md)
   - [Enums](./docs/enums.md)

--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -225,6 +225,9 @@ func ModelImports(r Generateable, settings GenerateSettings) [][]string {
 	pkg := make(map[string]struct{})
 	overrideTypes := map[string]string{}
 	for _, o := range append(settings.Overrides, settings.PackageMap[r.PkgName()].Overrides...) {
+		if o.goBasicType {
+			continue
+		}
 		overrideTypes[o.goTypeName] = o.goPackage
 	}
 
@@ -357,6 +360,9 @@ func QueryImports(r Generateable, settings GenerateSettings, filename string) []
 	pkg := make(map[string]struct{})
 	overrideTypes := map[string]string{}
 	for _, o := range append(settings.Overrides, settings.PackageMap[r.PkgName()].Overrides...) {
+		if o.goBasicType {
+			continue
+		}
 		overrideTypes[o.goTypeName] = o.goPackage
 	}
 


### PR DESCRIPTION
The `go_type` value in an override can now reference a basic type, such
as "string" or "bool".

Fixes #260 