### PR TITLE
examples: Add build tag to authors tests

### DIFF
--- a/examples/authors/db_test.go
+++ b/examples/authors/db_test.go
@@ -1,3 +1,5 @@
+// +build examples
+
 package authors
 
 import (


### PR DESCRIPTION
The tests in the examples directory should only run if the `examples` build tag is included:

```
go test -tags examples ./...
```