### PR TITLE
Add support for named arguments in INSERTs

### DIFF
--- a/internal/endtoend/testdata/named_param/go/query.sql.go
+++ b/internal/endtoend/testdata/named_param/go/query.sql.go
@@ -71,6 +71,22 @@ func (q *Queries) FuncParams(ctx context.Context, arg FuncParamsParams) ([]strin
 	return items, nil
 }
 
+const insertParams = `-- name: InsertParams :one
+INSERT INTO foo(name, bio) values ($1, $2) returning name
+`
+
+type InsertParamsParams struct {
+	Name string
+	Bio  string
+}
+
+func (q *Queries) InsertParams(ctx context.Context, arg InsertParamsParams) (string, error) {
+	row := q.db.QueryRowContext(ctx, insertParams, arg.Name, arg.Bio)
+	var name string
+	err := row.Scan(&name)
+	return name, err
+}
+
 const update = `-- name: Update :one
 UPDATE foo
 SET

--- a/internal/endtoend/testdata/named_param/query.sql
+++ b/internal/endtoend/testdata/named_param/query.sql
@@ -1,5 +1,8 @@
 CREATE TABLE foo (name text not null, bio text not null);
 
+-- name: InsertParams :one
+INSERT INTO foo(name, bio) values (@name, @bio) returning name;
+
 -- name: FuncParams :many
 SELECT name FROM foo WHERE name = sqlc.arg('slug') AND sqlc.arg(filter)::bool;
 


### PR DESCRIPTION
This is the first draft of the named args support in INSERTs. 

But perhaps this "navigation expression" should be refactored into a full-blown structure and used instead of `cursor.name`.