### PR TITLE
Support multi-line SQL comments

### DIFF
--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -762,7 +762,7 @@ func (r Result) columnsToStruct(name string, columns []goColumn, settings config
 		if o, ok := suffixes[c.id]; ok {
 			suffix = o
 		} else if v := seen[c.Name]; v > 0 {
-			suffix = v+1
+			suffix = v + 1
 		}
 		suffixes[c.id] = suffix
 		if suffix > 0 {
@@ -1065,7 +1065,7 @@ import (
 )
 
 {{range .Enums}}
-{{if .Comment}}// {{.Comment}}{{end}}
+{{if .Comment}}{{comment .Comment}}{{end}}
 type {{.Name}} string
 
 const (
@@ -1081,7 +1081,7 @@ func (e *{{.Name}}) Scan(src interface{}) error {
 {{end}}
 
 {{range .Structs}}
-{{if .Comment}}// {{.Comment}}{{end}}
+{{if .Comment}}{{comment .Comment}}{{end}}
 type {{.Name}} struct { {{- range .Fields}}
   {{- if .Comment}}
   // {{.Comment}}{{else}}
@@ -1224,9 +1224,14 @@ func LowerTitle(s string) string {
 	return string(a)
 }
 
+func DoubleSlashComment(s string) string {
+	return "// " + strings.ReplaceAll(s, "\n", "\n// ")
+}
+
 func Generate(r Generateable, settings config.CombinedSettings) (map[string]string, error) {
 	funcMap := template.FuncMap{
 		"lowerTitle": LowerTitle,
+		"comment":    DoubleSlashComment,
 		"imports":    Imports(r, settings),
 	}
 

--- a/internal/dinosql/kotlin/gen.go
+++ b/internal/dinosql/kotlin/gen.go
@@ -667,7 +667,6 @@ func ktParamName(c core.Column, number int) string {
 	return fmt.Sprintf("dollar_%d", number)
 }
 
-
 func ktColumnName(c core.Column, pos int) string {
 	if c.Name != "" {
 		return c.Name
@@ -812,7 +811,7 @@ package {{.Package}}
 {{end}}
 
 {{range .Enums}}
-{{if .Comment}}// {{.Comment}}{{end}}
+{{if .Comment}}{{comment .Comment}}{{end}}
 enum class {{.Name}}(val value: String) {
   {{- range $i, $e := .Constants}}
   {{- if $i }},{{end}}
@@ -827,7 +826,7 @@ enum class {{.Name}}(val value: String) {
 {{end}}
 
 {{range .KtDataClasses}}
-{{if .Comment}}// {{.Comment}}{{end}}
+{{if .Comment}}{{comment .Comment}}{{end}}
 data class {{.Name}} ( {{- range $i, $e := .Fields}}
   {{- if $i }},{{end}}
   {{- if .Comment}}
@@ -974,6 +973,7 @@ func ktFormat(s string) string {
 func KtGenerate(r KtGenerateable, settings config.CombinedSettings) (map[string]string, error) {
 	funcMap := template.FuncMap{
 		"lowerTitle": dinosql.LowerTitle,
+		"comment":    dinosql.DoubleSlashComment,
 		"imports":    KtImports(r, settings),
 		"offset":     Offset,
 	}
@@ -984,12 +984,12 @@ func KtGenerate(r KtGenerateable, settings config.CombinedSettings) (map[string]
 
 	pkg := settings.Package
 	tctx := ktTmplCtx{
-		Settings:            settings.Global,
-		Q:                   `"""`,
-		Package:             pkg.Gen.Kotlin.Package,
-		KtQueries:           r.KtQueries(settings),
-		Enums:               r.KtEnums(settings),
-		KtDataClasses:       r.KtDataClasses(settings),
+		Settings:      settings.Global,
+		Q:             `"""`,
+		Package:       pkg.Gen.Kotlin.Package,
+		KtQueries:     r.KtQueries(settings),
+		Enums:         r.KtEnums(settings),
+		KtDataClasses: r.KtDataClasses(settings),
 	}
 
 	output := map[string]string{}
@@ -1014,8 +1014,8 @@ func KtGenerate(r KtGenerateable, settings config.CombinedSettings) (map[string]
 		return nil, err
 	}
 	if err := execute("Queries.kt", ifaceFile); err != nil {
-			return nil, err
-		}
+		return nil, err
+	}
 	if err := execute("QueriesImpl.kt", sqlFile); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Multi-line SQL comments broke the code generator. This PR fixes the issue.

**The case:** Consider this SQL schema:
```sql
CREATE TABLE authors (
  id   bigserial PRIMARY KEY,
  name text      NOT NULL
);

COMMENT ON TABLE authors IS
'Keeps authors.
Contains id and name.';
```

**Previous behavior:** The code generator (`sqlc generate`) exited with an error:
```
...
// Keeps authors.
Contains id and name.
type Author struct {
  ID int64 
  Name string 
}


# package db
error generating code: source error: 17:1: expected declaration, found Contains
```
The reason is obvious: The code generator adds `//` only at the beginning of the comment string. As a result, only the first line of the comment string is commented out.

**New behavior:** Code generator adds `//` at the beginning of every line of the comment string. For the aforementioned schema, the `models.go` file will be generated as:
```go
...
// Keeps authors.
// Contains id and name.
type Author struct {
	ID   int64
	Name string
}
```

**The fix:**
- Implemented for both Go and Kotlin code generators.
- Works correctly for both Unix and Windows newlines (LF and CRLF).
- The changed filed are `go fmt`'d using `go1.13.4 linux/amd64`.