### PR TITLE
ast: Add support for CREATE TYPE as ENUM

### DIFF
--- a/internal/compiler/compile.go
+++ b/internal/compiler/compile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -22,6 +23,35 @@ import (
 type Parser interface {
 	Parse(io.Reader) ([]ast.Statement, error)
 }
+
+// copied over from gen.go
+func structName(name string) string {
+	out := ""
+	for _, p := range strings.Split(name, "_") {
+		if p == "id" {
+			out += "ID"
+		} else {
+			out += strings.Title(p)
+		}
+	}
+	return out
+}
+
+var identPattern = regexp.MustCompile("[^a-zA-Z0-9_]+")
+
+func enumValueName(value string) string {
+	name := ""
+	id := strings.Replace(value, "-", "_", -1)
+	id = strings.Replace(id, ":", "_", -1)
+	id = strings.Replace(id, "/", "_", -1)
+	id = identPattern.ReplaceAllString(id, "")
+	for _, part := range strings.Split(id, "_") {
+		name += strings.Title(part)
+	}
+	return name
+}
+
+// end copypasta
 
 func Run(conf config.SQL, combo config.CombinedSettings) (*Result, error) {
 	var p Parser
@@ -53,25 +83,52 @@ func Run(conf config.SQL, combo config.CombinedSettings) (*Result, error) {
 	}
 
 	var structs []dinosql.GoStruct
+	var enums []dinosql.GoEnum
 	for _, schema := range c.Schemas {
 		for _, table := range schema.Tables {
 			s := dinosql.GoStruct{
-				Table: pg.FQN{Schema: table.Rel.Schema, Rel: table.Rel.Name},
+				Table: pg.FQN{Schema: schema.Name, Rel: table.Rel.Name},
 				Name:  strings.Title(table.Rel.Name),
 			}
 			for _, col := range table.Columns {
 				s.Fields = append(s.Fields, dinosql.GoField{
-					Name: strings.Title(col.Name),
+					Name: structName(col.Name),
 					Type: "string",
 					Tags: map[string]string{"json:": col.Name},
 				})
 			}
 			structs = append(structs, s)
 		}
+		for _, typ := range schema.Types {
+			switch t := typ.(type) {
+			case catalog.Enum:
+				var name string
+				// TODO: This name should be public, not main
+				if schema.Name == "main" {
+					name = t.Name
+				} else {
+					name = schema.Name + "_" + t.Name
+				}
+				e := dinosql.GoEnum{
+					Name: structName(name),
+				}
+				for _, v := range t.Vals {
+					e.Constants = append(e.Constants, dinosql.GoConstant{
+						Name:  e.Name + enumValueName(v),
+						Value: v,
+						Type:  e.Name,
+					})
+				}
+				enums = append(enums, e)
+			}
+		}
 	}
+
 	if len(structs) > 0 {
 		sort.Slice(structs, func(i, j int) bool { return structs[i].Name < structs[j].Name })
 	}
-
-	return &Result{structs: structs}, nil
+	if len(enums) > 0 {
+		sort.Slice(enums, func(i, j int) bool { return enums[i].Name < enums[j].Name })
+	}
+	return &Result{structs: structs, enums: enums}, nil
 }

--- a/internal/compiler/result.go
+++ b/internal/compiler/result.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Result struct {
+	enums   []dinosql.GoEnum
 	structs []dinosql.GoStruct
 	queries []dinosql.GoQuery
 }
@@ -19,5 +20,5 @@ func (r *Result) GoQueries(settings config.CombinedSettings) []dinosql.GoQuery {
 }
 
 func (r *Result) Enums(settings config.CombinedSettings) []dinosql.GoEnum {
-	return nil
+	return r.enums
 }

--- a/internal/endtoend/testdata/experimental_elephant/go/models.go
+++ b/internal/endtoend/testdata/experimental_elephant/go/models.go
@@ -2,7 +2,29 @@
 
 package querytest
 
-import ()
+import (
+	"fmt"
+)
+
+type Mood string
+
+const (
+	MoodSad   Mood = "sad"
+	MoodOk    Mood = "ok"
+	MoodHappy Mood = "happy"
+)
+
+func (e *Mood) Scan(src interface{}) error {
+	switch s := src.(type) {
+	case []byte:
+		*e = Mood(s)
+	case string:
+		*e = Mood(s)
+	default:
+		return fmt.Errorf("unsupported scan type for Mood: %T", src)
+	}
+	return nil
+}
 
 type Baz struct {
 	Name  string

--- a/internal/endtoend/testdata/experimental_elephant/query.sql
+++ b/internal/endtoend/testdata/experimental_elephant/query.sql
@@ -6,6 +6,8 @@ CREATE TABLE bar (
         baz text NOT NULL 
 );
 
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+
 SELECT bar FROM foo;
 
 DROP TABLE bar;

--- a/internal/sql/ast/ast.go
+++ b/internal/sql/ast/ast.go
@@ -57,6 +57,15 @@ func (n *AlterTableCmd) Pos() int {
 	return 0
 }
 
+type CreateEnumStmt struct {
+	TypeName *TypeName
+	Vals     *List
+}
+
+func (n *CreateEnumStmt) Pos() int {
+	return 0
+}
+
 type CreateTableStmt struct {
 	IfNotExists bool
 	Name        *TableName
@@ -88,7 +97,8 @@ func (n *ColumnDef) Pos() int {
 }
 
 type TypeName struct {
-	Name string
+	Schema string
+	Name   string
 }
 
 func (n *TypeName) Pos() int {
@@ -125,5 +135,13 @@ type ColumnRef struct {
 }
 
 func (n *ColumnRef) Pos() int {
+	return 0
+}
+
+type String struct {
+	Str string
+}
+
+func (n *String) Pos() int {
 	return 0
 }


### PR DESCRIPTION
MySQL and SQLite do not support CREATE TYPE ... ENUM, so this change
mainly involves porting the existing enum support from the dinosql /
catalog package to the sql/catalog package