### PR TITLE
internal/dinosql: add map containing all enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,9 @@ Each package document has the following keys:
   - If true, include support for prepared queries. Defaults to `false`.
 - `emit_interface`:
   - If true, output a `Querier` interface in the generated package. Defaults to `false`.
+- `emit_enum_mapping`:
+  - If true, output a map containing all members of an enum, which can be used
+    to easily test for membership.
 - `path`:
   - Output directory for generated code
 - `queries`:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,7 +114,8 @@ type SQLGen struct {
 type SQLGo struct {
 	EmitInterface       bool              `json:"emit_interface" yaml:"emit_interface"`
 	EmitJSONTags        bool              `json:"emit_json_tags" yaml:"emit_json_tags"`
-	EmitPreparedQueries bool              `json:"emit_prepared_queries" yaml:"emit_prepared_queries":`
+	EmitPreparedQueries bool              `json:"emit_prepared_queries" yaml:"emit_prepared_queries"`
+	EmitEnumMapping     bool              `json:"emit_enum_mapping" yaml:"emit_enum_mapping"`
 	Package             string            `json:"package" yaml:"package"`
 	Out                 string            `json:"out" yaml:"out"`
 	Overrides           []Override        `json:"overrides,omitempty" yaml:"overrides"`

--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -1145,6 +1145,14 @@ const (
 	{{- end}}
 )
 
+{{ if $.EmitEnumMapping }}
+var Every{{.Name}} = map[{{.Name}}]bool{
+	{{ range .Constants -}}
+	{{.Name}}: true,
+	{{ end -}}
+}
+{{ end -}}
+
 func (e *{{.Name}}) Scan(src interface{}) error {
 	switch s := src.(type) {
 	case []byte:
@@ -1299,6 +1307,7 @@ type tmplCtx struct {
 	EmitJSONTags        bool
 	EmitPreparedQueries bool
 	EmitInterface       bool
+	EmitEnumMapping     bool
 }
 
 func (t *tmplCtx) OutputQuery(sourceName string) bool {
@@ -1330,6 +1339,7 @@ func Generate(r Generateable, settings config.CombinedSettings) (map[string]stri
 		EmitInterface:       golang.EmitInterface,
 		EmitJSONTags:        golang.EmitJSONTags,
 		EmitPreparedQueries: golang.EmitPreparedQueries,
+		EmitEnumMapping:     golang.EmitEnumMapping,
 		Q:                   "`",
 		Package:             golang.Package,
 		GoQueries:           r.GoQueries(settings),

--- a/internal/mysql/gen.go
+++ b/internal/mysql/gen.go
@@ -63,7 +63,7 @@ func (pGen PackageGenerator) enumNameFromColDef(col *sqlparser.ColumnDefinition)
 		dinosql.StructName(col.Name.String(), pGen.CombinedSettings))
 }
 
-// Structs marshels each query into a go struct for generation
+// Structs marshals each query into a go struct for generation
 func (r *Result) Structs(settings config.CombinedSettings) []dinosql.GoStruct {
 	var structs []dinosql.GoStruct
 	for tableName, cols := range r.Schema.tables {


### PR DESCRIPTION
Currently if I want to test for enum membership, I need to write a
custom function and then remember update it every time I add a new
field to an enum.

By placing all of the enums in a map, it is possible to write a
function in a user file in the same package that tests for membership
and does not require updating (since it can just check the map). This
also avoids the need to change the public API.

Fixes #447.