### PR TITLE
internal/endtoend: remove %w

### DIFF
--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -134,7 +134,7 @@ func expectedStderr(t *testing.T, dir string) string {
 		}
 		rd, err := os.Open(filepath.Join(dir, file.Name()))
 		if err != nil {
-			t.Fatalf("could not open %s: %w", file.Name(), err)
+			t.Fatalf("could not open %s: %v", file.Name(), err)
 		}
 		scanner := bufio.NewScanner(rd)
 		capture := false


### PR DESCRIPTION
"go vet" warns about this, presumably because a Fatal directive is not
catchable or re-throwable.