### PR TITLE
ast: Add AST for ALTER TABLE ADD / DROP COLUMN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+build:
+	go build ./...
+
+test:
+	go test --tags=exp ./...
+
+sqlc-dev:
+	go build -o ~/bin/sqlc-dev --tags=exp ./cmd/sqlc/
+
+regen:
+	cd internal/endtoend && ./regenerate.sh

--- a/internal/catalog/build.go
+++ b/internal/catalog/build.go
@@ -311,6 +311,7 @@ func Update(c *pg.Catalog, stmt nodes.Node) error {
 		} else {
 			c.Schemas[name] = pg.NewSchema()
 		}
+
 	case nodes.DropStmt:
 		for _, obj := range n.Objects.Items {
 			if n.RemoveType == nodes.OBJECT_TABLE || n.RemoveType == nodes.OBJECT_TYPE {

--- a/internal/endtoend/testdata/experimental_dolphin/go/models.go
+++ b/internal/endtoend/testdata/experimental_dolphin/go/models.go
@@ -4,6 +4,11 @@ package querytest
 
 import ()
 
+type Baz struct {
+	Name  string
+	Email string
+}
+
 type Foo struct {
 	Bar string
 }

--- a/internal/endtoend/testdata/experimental_dolphin/query.sql
+++ b/internal/endtoend/testdata/experimental_dolphin/query.sql
@@ -1,0 +1,21 @@
+CREATE TABLE foo (
+        bar text NOT NULL 
+);
+
+CREATE TABLE bar (
+        baz text NOT NULL 
+);
+
+SELECT bar FROM foo;
+
+DROP TABLE bar;
+DROP TABLE IF EXISTS bar;
+DROP TABLE IF EXISTS baz;
+
+
+CREATE TABLE baz (name text);
+ALTER TABLE baz ADD COLUMN email text;
+ALTER TABLE baz ADD COLUMN bar text;
+ALTER TABLE baz DROP COLUMN IF EXISTS foo;
+ALTER TABLE baz DROP COLUMN bar;
+ALTER TABLE baz DROP COLUMN IF EXISTS bar;

--- a/internal/endtoend/testdata/experimental_dolphin/sqlc.json
+++ b/internal/endtoend/testdata/experimental_dolphin/sqlc.json
@@ -5,8 +5,8 @@
       "path": "go",
       "name": "querytest",
       "engine": "_dolphin",
-      "schema": "../experimental.sql",
-      "queries": "../experimental.sql"
+      "schema": "query.sql",
+      "queries": "query.sql"
     }
   ]
 }

--- a/internal/endtoend/testdata/experimental_elephant/go/models.go
+++ b/internal/endtoend/testdata/experimental_elephant/go/models.go
@@ -4,6 +4,11 @@ package querytest
 
 import ()
 
+type Baz struct {
+	Name  string
+	Email string
+}
+
 type Foo struct {
 	Bar string
 }

--- a/internal/endtoend/testdata/experimental_elephant/query.sql
+++ b/internal/endtoend/testdata/experimental_elephant/query.sql
@@ -1,0 +1,21 @@
+CREATE TABLE foo (
+        bar text NOT NULL 
+);
+
+CREATE TABLE bar (
+        baz text NOT NULL 
+);
+
+SELECT bar FROM foo;
+
+DROP TABLE bar;
+DROP TABLE IF EXISTS bar;
+DROP TABLE IF EXISTS baz;
+
+
+CREATE TABLE baz (name text);
+ALTER TABLE baz ADD COLUMN email text;
+ALTER TABLE baz ADD COLUMN bar text;
+ALTER TABLE baz DROP COLUMN IF EXISTS foo;
+ALTER TABLE baz DROP COLUMN bar;
+ALTER TABLE baz DROP COLUMN IF EXISTS bar;

--- a/internal/endtoend/testdata/experimental_elephant/sqlc.json
+++ b/internal/endtoend/testdata/experimental_elephant/sqlc.json
@@ -5,8 +5,8 @@
       "path": "go",
       "name": "querytest",
       "engine": "_elephant",
-      "schema": "../experimental.sql",
-      "queries": "../experimental.sql"
+      "schema": "query.sql",
+      "queries": "query.sql"
     }
   ]
 }

--- a/internal/endtoend/testdata/experimental_lemon/go/models.go
+++ b/internal/endtoend/testdata/experimental_lemon/go/models.go
@@ -4,6 +4,11 @@ package querytest
 
 import ()
 
+type Baz struct {
+	Name  string
+	Email string
+}
+
 type Foo struct {
 	Bar string
 }

--- a/internal/endtoend/testdata/experimental_lemon/query.sql
+++ b/internal/endtoend/testdata/experimental_lemon/query.sql
@@ -9,4 +9,9 @@ CREATE TABLE bar (
 SELECT bar FROM foo;
 
 DROP TABLE bar;
+DROP TABLE IF EXISTS bar;
 DROP TABLE IF EXISTS baz;
+
+
+CREATE TABLE baz (name text);
+ALTER TABLE baz ADD COLUMN email text;

--- a/internal/endtoend/testdata/experimental_lemon/sqlc.json
+++ b/internal/endtoend/testdata/experimental_lemon/sqlc.json
@@ -5,8 +5,8 @@
       "path": "go",
       "name": "querytest",
       "engine": "_lemon",
-      "schema": "../experimental.sql",
-      "queries": "../experimental.sql"
+      "schema": "query.sql",
+      "queries": "query.sql"
     }
   ]
 }

--- a/internal/postgresql/utils.go
+++ b/internal/postgresql/utils.go
@@ -1,0 +1,21 @@
+package postgresql
+
+import nodes "github.com/lfittl/pg_query_go/nodes"
+
+func isNotNull(n nodes.ColumnDef) bool {
+	if n.IsNotNull {
+		return true
+	}
+	for _, c := range n.Constraints.Items {
+		switch n := c.(type) {
+		case nodes.Constraint:
+			if n.Contype == nodes.CONSTR_NOTNULL {
+				return true
+			}
+			if n.Contype == nodes.CONSTR_PRIMARY {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/sql/ast/ast.go
+++ b/internal/sql/ast/ast.go
@@ -26,6 +26,37 @@ func (n *TableName) Pos() int {
 	return 0
 }
 
+type AlterTableStmt struct {
+	Table *TableName
+	Cmds  *List
+	// MissingOk bool
+}
+
+func (n *AlterTableStmt) Pos() int {
+	return 0
+}
+
+type AlterTableType int
+
+const (
+	AT_AddColumn AlterTableType = iota
+	AT_AlterColumnType
+	AT_DropColumn
+	AT_DropNotNull
+	AT_SetNotNull
+)
+
+type AlterTableCmd struct {
+	Subtype   AlterTableType
+	Name      *string
+	Def       *ColumnDef
+	MissingOk bool
+}
+
+func (n *AlterTableCmd) Pos() int {
+	return 0
+}
+
 type CreateTableStmt struct {
 	IfNotExists bool
 	Name        *TableName
@@ -45,9 +76,11 @@ func (n *DropTableStmt) Pos() int {
 	return 0
 }
 
+// TODO: Support array types
 type ColumnDef struct {
-	Colname  string
-	TypeName *TypeName
+	Colname   string
+	TypeName  *TypeName
+	IsNotNull bool
 }
 
 func (n *ColumnDef) Pos() int {

--- a/internal/sql/catalog/catalog.go
+++ b/internal/sql/catalog/catalog.go
@@ -2,7 +2,6 @@ package catalog
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/kyleconroy/sqlc/internal/sql/ast"
 )
@@ -117,7 +116,6 @@ func (c *Catalog) alterTable(stmt *ast.AlterTableStmt) error {
 				}
 				if idx < 0 && !cmd.MissingOk {
 					// return wrap(pg.ErrorColumnDoesNotExist(table.Name, *cmd.Name), raw.StmtLocation)
-					fmt.Println(table.Rel.Name, *cmd.Name)
 					return ErrColumnNotFound
 				}
 				// If a missing column is allowed, skip this command

--- a/internal/sql/catalog/catalog.go
+++ b/internal/sql/catalog/catalog.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/kyleconroy/sqlc/internal/sql/ast"
 )
@@ -19,6 +20,8 @@ func Build(stmts []ast.Statement) (*Catalog, error) {
 		}
 		var err error
 		switch n := stmts[i].Raw.Stmt.(type) {
+		case *ast.AlterTableStmt:
+			err = c.alterTable(n)
 		case *ast.CreateTableStmt:
 			err = c.createTable(n)
 		case *ast.DropTableStmt:
@@ -31,8 +34,11 @@ func Build(stmts []ast.Statement) (*Catalog, error) {
 	return c, nil
 }
 
+// TODO: This need to be rich error types
 var ErrRelationNotFound = errors.New("relation not found")
 var ErrSchemaNotFound = errors.New("schema not found")
+var ErrColumnNotFound = errors.New("column not found")
+var ErrColumnExists = errors.New("column already exists")
 
 func (c *Catalog) getSchema(name string) (*Schema, error) {
 	for i := range c.Schemas {
@@ -41,6 +47,118 @@ func (c *Catalog) getSchema(name string) (*Schema, error) {
 		}
 	}
 	return nil, ErrSchemaNotFound
+}
+
+func (c *Catalog) getTable(name *ast.TableName) (*Schema, *Table, error) {
+	ns := name.Schema
+	if ns == "" {
+		ns = c.DefaultSchema
+	}
+	var s *Schema
+	for i := range c.Schemas {
+		if c.Schemas[i].Name == ns {
+			s = c.Schemas[i]
+			break
+		}
+	}
+	if s == nil {
+		return nil, nil, ErrSchemaNotFound
+	}
+	t, _, err := s.getTable(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	return s, t, nil
+}
+
+func (c *Catalog) alterTable(stmt *ast.AlterTableStmt) error {
+	var implemented bool
+	for _, item := range stmt.Cmds.Items {
+		switch cmd := item.(type) {
+		case *ast.AlterTableCmd:
+			switch cmd.Subtype {
+			case ast.AT_AddColumn:
+				implemented = true
+			case ast.AT_AlterColumnType:
+				implemented = true
+			case ast.AT_DropColumn:
+				implemented = true
+			case ast.AT_DropNotNull:
+				implemented = true
+			case ast.AT_SetNotNull:
+				implemented = true
+			}
+		}
+	}
+	if !implemented {
+		return nil
+	}
+	_, table, err := c.getTable(stmt.Table)
+	if err != nil {
+		return err
+	}
+
+	for _, cmd := range stmt.Cmds.Items {
+		switch cmd := cmd.(type) {
+		case *ast.AlterTableCmd:
+			idx := -1
+
+			// Lookup column names for column-related commands
+			switch cmd.Subtype {
+			case ast.AT_AlterColumnType,
+				ast.AT_DropColumn,
+				ast.AT_DropNotNull,
+				ast.AT_SetNotNull:
+				for i, c := range table.Columns {
+					if c.Name == *cmd.Name {
+						idx = i
+						break
+					}
+				}
+				if idx < 0 && !cmd.MissingOk {
+					// return wrap(pg.ErrorColumnDoesNotExist(table.Name, *cmd.Name), raw.StmtLocation)
+					fmt.Println(table.Rel.Name, *cmd.Name)
+					return ErrColumnNotFound
+				}
+				// If a missing column is allowed, skip this command
+				if idx < 0 && cmd.MissingOk {
+					continue
+				}
+			}
+
+			switch cmd.Subtype {
+
+			case ast.AT_AddColumn:
+				for _, c := range table.Columns {
+					if c.Name == cmd.Def.Colname {
+						// return wrap(pg.ErrorColumnAlreadyExists(table.Name, *d.Colname), d.Location)
+						return ErrColumnExists
+					}
+				}
+				table.Columns = append(table.Columns, &Column{
+					Name:      cmd.Def.Colname,
+					Type:      *cmd.Def.TypeName,
+					IsNotNull: cmd.Def.IsNotNull,
+				})
+
+			case ast.AT_AlterColumnType:
+				table.Columns[idx].Type = *cmd.Def.TypeName
+				// table.Columns[idx].IsArray = isArray(d.TypeName)
+
+			case ast.AT_DropColumn:
+				table.Columns = append(table.Columns[:idx], table.Columns[idx+1:]...)
+
+			case ast.AT_DropNotNull:
+				table.Columns[idx].IsNotNull = false
+
+			case ast.AT_SetNotNull:
+				table.Columns[idx].IsNotNull = true
+
+			}
+		}
+	}
+
+	return nil
 }
 
 func (c *Catalog) createTable(stmt *ast.CreateTableStmt) error {
@@ -62,8 +180,9 @@ func (c *Catalog) createTable(stmt *ast.CreateTableStmt) error {
 	tbl := Table{Rel: stmt.Name}
 	for _, col := range stmt.Cols {
 		tbl.Columns = append(tbl.Columns, &Column{
-			Name: col.Colname,
-			Type: *col.TypeName,
+			Name:      col.Colname,
+			Type:      *col.TypeName,
+			IsNotNull: col.IsNotNull,
 		})
 	}
 	schema.Tables = append(schema.Tables, &tbl)
@@ -124,7 +243,9 @@ type Table struct {
 	Comment string
 }
 
+// TODO: Should this just be ast Nodes?
 type Column struct {
-	Name string
-	Type ast.TypeName
+	Name      string
+	Type      ast.TypeName
+	IsNotNull bool
 }

--- a/internal/sqlite/utils.go
+++ b/internal/sqlite/utils.go
@@ -1,0 +1,21 @@
+package sqlite
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/kyleconroy/sqlc/internal/sqlite/parser"
+)
+
+type tableNamer interface {
+	Table_name() parser.ITable_nameContext
+	Database_name() parser.IDatabase_nameContext
+}
+
+func parseTableName(c tableNamer) *ast.TableName {
+	name := ast.TableName{
+		Name: c.Table_name().GetText(),
+	}
+	if c.Database_name() != nil {
+		name.Schema = c.Database_name().GetText()
+	}
+	return &name
+}


### PR DESCRIPTION
Port ALTER TABLE support from `internal/catalog` to `internal/sql/catalog`. Add support for MySQL and SQLite. A note that SQLite does not support DROP COLUMN or ADD COLUMN IF EXISTS.