### PR TITLE
Implement ALTER TYPE RENAME VALUE / ADD VALUE

### DIFF
--- a/internal/catalog/build_test.go
+++ b/internal/catalog/build_test.go
@@ -240,6 +240,27 @@ func TestUpdate(t *testing.T) {
 				},
 			},
 		},
+		/*
+			{
+				`
+				CREATE TYPE status AS ENUM ('open', 'closed');
+				ALTER TYPE status RENAME VALUE 'closed' TO 'shut';
+				`,
+				pg.Catalog{
+					Schemas: map[string]pg.Schema{
+						"public": {
+							Types: map[string]pg.Type{
+								"status": pg.Enum{
+									Name: "status",
+									Vals: []string{"open", "shut"},
+								},
+							},
+							Tables: map[string]pg.Table{},
+						},
+					},
+				},
+			},
+		*/
 		{
 			`
 			CREATE TABLE venues ();

--- a/internal/catalog/build_test.go
+++ b/internal/catalog/build_test.go
@@ -46,6 +46,43 @@ func TestUpdate(t *testing.T) {
 			},
 		},
 		{
+			`
+			CREATE TYPE status AS ENUM ('open', 'closed');
+			ALTER TYPE status RENAME VALUE 'closed' TO 'shut';
+			`,
+			pg.Catalog{
+				Schemas: map[string]pg.Schema{
+					"public": {
+						Types: map[string]pg.Type{
+							"status": pg.Enum{
+								Name: "status",
+								Vals: []string{"open", "shut"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			`
+			CREATE TYPE status AS ENUM ('open', 'closed');
+			ALTER TYPE status ADD VALUE 'unknown';
+			ALTER TYPE status ADD VALUE IF NOT EXISTS 'unknown';
+			`,
+			pg.Catalog{
+				Schemas: map[string]pg.Schema{
+					"public": {
+						Types: map[string]pg.Type{
+							"status": pg.Enum{
+								Name: "status",
+								Vals: []string{"open", "closed", "unknown"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			"CREATE TABLE venues ();",
 			pg.Catalog{
 				Schemas: map[string]pg.Schema{

--- a/internal/postgresql/parse.go
+++ b/internal/postgresql/parse.go
@@ -188,6 +188,25 @@ func (p *Parser) Parse(r io.Reader) ([]ast.Statement, error) {
 func translate(node nodes.Node) (ast.Node, error) {
 	switch n := node.(type) {
 
+	case nodes.AlterEnumStmt:
+		name, err := parseTypeName(n.TypeName)
+		if err != nil {
+			return nil, err
+		}
+		if n.OldVal != nil {
+			return &ast.AlterTypeRenameValueStmt{
+				Type:     name,
+				OldValue: n.OldVal,
+				NewValue: n.NewVal,
+			}, nil
+		} else {
+			return &ast.AlterTypeAddValueStmt{
+				Type:               name,
+				NewValue:           n.NewVal,
+				SkipIfNewValExists: n.SkipIfNewValExists,
+			}, nil
+		}
+
 	case nodes.AlterObjectSchemaStmt:
 		switch n.ObjectType {
 

--- a/internal/sql/ast/ast.go
+++ b/internal/sql/ast/ast.go
@@ -230,6 +230,26 @@ func (n *RenameColumnStmt) Pos() int {
 	return 0
 }
 
+type AlterTypeRenameValueStmt struct {
+	Type     *TypeName
+	OldValue *string
+	NewValue *string
+}
+
+func (n *AlterTypeRenameValueStmt) Pos() int {
+	return 0
+}
+
+type AlterTypeAddValueStmt struct {
+	Type               *TypeName
+	NewValue           *string
+	SkipIfNewValExists bool
+}
+
+func (n *AlterTypeAddValueStmt) Pos() int {
+	return 0
+}
+
 type RenameTableStmt struct {
 	Table   *TableName
 	NewName *string

--- a/internal/sql/catalog/catalog.go
+++ b/internal/sql/catalog/catalog.go
@@ -226,6 +226,10 @@ func (c *Catalog) Build(stmts []ast.Statement) error {
 			err = c.alterTable(n)
 		case *ast.AlterTableSetSchemaStmt:
 			err = c.alterTableSetSchema(n)
+		case *ast.AlterTypeAddValueStmt:
+			err = c.alterTypeAddValue(n)
+		case *ast.AlterTypeRenameValueStmt:
+			err = c.alterTypeRenameValue(n)
 		case *ast.CommentOnColumnStmt:
 			err = c.commentOnColumn(n)
 		case *ast.CommentOnSchemaStmt:

--- a/internal/sql/catalog/types.go
+++ b/internal/sql/catalog/types.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/kyleconroy/sqlc/internal/sql/ast"
 	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
@@ -33,6 +34,79 @@ func (c *Catalog) createEnum(stmt *ast.CreateEnumStmt) error {
 		Name: stmt.TypeName.Name,
 		Vals: stringSlice(stmt.Vals),
 	})
+	return nil
+}
+
+func (c *Catalog) alterTypeRenameValue(stmt *ast.AlterTypeRenameValueStmt) error {
+	ns := stmt.Type.Schema
+	if ns == "" {
+		ns = c.DefaultSchema
+	}
+	schema, err := c.getSchema(ns)
+	if err != nil {
+		return err
+	}
+	typ, _, err := schema.getType(stmt.Type)
+	if err != nil {
+		return err
+	}
+	enum, ok := typ.(*Enum)
+	if !ok {
+		return fmt.Errorf("type is not an enum: %s", stmt.Type)
+	}
+
+	oldIndex := -1
+	newIndex := -1
+	for i, val := range enum.Vals {
+		if val == *stmt.OldValue {
+			oldIndex = i
+		}
+		if val == *stmt.NewValue {
+			newIndex = i
+		}
+	}
+	if oldIndex < 0 {
+		return fmt.Errorf("type %s does not have value %s", stmt.Type, *stmt.OldValue)
+	}
+	if newIndex >= 0 {
+		return fmt.Errorf("type %s already has value %s", stmt.Type, *stmt.NewValue)
+	}
+	enum.Vals[oldIndex] = *stmt.NewValue
+	return nil
+}
+
+func (c *Catalog) alterTypeAddValue(stmt *ast.AlterTypeAddValueStmt) error {
+	ns := stmt.Type.Schema
+	if ns == "" {
+		ns = c.DefaultSchema
+	}
+	schema, err := c.getSchema(ns)
+	if err != nil {
+		return err
+	}
+	typ, _, err := schema.getType(stmt.Type)
+	if err != nil {
+		return err
+	}
+	enum, ok := typ.(*Enum)
+	if !ok {
+		return fmt.Errorf("type is not an enum: %s", stmt.Type)
+	}
+
+	newIndex := -1
+	for i, val := range enum.Vals {
+		if val == *stmt.NewValue {
+			newIndex = i
+		}
+	}
+	if newIndex >= 0 {
+		if !stmt.SkipIfNewValExists {
+			return fmt.Errorf("type %s already has value %s", stmt.Type, *stmt.NewValue)
+		} else {
+			return nil
+		}
+	}
+	enum.Vals = append(enum.Vals, *stmt.NewValue)
 	return nil
 }
 


### PR DESCRIPTION
This pull requests actually includes two parallel implementations of ALTER TYPE, one for the legacy `internal/catalog` package, and one for the new `internal/sql/catalog` package. I really need to port the `internal/dinosql` package over to the new catalog so I don't need to waste time doing things twice.

Fix #428