### PR TITLE
internal/parser: Error if last query is missing

### DIFF
--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -436,6 +436,9 @@ func parseQuery(c core.Catalog, stmt nodes.Node, source string) (*Query, error) 
 	if err != nil {
 		return nil, err
 	}
+	if rawSQL == "" {
+		return nil, errors.New("missing semicolon at end of file")
+	}
 	if err := validateFuncCall(&c, raw); err != nil {
 		return nil, err
 	}

--- a/internal/endtoend/testdata/missing_semicolon/query.sql
+++ b/internal/endtoend/testdata/missing_semicolon/query.sql
@@ -1,0 +1,11 @@
+CREATE TABLE foo (email text not null);
+
+-- name: FirstQuery :many
+SELECT * FROM foo;
+
+-- name: SecondQuery :many
+SELECT * FROM foo WHERE email = $1
+
+-- stderr
+-- # package querytest
+-- query.sql:7:1: missing semicolon at end of file

--- a/internal/endtoend/testdata/missing_semicolon/sqlc.json
+++ b/internal/endtoend/testdata/missing_semicolon/sqlc.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "packages": [{
+    "path": "go",
+	"name": "querytest",
+	"schema": "query.sql",
+	"queries": "query.sql"
+  }]
+}


### PR DESCRIPTION
If the last query in the file does not have a semicolon, return an error

Fixes #265 
