### PR TITLE
Fix settings example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ in the directory where the `sqlc` command is run.
 ```yaml
 version: "1"
 packages:
-  - name: "db",
+  - name: "db"
     emit_json_tags: true
     emit_prepared_queries: false
     emit_interface: true


### PR DESCRIPTION
The example had invalid yaml syntax.

Removed the comma at the end of the line to make the example valid yaml.