### PR TITLE
internal/parser: Resolve nested CTEs

### DIFF
--- a/internal/endtoend/testdata/star_expansion_cte/query.sql
+++ b/internal/endtoend/testdata/star_expansion_cte/query.sql
@@ -1,4 +1,11 @@
 CREATE TABLE foo (a text, b text);
 CREATE TABLE bar (c text, d text);
+
 -- name: StarExpansionCTE :many
 WITH cte AS (SELECT * FROM foo) SELECT * FROM bar;
+
+-- name: StarExpansionTwoCTE :many
+WITH 
+  a AS (SELECT * FROM foo),
+  b AS (SELECT 1::int as bar, * FROM a)
+SELECT * FROM b;


### PR DESCRIPTION
Before this change, queries with multiple CTEs referring to previous CTEs would fail. The query catalog is now passed around correctly.

Fixes #269 