### PR TITLE
parser: optionally rewrite numbered params to positional params

### DIFF
--- a/internal/dinosql/config.go
+++ b/internal/dinosql/config.go
@@ -51,6 +51,8 @@ type PackageSettings struct {
 	EmitJSONTags        bool       `json:"emit_json_tags"`
 	EmitPreparedQueries bool       `json:"emit_prepared_queries"`
 	Overrides           []Override `json:"overrides"`
+	// HACK: this is only set in tests, only here till Kotlin support can be merged.
+	rewriteParams       bool
 }
 
 type Override struct {


### PR DESCRIPTION
JDBC seems to only support positional parameters like `?`. I had to write a HACK to convert numbered parameters like $`1 `to `?`. This is buggy and terrible. It also means that you can't use `$1` multiple times in the same query to reference the same value.

This is a better change that examines the AST and edits the parser in the parsing step. It's cherry-picked from https://github.com/mightyguava/sqlc/pull/5 because I'd like to merge changes to core parsing code to master rather than risk complicated merge conflicts later.

When the option is off, nothing changes.

When the option is on, the parameters are no longer sorted by their `Number`, since we will rely on position as the binding index instead. Repeated parameters are no longer ignored. All parameters are included in the same order they appear in the query string. This means that there may be multiple `Columns` for the same query with the same `Number`. The generator can choose to de-dupe or not. Since this option will be tied to the generator, likely only Java/Kotlin generators, this is fine.