### PR TITLE
Generate the internal/sql/pg package

### DIFF
--- a/internal/postgresql/convert.go
+++ b/internal/postgresql/convert.go
@@ -1,0 +1,3606 @@
+package postgresql
+
+import (
+	nodes "github.com/lfittl/pg_query_go/nodes"
+
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/kyleconroy/sqlc/internal/sql/ast/pg"
+)
+
+func convertList(l nodes.List) *ast.List {
+	out := &ast.List{}
+	for _, item := range l.Items {
+		out.Items = append(out.Items, convertNode(item))
+	}
+	return out
+}
+
+func convertValuesList(l [][]nodes.Node) [][]ast.Node {
+	out := [][]ast.Node{}
+	for _, outer := range l {
+		o := []ast.Node{}
+		for _, inner := range outer {
+			o = append(o, convertNode(inner))
+		}
+		out = append(out, o)
+	}
+	return out
+}
+
+func convert(node nodes.Node) (ast.Node, error) {
+	return convertNode(node), nil
+}
+
+func convertA_ArrayExpr(n *nodes.A_ArrayExpr) *pg.A_ArrayExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.A_ArrayExpr{
+		Elements: convertList(n.Elements),
+		Location: n.Location,
+	}
+}
+
+func convertA_Const(n *nodes.A_Const) *pg.A_Const {
+	if n == nil {
+		return nil
+	}
+	return &pg.A_Const{
+		Val:      convertNode(n.Val),
+		Location: n.Location,
+	}
+}
+
+func convertA_Expr(n *nodes.A_Expr) *pg.A_Expr {
+	if n == nil {
+		return nil
+	}
+	return &pg.A_Expr{
+		Kind:     pg.A_Expr_Kind(n.Kind),
+		Name:     convertList(n.Name),
+		Lexpr:    convertNode(n.Lexpr),
+		Rexpr:    convertNode(n.Rexpr),
+		Location: n.Location,
+	}
+}
+
+func convertA_Indices(n *nodes.A_Indices) *pg.A_Indices {
+	if n == nil {
+		return nil
+	}
+	return &pg.A_Indices{
+		IsSlice: n.IsSlice,
+		Lidx:    convertNode(n.Lidx),
+		Uidx:    convertNode(n.Uidx),
+	}
+}
+
+func convertA_Indirection(n *nodes.A_Indirection) *pg.A_Indirection {
+	if n == nil {
+		return nil
+	}
+	return &pg.A_Indirection{
+		Arg:         convertNode(n.Arg),
+		Indirection: convertList(n.Indirection),
+	}
+}
+
+func convertA_Star(n *nodes.A_Star) *pg.A_Star {
+	if n == nil {
+		return nil
+	}
+	return &pg.A_Star{}
+}
+
+func convertAccessPriv(n *nodes.AccessPriv) *pg.AccessPriv {
+	if n == nil {
+		return nil
+	}
+	return &pg.AccessPriv{
+		PrivName: n.PrivName,
+		Cols:     convertList(n.Cols),
+	}
+}
+
+func convertAggref(n *nodes.Aggref) *pg.Aggref {
+	if n == nil {
+		return nil
+	}
+	return &pg.Aggref{
+		Xpr:           convertNode(n.Xpr),
+		Aggfnoid:      pg.Oid(n.Aggfnoid),
+		Aggtype:       pg.Oid(n.Aggtype),
+		Aggcollid:     pg.Oid(n.Aggcollid),
+		Inputcollid:   pg.Oid(n.Inputcollid),
+		Aggtranstype:  pg.Oid(n.Aggtranstype),
+		Aggargtypes:   convertList(n.Aggargtypes),
+		Aggdirectargs: convertList(n.Aggdirectargs),
+		Args:          convertList(n.Args),
+		Aggorder:      convertList(n.Aggorder),
+		Aggdistinct:   convertList(n.Aggdistinct),
+		Aggfilter:     convertNode(n.Aggfilter),
+		Aggstar:       n.Aggstar,
+		Aggvariadic:   n.Aggvariadic,
+		Aggkind:       n.Aggkind,
+		Agglevelsup:   pg.Index(n.Agglevelsup),
+		Aggsplit:      pg.AggSplit(n.Aggsplit),
+		Location:      n.Location,
+	}
+}
+
+func convertAlias(n *nodes.Alias) *pg.Alias {
+	if n == nil {
+		return nil
+	}
+	return &pg.Alias{
+		Aliasname: n.Aliasname,
+		Colnames:  convertList(n.Colnames),
+	}
+}
+
+func convertAlterCollationStmt(n *nodes.AlterCollationStmt) *pg.AlterCollationStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterCollationStmt{
+		Collname: convertList(n.Collname),
+	}
+}
+
+func convertAlterDatabaseSetStmt(n *nodes.AlterDatabaseSetStmt) *pg.AlterDatabaseSetStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterDatabaseSetStmt{
+		Dbname:  n.Dbname,
+		Setstmt: convertVariableSetStmt(n.Setstmt),
+	}
+}
+
+func convertAlterDatabaseStmt(n *nodes.AlterDatabaseStmt) *pg.AlterDatabaseStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterDatabaseStmt{
+		Dbname:  n.Dbname,
+		Options: convertList(n.Options),
+	}
+}
+
+func convertAlterDefaultPrivilegesStmt(n *nodes.AlterDefaultPrivilegesStmt) *pg.AlterDefaultPrivilegesStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterDefaultPrivilegesStmt{
+		Options: convertList(n.Options),
+		Action:  convertGrantStmt(n.Action),
+	}
+}
+
+func convertAlterDomainStmt(n *nodes.AlterDomainStmt) *pg.AlterDomainStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterDomainStmt{
+		Subtype:   n.Subtype,
+		TypeName:  convertList(n.TypeName),
+		Name:      n.Name,
+		Def:       convertNode(n.Def),
+		Behavior:  pg.DropBehavior(n.Behavior),
+		MissingOk: n.MissingOk,
+	}
+}
+
+func convertAlterEnumStmt(n *nodes.AlterEnumStmt) *pg.AlterEnumStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterEnumStmt{
+		TypeName:           convertList(n.TypeName),
+		OldVal:             n.OldVal,
+		NewVal:             n.NewVal,
+		NewValNeighbor:     n.NewValNeighbor,
+		NewValIsAfter:      n.NewValIsAfter,
+		SkipIfNewValExists: n.SkipIfNewValExists,
+	}
+}
+
+func convertAlterEventTrigStmt(n *nodes.AlterEventTrigStmt) *pg.AlterEventTrigStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterEventTrigStmt{
+		Trigname:  n.Trigname,
+		Tgenabled: n.Tgenabled,
+	}
+}
+
+func convertAlterExtensionContentsStmt(n *nodes.AlterExtensionContentsStmt) *pg.AlterExtensionContentsStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterExtensionContentsStmt{
+		Extname: n.Extname,
+		Action:  n.Action,
+		Objtype: pg.ObjectType(n.Objtype),
+		Object:  convertNode(n.Object),
+	}
+}
+
+func convertAlterExtensionStmt(n *nodes.AlterExtensionStmt) *pg.AlterExtensionStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterExtensionStmt{
+		Extname: n.Extname,
+		Options: convertList(n.Options),
+	}
+}
+
+func convertAlterFdwStmt(n *nodes.AlterFdwStmt) *pg.AlterFdwStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterFdwStmt{
+		Fdwname:     n.Fdwname,
+		FuncOptions: convertList(n.FuncOptions),
+		Options:     convertList(n.Options),
+	}
+}
+
+func convertAlterForeignServerStmt(n *nodes.AlterForeignServerStmt) *pg.AlterForeignServerStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterForeignServerStmt{
+		Servername: n.Servername,
+		Version:    n.Version,
+		Options:    convertList(n.Options),
+		HasVersion: n.HasVersion,
+	}
+}
+
+func convertAlterFunctionStmt(n *nodes.AlterFunctionStmt) *pg.AlterFunctionStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterFunctionStmt{
+		Func:    convertObjectWithArgs(n.Func),
+		Actions: convertList(n.Actions),
+	}
+}
+
+func convertAlterObjectDependsStmt(n *nodes.AlterObjectDependsStmt) *pg.AlterObjectDependsStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterObjectDependsStmt{
+		ObjectType: pg.ObjectType(n.ObjectType),
+		Relation:   convertRangeVar(n.Relation),
+		Object:     convertNode(n.Object),
+		Extname:    convertNode(n.Extname),
+	}
+}
+
+func convertAlterObjectSchemaStmt(n *nodes.AlterObjectSchemaStmt) *pg.AlterObjectSchemaStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterObjectSchemaStmt{
+		ObjectType: pg.ObjectType(n.ObjectType),
+		Relation:   convertRangeVar(n.Relation),
+		Object:     convertNode(n.Object),
+		Newschema:  n.Newschema,
+		MissingOk:  n.MissingOk,
+	}
+}
+
+func convertAlterOpFamilyStmt(n *nodes.AlterOpFamilyStmt) *pg.AlterOpFamilyStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterOpFamilyStmt{
+		Opfamilyname: convertList(n.Opfamilyname),
+		Amname:       n.Amname,
+		IsDrop:       n.IsDrop,
+		Items:        convertList(n.Items),
+	}
+}
+
+func convertAlterOperatorStmt(n *nodes.AlterOperatorStmt) *pg.AlterOperatorStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterOperatorStmt{
+		Opername: convertObjectWithArgs(n.Opername),
+		Options:  convertList(n.Options),
+	}
+}
+
+func convertAlterOwnerStmt(n *nodes.AlterOwnerStmt) *pg.AlterOwnerStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterOwnerStmt{
+		ObjectType: pg.ObjectType(n.ObjectType),
+		Relation:   convertRangeVar(n.Relation),
+		Object:     convertNode(n.Object),
+		Newowner:   convertRoleSpec(n.Newowner),
+	}
+}
+
+func convertAlterPolicyStmt(n *nodes.AlterPolicyStmt) *pg.AlterPolicyStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterPolicyStmt{
+		PolicyName: n.PolicyName,
+		Table:      convertRangeVar(n.Table),
+		Roles:      convertList(n.Roles),
+		Qual:       convertNode(n.Qual),
+		WithCheck:  convertNode(n.WithCheck),
+	}
+}
+
+func convertAlterPublicationStmt(n *nodes.AlterPublicationStmt) *pg.AlterPublicationStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterPublicationStmt{
+		Pubname:      n.Pubname,
+		Options:      convertList(n.Options),
+		Tables:       convertList(n.Tables),
+		ForAllTables: n.ForAllTables,
+		TableAction:  pg.DefElemAction(n.TableAction),
+	}
+}
+
+func convertAlterRoleSetStmt(n *nodes.AlterRoleSetStmt) *pg.AlterRoleSetStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterRoleSetStmt{
+		Role:     convertRoleSpec(n.Role),
+		Database: n.Database,
+		Setstmt:  convertVariableSetStmt(n.Setstmt),
+	}
+}
+
+func convertAlterRoleStmt(n *nodes.AlterRoleStmt) *pg.AlterRoleStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterRoleStmt{
+		Role:    convertRoleSpec(n.Role),
+		Options: convertList(n.Options),
+		Action:  n.Action,
+	}
+}
+
+func convertAlterSeqStmt(n *nodes.AlterSeqStmt) *pg.AlterSeqStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterSeqStmt{
+		Sequence:    convertRangeVar(n.Sequence),
+		Options:     convertList(n.Options),
+		ForIdentity: n.ForIdentity,
+		MissingOk:   n.MissingOk,
+	}
+}
+
+func convertAlterSubscriptionStmt(n *nodes.AlterSubscriptionStmt) *pg.AlterSubscriptionStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterSubscriptionStmt{
+		Kind:        pg.AlterSubscriptionType(n.Kind),
+		Subname:     n.Subname,
+		Conninfo:    n.Conninfo,
+		Publication: convertList(n.Publication),
+		Options:     convertList(n.Options),
+	}
+}
+
+func convertAlterSystemStmt(n *nodes.AlterSystemStmt) *pg.AlterSystemStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterSystemStmt{
+		Setstmt: convertVariableSetStmt(n.Setstmt),
+	}
+}
+
+func convertAlterTSConfigurationStmt(n *nodes.AlterTSConfigurationStmt) *pg.AlterTSConfigurationStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterTSConfigurationStmt{
+		Kind:      pg.AlterTSConfigType(n.Kind),
+		Cfgname:   convertList(n.Cfgname),
+		Tokentype: convertList(n.Tokentype),
+		Dicts:     convertList(n.Dicts),
+		Override:  n.Override,
+		Replace:   n.Replace,
+		MissingOk: n.MissingOk,
+	}
+}
+
+func convertAlterTSDictionaryStmt(n *nodes.AlterTSDictionaryStmt) *pg.AlterTSDictionaryStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterTSDictionaryStmt{
+		Dictname: convertList(n.Dictname),
+		Options:  convertList(n.Options),
+	}
+}
+
+func convertAlterTableCmd(n *nodes.AlterTableCmd) *pg.AlterTableCmd {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterTableCmd{
+		Subtype:   pg.AlterTableType(n.Subtype),
+		Name:      n.Name,
+		Newowner:  convertRoleSpec(n.Newowner),
+		Def:       convertNode(n.Def),
+		Behavior:  pg.DropBehavior(n.Behavior),
+		MissingOk: n.MissingOk,
+	}
+}
+
+func convertAlterTableMoveAllStmt(n *nodes.AlterTableMoveAllStmt) *pg.AlterTableMoveAllStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterTableMoveAllStmt{
+		OrigTablespacename: n.OrigTablespacename,
+		Objtype:            pg.ObjectType(n.Objtype),
+		Roles:              convertList(n.Roles),
+		NewTablespacename:  n.NewTablespacename,
+		Nowait:             n.Nowait,
+	}
+}
+
+func convertAlterTableSpaceOptionsStmt(n *nodes.AlterTableSpaceOptionsStmt) *pg.AlterTableSpaceOptionsStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterTableSpaceOptionsStmt{
+		Tablespacename: n.Tablespacename,
+		Options:        convertList(n.Options),
+		IsReset:        n.IsReset,
+	}
+}
+
+func convertAlterTableStmt(n *nodes.AlterTableStmt) *pg.AlterTableStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterTableStmt{
+		Relation:  convertRangeVar(n.Relation),
+		Cmds:      convertList(n.Cmds),
+		Relkind:   pg.ObjectType(n.Relkind),
+		MissingOk: n.MissingOk,
+	}
+}
+
+func convertAlterUserMappingStmt(n *nodes.AlterUserMappingStmt) *pg.AlterUserMappingStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlterUserMappingStmt{
+		User:       convertRoleSpec(n.User),
+		Servername: n.Servername,
+		Options:    convertList(n.Options),
+	}
+}
+
+func convertAlternativeSubPlan(n *nodes.AlternativeSubPlan) *pg.AlternativeSubPlan {
+	if n == nil {
+		return nil
+	}
+	return &pg.AlternativeSubPlan{
+		Xpr:      convertNode(n.Xpr),
+		Subplans: convertList(n.Subplans),
+	}
+}
+
+func convertArrayCoerceExpr(n *nodes.ArrayCoerceExpr) *pg.ArrayCoerceExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.ArrayCoerceExpr{
+		Xpr:          convertNode(n.Xpr),
+		Arg:          convertNode(n.Arg),
+		Elemfuncid:   pg.Oid(n.Elemfuncid),
+		Resulttype:   pg.Oid(n.Resulttype),
+		Resulttypmod: n.Resulttypmod,
+		Resultcollid: pg.Oid(n.Resultcollid),
+		IsExplicit:   n.IsExplicit,
+		Coerceformat: pg.CoercionForm(n.Coerceformat),
+		Location:     n.Location,
+	}
+}
+
+func convertArrayExpr(n *nodes.ArrayExpr) *pg.ArrayExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.ArrayExpr{
+		Xpr:           convertNode(n.Xpr),
+		ArrayTypeid:   pg.Oid(n.ArrayTypeid),
+		ArrayCollid:   pg.Oid(n.ArrayCollid),
+		ElementTypeid: pg.Oid(n.ElementTypeid),
+		Elements:      convertList(n.Elements),
+		Multidims:     n.Multidims,
+		Location:      n.Location,
+	}
+}
+
+func convertArrayRef(n *nodes.ArrayRef) *pg.ArrayRef {
+	if n == nil {
+		return nil
+	}
+	return &pg.ArrayRef{
+		Xpr:             convertNode(n.Xpr),
+		Refarraytype:    pg.Oid(n.Refarraytype),
+		Refelemtype:     pg.Oid(n.Refelemtype),
+		Reftypmod:       n.Reftypmod,
+		Refcollid:       pg.Oid(n.Refcollid),
+		Refupperindexpr: convertList(n.Refupperindexpr),
+		Reflowerindexpr: convertList(n.Reflowerindexpr),
+		Refexpr:         convertNode(n.Refexpr),
+		Refassgnexpr:    convertNode(n.Refassgnexpr),
+	}
+}
+
+func convertBitString(n *nodes.BitString) *pg.BitString {
+	if n == nil {
+		return nil
+	}
+	return &pg.BitString{
+		Str: n.Str,
+	}
+}
+
+func convertBlockIdData(n *nodes.BlockIdData) *pg.BlockIdData {
+	if n == nil {
+		return nil
+	}
+	return &pg.BlockIdData{
+		BiHi: n.BiHi,
+		BiLo: n.BiLo,
+	}
+}
+
+func convertBoolExpr(n *nodes.BoolExpr) *pg.BoolExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.BoolExpr{
+		Xpr:      convertNode(n.Xpr),
+		Boolop:   pg.BoolExprType(n.Boolop),
+		Args:     convertList(n.Args),
+		Location: n.Location,
+	}
+}
+
+func convertBooleanTest(n *nodes.BooleanTest) *pg.BooleanTest {
+	if n == nil {
+		return nil
+	}
+	return &pg.BooleanTest{
+		Xpr:          convertNode(n.Xpr),
+		Arg:          convertNode(n.Arg),
+		Booltesttype: pg.BoolTestType(n.Booltesttype),
+		Location:     n.Location,
+	}
+}
+
+func convertCaseExpr(n *nodes.CaseExpr) *pg.CaseExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.CaseExpr{
+		Xpr:        convertNode(n.Xpr),
+		Casetype:   pg.Oid(n.Casetype),
+		Casecollid: pg.Oid(n.Casecollid),
+		Arg:        convertNode(n.Arg),
+		Args:       convertList(n.Args),
+		Defresult:  convertNode(n.Defresult),
+		Location:   n.Location,
+	}
+}
+
+func convertCaseTestExpr(n *nodes.CaseTestExpr) *pg.CaseTestExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.CaseTestExpr{
+		Xpr:       convertNode(n.Xpr),
+		TypeId:    pg.Oid(n.TypeId),
+		TypeMod:   n.TypeMod,
+		Collation: pg.Oid(n.Collation),
+	}
+}
+
+func convertCaseWhen(n *nodes.CaseWhen) *pg.CaseWhen {
+	if n == nil {
+		return nil
+	}
+	return &pg.CaseWhen{
+		Xpr:      convertNode(n.Xpr),
+		Expr:     convertNode(n.Expr),
+		Result:   convertNode(n.Result),
+		Location: n.Location,
+	}
+}
+
+func convertCheckPointStmt(n *nodes.CheckPointStmt) *pg.CheckPointStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CheckPointStmt{}
+}
+
+func convertClosePortalStmt(n *nodes.ClosePortalStmt) *pg.ClosePortalStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.ClosePortalStmt{
+		Portalname: n.Portalname,
+	}
+}
+
+func convertClusterStmt(n *nodes.ClusterStmt) *pg.ClusterStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.ClusterStmt{
+		Relation:  convertRangeVar(n.Relation),
+		Indexname: n.Indexname,
+		Verbose:   n.Verbose,
+	}
+}
+
+func convertCoalesceExpr(n *nodes.CoalesceExpr) *pg.CoalesceExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.CoalesceExpr{
+		Xpr:            convertNode(n.Xpr),
+		Coalescetype:   pg.Oid(n.Coalescetype),
+		Coalescecollid: pg.Oid(n.Coalescecollid),
+		Args:           convertList(n.Args),
+		Location:       n.Location,
+	}
+}
+
+func convertCoerceToDomain(n *nodes.CoerceToDomain) *pg.CoerceToDomain {
+	if n == nil {
+		return nil
+	}
+	return &pg.CoerceToDomain{
+		Xpr:            convertNode(n.Xpr),
+		Arg:            convertNode(n.Arg),
+		Resulttype:     pg.Oid(n.Resulttype),
+		Resulttypmod:   n.Resulttypmod,
+		Resultcollid:   pg.Oid(n.Resultcollid),
+		Coercionformat: pg.CoercionForm(n.Coercionformat),
+		Location:       n.Location,
+	}
+}
+
+func convertCoerceToDomainValue(n *nodes.CoerceToDomainValue) *pg.CoerceToDomainValue {
+	if n == nil {
+		return nil
+	}
+	return &pg.CoerceToDomainValue{
+		Xpr:       convertNode(n.Xpr),
+		TypeId:    pg.Oid(n.TypeId),
+		TypeMod:   n.TypeMod,
+		Collation: pg.Oid(n.Collation),
+		Location:  n.Location,
+	}
+}
+
+func convertCoerceViaIO(n *nodes.CoerceViaIO) *pg.CoerceViaIO {
+	if n == nil {
+		return nil
+	}
+	return &pg.CoerceViaIO{
+		Xpr:          convertNode(n.Xpr),
+		Arg:          convertNode(n.Arg),
+		Resulttype:   pg.Oid(n.Resulttype),
+		Resultcollid: pg.Oid(n.Resultcollid),
+		Coerceformat: pg.CoercionForm(n.Coerceformat),
+		Location:     n.Location,
+	}
+}
+
+func convertCollateClause(n *nodes.CollateClause) *pg.CollateClause {
+	if n == nil {
+		return nil
+	}
+	return &pg.CollateClause{
+		Arg:      convertNode(n.Arg),
+		Collname: convertList(n.Collname),
+		Location: n.Location,
+	}
+}
+
+func convertCollateExpr(n *nodes.CollateExpr) *pg.CollateExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.CollateExpr{
+		Xpr:      convertNode(n.Xpr),
+		Arg:      convertNode(n.Arg),
+		CollOid:  pg.Oid(n.CollOid),
+		Location: n.Location,
+	}
+}
+
+func convertColumnDef(n *nodes.ColumnDef) *pg.ColumnDef {
+	if n == nil {
+		return nil
+	}
+	return &pg.ColumnDef{
+		Colname:       n.Colname,
+		TypeName:      convertTypeName(n.TypeName),
+		Inhcount:      n.Inhcount,
+		IsLocal:       n.IsLocal,
+		IsNotNull:     n.IsNotNull,
+		IsFromType:    n.IsFromType,
+		IsFromParent:  n.IsFromParent,
+		Storage:       n.Storage,
+		RawDefault:    convertNode(n.RawDefault),
+		CookedDefault: convertNode(n.CookedDefault),
+		Identity:      n.Identity,
+		CollClause:    convertCollateClause(n.CollClause),
+		CollOid:       pg.Oid(n.CollOid),
+		Constraints:   convertList(n.Constraints),
+		Fdwoptions:    convertList(n.Fdwoptions),
+		Location:      n.Location,
+	}
+}
+
+func convertColumnRef(n *nodes.ColumnRef) *pg.ColumnRef {
+	if n == nil {
+		return nil
+	}
+	return &pg.ColumnRef{
+		Fields:   convertList(n.Fields),
+		Location: n.Location,
+	}
+}
+
+func convertCommentStmt(n *nodes.CommentStmt) *pg.CommentStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CommentStmt{
+		Objtype: pg.ObjectType(n.Objtype),
+		Object:  convertNode(n.Object),
+		Comment: n.Comment,
+	}
+}
+
+func convertCommonTableExpr(n *nodes.CommonTableExpr) *pg.CommonTableExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.CommonTableExpr{
+		Ctename:          n.Ctename,
+		Aliascolnames:    convertList(n.Aliascolnames),
+		Ctequery:         convertNode(n.Ctequery),
+		Location:         n.Location,
+		Cterecursive:     n.Cterecursive,
+		Cterefcount:      n.Cterefcount,
+		Ctecolnames:      convertList(n.Ctecolnames),
+		Ctecoltypes:      convertList(n.Ctecoltypes),
+		Ctecoltypmods:    convertList(n.Ctecoltypmods),
+		Ctecolcollations: convertList(n.Ctecolcollations),
+	}
+}
+
+func convertCompositeTypeStmt(n *nodes.CompositeTypeStmt) *pg.CompositeTypeStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CompositeTypeStmt{
+		Typevar:    convertRangeVar(n.Typevar),
+		Coldeflist: convertList(n.Coldeflist),
+	}
+}
+
+func convertConst(n *nodes.Const) *pg.Const {
+	if n == nil {
+		return nil
+	}
+	return &pg.Const{
+		Xpr:         convertNode(n.Xpr),
+		Consttype:   pg.Oid(n.Consttype),
+		Consttypmod: n.Consttypmod,
+		Constcollid: pg.Oid(n.Constcollid),
+		Constlen:    n.Constlen,
+		Constvalue:  pg.Datum(n.Constvalue),
+		Constisnull: n.Constisnull,
+		Constbyval:  n.Constbyval,
+		Location:    n.Location,
+	}
+}
+
+func convertConstraint(n *nodes.Constraint) *pg.Constraint {
+	if n == nil {
+		return nil
+	}
+	return &pg.Constraint{
+		Contype:        pg.ConstrType(n.Contype),
+		Conname:        n.Conname,
+		Deferrable:     n.Deferrable,
+		Initdeferred:   n.Initdeferred,
+		Location:       n.Location,
+		IsNoInherit:    n.IsNoInherit,
+		RawExpr:        convertNode(n.RawExpr),
+		CookedExpr:     n.CookedExpr,
+		GeneratedWhen:  n.GeneratedWhen,
+		Keys:           convertList(n.Keys),
+		Exclusions:     convertList(n.Exclusions),
+		Options:        convertList(n.Options),
+		Indexname:      n.Indexname,
+		Indexspace:     n.Indexspace,
+		AccessMethod:   n.AccessMethod,
+		WhereClause:    convertNode(n.WhereClause),
+		Pktable:        convertRangeVar(n.Pktable),
+		FkAttrs:        convertList(n.FkAttrs),
+		PkAttrs:        convertList(n.PkAttrs),
+		FkMatchtype:    n.FkMatchtype,
+		FkUpdAction:    n.FkUpdAction,
+		FkDelAction:    n.FkDelAction,
+		OldConpfeqop:   convertList(n.OldConpfeqop),
+		OldPktableOid:  pg.Oid(n.OldPktableOid),
+		SkipValidation: n.SkipValidation,
+		InitiallyValid: n.InitiallyValid,
+	}
+}
+
+func convertConstraintsSetStmt(n *nodes.ConstraintsSetStmt) *pg.ConstraintsSetStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.ConstraintsSetStmt{
+		Constraints: convertList(n.Constraints),
+		Deferred:    n.Deferred,
+	}
+}
+
+func convertConvertRowtypeExpr(n *nodes.ConvertRowtypeExpr) *pg.ConvertRowtypeExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.ConvertRowtypeExpr{
+		Xpr:           convertNode(n.Xpr),
+		Arg:           convertNode(n.Arg),
+		Resulttype:    pg.Oid(n.Resulttype),
+		Convertformat: pg.CoercionForm(n.Convertformat),
+		Location:      n.Location,
+	}
+}
+
+func convertCopyStmt(n *nodes.CopyStmt) *pg.CopyStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CopyStmt{
+		Relation:  convertRangeVar(n.Relation),
+		Query:     convertNode(n.Query),
+		Attlist:   convertList(n.Attlist),
+		IsFrom:    n.IsFrom,
+		IsProgram: n.IsProgram,
+		Filename:  n.Filename,
+		Options:   convertList(n.Options),
+	}
+}
+
+func convertCreateAmStmt(n *nodes.CreateAmStmt) *pg.CreateAmStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateAmStmt{
+		Amname:      n.Amname,
+		HandlerName: convertList(n.HandlerName),
+		Amtype:      n.Amtype,
+	}
+}
+
+func convertCreateCastStmt(n *nodes.CreateCastStmt) *pg.CreateCastStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateCastStmt{
+		Sourcetype: convertTypeName(n.Sourcetype),
+		Targettype: convertTypeName(n.Targettype),
+		Func:       convertObjectWithArgs(n.Func),
+		Context:    pg.CoercionContext(n.Context),
+		Inout:      n.Inout,
+	}
+}
+
+func convertCreateConversionStmt(n *nodes.CreateConversionStmt) *pg.CreateConversionStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateConversionStmt{
+		ConversionName:  convertList(n.ConversionName),
+		ForEncodingName: n.ForEncodingName,
+		ToEncodingName:  n.ToEncodingName,
+		FuncName:        convertList(n.FuncName),
+		Def:             n.Def,
+	}
+}
+
+func convertCreateDomainStmt(n *nodes.CreateDomainStmt) *pg.CreateDomainStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateDomainStmt{
+		Domainname:  convertList(n.Domainname),
+		TypeName:    convertTypeName(n.TypeName),
+		CollClause:  convertCollateClause(n.CollClause),
+		Constraints: convertList(n.Constraints),
+	}
+}
+
+func convertCreateEnumStmt(n *nodes.CreateEnumStmt) *pg.CreateEnumStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateEnumStmt{
+		TypeName: convertList(n.TypeName),
+		Vals:     convertList(n.Vals),
+	}
+}
+
+func convertCreateEventTrigStmt(n *nodes.CreateEventTrigStmt) *pg.CreateEventTrigStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateEventTrigStmt{
+		Trigname:   n.Trigname,
+		Eventname:  n.Eventname,
+		Whenclause: convertList(n.Whenclause),
+		Funcname:   convertList(n.Funcname),
+	}
+}
+
+func convertCreateExtensionStmt(n *nodes.CreateExtensionStmt) *pg.CreateExtensionStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateExtensionStmt{
+		Extname:     n.Extname,
+		IfNotExists: n.IfNotExists,
+		Options:     convertList(n.Options),
+	}
+}
+
+func convertCreateFdwStmt(n *nodes.CreateFdwStmt) *pg.CreateFdwStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateFdwStmt{
+		Fdwname:     n.Fdwname,
+		FuncOptions: convertList(n.FuncOptions),
+		Options:     convertList(n.Options),
+	}
+}
+
+func convertCreateForeignServerStmt(n *nodes.CreateForeignServerStmt) *pg.CreateForeignServerStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateForeignServerStmt{
+		Servername:  n.Servername,
+		Servertype:  n.Servertype,
+		Version:     n.Version,
+		Fdwname:     n.Fdwname,
+		IfNotExists: n.IfNotExists,
+		Options:     convertList(n.Options),
+	}
+}
+
+func convertCreateForeignTableStmt(n *nodes.CreateForeignTableStmt) *pg.CreateForeignTableStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateForeignTableStmt{
+		Base:       convertCreateStmt(&n.Base),
+		Servername: n.Servername,
+		Options:    convertList(n.Options),
+	}
+}
+
+func convertCreateFunctionStmt(n *nodes.CreateFunctionStmt) *pg.CreateFunctionStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateFunctionStmt{
+		Replace:    n.Replace,
+		Funcname:   convertList(n.Funcname),
+		Parameters: convertList(n.Parameters),
+		ReturnType: convertTypeName(n.ReturnType),
+		Options:    convertList(n.Options),
+		WithClause: convertList(n.WithClause),
+	}
+}
+
+func convertCreateOpClassItem(n *nodes.CreateOpClassItem) *pg.CreateOpClassItem {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateOpClassItem{
+		Itemtype:    n.Itemtype,
+		Name:        convertObjectWithArgs(n.Name),
+		Number:      n.Number,
+		OrderFamily: convertList(n.OrderFamily),
+		ClassArgs:   convertList(n.ClassArgs),
+		Storedtype:  convertTypeName(n.Storedtype),
+	}
+}
+
+func convertCreateOpClassStmt(n *nodes.CreateOpClassStmt) *pg.CreateOpClassStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateOpClassStmt{
+		Opclassname:  convertList(n.Opclassname),
+		Opfamilyname: convertList(n.Opfamilyname),
+		Amname:       n.Amname,
+		Datatype:     convertTypeName(n.Datatype),
+		Items:        convertList(n.Items),
+		IsDefault:    n.IsDefault,
+	}
+}
+
+func convertCreateOpFamilyStmt(n *nodes.CreateOpFamilyStmt) *pg.CreateOpFamilyStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateOpFamilyStmt{
+		Opfamilyname: convertList(n.Opfamilyname),
+		Amname:       n.Amname,
+	}
+}
+
+func convertCreatePLangStmt(n *nodes.CreatePLangStmt) *pg.CreatePLangStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreatePLangStmt{
+		Replace:     n.Replace,
+		Plname:      n.Plname,
+		Plhandler:   convertList(n.Plhandler),
+		Plinline:    convertList(n.Plinline),
+		Plvalidator: convertList(n.Plvalidator),
+		Pltrusted:   n.Pltrusted,
+	}
+}
+
+func convertCreatePolicyStmt(n *nodes.CreatePolicyStmt) *pg.CreatePolicyStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreatePolicyStmt{
+		PolicyName: n.PolicyName,
+		Table:      convertRangeVar(n.Table),
+		CmdName:    n.CmdName,
+		Permissive: n.Permissive,
+		Roles:      convertList(n.Roles),
+		Qual:       convertNode(n.Qual),
+		WithCheck:  convertNode(n.WithCheck),
+	}
+}
+
+func convertCreatePublicationStmt(n *nodes.CreatePublicationStmt) *pg.CreatePublicationStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreatePublicationStmt{
+		Pubname:      n.Pubname,
+		Options:      convertList(n.Options),
+		Tables:       convertList(n.Tables),
+		ForAllTables: n.ForAllTables,
+	}
+}
+
+func convertCreateRangeStmt(n *nodes.CreateRangeStmt) *pg.CreateRangeStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateRangeStmt{
+		TypeName: convertList(n.TypeName),
+		Params:   convertList(n.Params),
+	}
+}
+
+func convertCreateRoleStmt(n *nodes.CreateRoleStmt) *pg.CreateRoleStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateRoleStmt{
+		StmtType: pg.RoleStmtType(n.StmtType),
+		Role:     n.Role,
+		Options:  convertList(n.Options),
+	}
+}
+
+func convertCreateSchemaStmt(n *nodes.CreateSchemaStmt) *pg.CreateSchemaStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateSchemaStmt{
+		Schemaname:  n.Schemaname,
+		Authrole:    convertRoleSpec(n.Authrole),
+		SchemaElts:  convertList(n.SchemaElts),
+		IfNotExists: n.IfNotExists,
+	}
+}
+
+func convertCreateSeqStmt(n *nodes.CreateSeqStmt) *pg.CreateSeqStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateSeqStmt{
+		Sequence:    convertRangeVar(n.Sequence),
+		Options:     convertList(n.Options),
+		OwnerId:     pg.Oid(n.OwnerId),
+		ForIdentity: n.ForIdentity,
+		IfNotExists: n.IfNotExists,
+	}
+}
+
+func convertCreateStatsStmt(n *nodes.CreateStatsStmt) *pg.CreateStatsStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateStatsStmt{
+		Defnames:    convertList(n.Defnames),
+		StatTypes:   convertList(n.StatTypes),
+		Exprs:       convertList(n.Exprs),
+		Relations:   convertList(n.Relations),
+		IfNotExists: n.IfNotExists,
+	}
+}
+
+func convertCreateStmt(n *nodes.CreateStmt) *pg.CreateStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateStmt{
+		Relation:       convertRangeVar(n.Relation),
+		TableElts:      convertList(n.TableElts),
+		InhRelations:   convertList(n.InhRelations),
+		Partbound:      convertPartitionBoundSpec(n.Partbound),
+		Partspec:       convertPartitionSpec(n.Partspec),
+		OfTypename:     convertTypeName(n.OfTypename),
+		Constraints:    convertList(n.Constraints),
+		Options:        convertList(n.Options),
+		Oncommit:       pg.OnCommitAction(n.Oncommit),
+		Tablespacename: n.Tablespacename,
+		IfNotExists:    n.IfNotExists,
+	}
+}
+
+func convertCreateSubscriptionStmt(n *nodes.CreateSubscriptionStmt) *pg.CreateSubscriptionStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateSubscriptionStmt{
+		Subname:     n.Subname,
+		Conninfo:    n.Conninfo,
+		Publication: convertList(n.Publication),
+		Options:     convertList(n.Options),
+	}
+}
+
+func convertCreateTableAsStmt(n *nodes.CreateTableAsStmt) *pg.CreateTableAsStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateTableAsStmt{
+		Query:        convertNode(n.Query),
+		Into:         convertIntoClause(n.Into),
+		Relkind:      pg.ObjectType(n.Relkind),
+		IsSelectInto: n.IsSelectInto,
+		IfNotExists:  n.IfNotExists,
+	}
+}
+
+func convertCreateTableSpaceStmt(n *nodes.CreateTableSpaceStmt) *pg.CreateTableSpaceStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateTableSpaceStmt{
+		Tablespacename: n.Tablespacename,
+		Owner:          convertRoleSpec(n.Owner),
+		Location:       n.Location,
+		Options:        convertList(n.Options),
+	}
+}
+
+func convertCreateTransformStmt(n *nodes.CreateTransformStmt) *pg.CreateTransformStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateTransformStmt{
+		Replace:  n.Replace,
+		TypeName: convertTypeName(n.TypeName),
+		Lang:     n.Lang,
+		Fromsql:  convertObjectWithArgs(n.Fromsql),
+		Tosql:    convertObjectWithArgs(n.Tosql),
+	}
+}
+
+func convertCreateTrigStmt(n *nodes.CreateTrigStmt) *pg.CreateTrigStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateTrigStmt{
+		Trigname:       n.Trigname,
+		Relation:       convertRangeVar(n.Relation),
+		Funcname:       convertList(n.Funcname),
+		Args:           convertList(n.Args),
+		Row:            n.Row,
+		Timing:         n.Timing,
+		Events:         n.Events,
+		Columns:        convertList(n.Columns),
+		WhenClause:     convertNode(n.WhenClause),
+		Isconstraint:   n.Isconstraint,
+		TransitionRels: convertList(n.TransitionRels),
+		Deferrable:     n.Deferrable,
+		Initdeferred:   n.Initdeferred,
+		Constrrel:      convertRangeVar(n.Constrrel),
+	}
+}
+
+func convertCreateUserMappingStmt(n *nodes.CreateUserMappingStmt) *pg.CreateUserMappingStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreateUserMappingStmt{
+		User:        convertRoleSpec(n.User),
+		Servername:  n.Servername,
+		IfNotExists: n.IfNotExists,
+		Options:     convertList(n.Options),
+	}
+}
+
+func convertCreatedbStmt(n *nodes.CreatedbStmt) *pg.CreatedbStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.CreatedbStmt{
+		Dbname:  n.Dbname,
+		Options: convertList(n.Options),
+	}
+}
+
+func convertCurrentOfExpr(n *nodes.CurrentOfExpr) *pg.CurrentOfExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.CurrentOfExpr{
+		Xpr:         convertNode(n.Xpr),
+		Cvarno:      pg.Index(n.Cvarno),
+		CursorName:  n.CursorName,
+		CursorParam: n.CursorParam,
+	}
+}
+
+func convertDeallocateStmt(n *nodes.DeallocateStmt) *pg.DeallocateStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.DeallocateStmt{
+		Name: n.Name,
+	}
+}
+
+func convertDeclareCursorStmt(n *nodes.DeclareCursorStmt) *pg.DeclareCursorStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.DeclareCursorStmt{
+		Portalname: n.Portalname,
+		Options:    n.Options,
+		Query:      convertNode(n.Query),
+	}
+}
+
+func convertDefElem(n *nodes.DefElem) *pg.DefElem {
+	if n == nil {
+		return nil
+	}
+	return &pg.DefElem{
+		Defnamespace: n.Defnamespace,
+		Defname:      n.Defname,
+		Arg:          convertNode(n.Arg),
+		Defaction:    pg.DefElemAction(n.Defaction),
+		Location:     n.Location,
+	}
+}
+
+func convertDefineStmt(n *nodes.DefineStmt) *pg.DefineStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.DefineStmt{
+		Kind:        pg.ObjectType(n.Kind),
+		Oldstyle:    n.Oldstyle,
+		Defnames:    convertList(n.Defnames),
+		Args:        convertList(n.Args),
+		Definition:  convertList(n.Definition),
+		IfNotExists: n.IfNotExists,
+	}
+}
+
+func convertDeleteStmt(n *nodes.DeleteStmt) *pg.DeleteStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.DeleteStmt{
+		Relation:      convertRangeVar(n.Relation),
+		UsingClause:   convertList(n.UsingClause),
+		WhereClause:   convertNode(n.WhereClause),
+		ReturningList: convertList(n.ReturningList),
+		WithClause:    convertWithClause(n.WithClause),
+	}
+}
+
+func convertDiscardStmt(n *nodes.DiscardStmt) *pg.DiscardStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.DiscardStmt{
+		Target: pg.DiscardMode(n.Target),
+	}
+}
+
+func convertDoStmt(n *nodes.DoStmt) *pg.DoStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.DoStmt{
+		Args: convertList(n.Args),
+	}
+}
+
+func convertDropOwnedStmt(n *nodes.DropOwnedStmt) *pg.DropOwnedStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.DropOwnedStmt{
+		Roles:    convertList(n.Roles),
+		Behavior: pg.DropBehavior(n.Behavior),
+	}
+}
+
+func convertDropRoleStmt(n *nodes.DropRoleStmt) *pg.DropRoleStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.DropRoleStmt{
+		Roles:     convertList(n.Roles),
+		MissingOk: n.MissingOk,
+	}
+}
+
+func convertDropStmt(n *nodes.DropStmt) *pg.DropStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.DropStmt{
+		Objects:    convertList(n.Objects),
+		RemoveType: pg.ObjectType(n.RemoveType),
+		Behavior:   pg.DropBehavior(n.Behavior),
+		MissingOk:  n.MissingOk,
+		Concurrent: n.Concurrent,
+	}
+}
+
+func convertDropSubscriptionStmt(n *nodes.DropSubscriptionStmt) *pg.DropSubscriptionStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.DropSubscriptionStmt{
+		Subname:   n.Subname,
+		MissingOk: n.MissingOk,
+		Behavior:  pg.DropBehavior(n.Behavior),
+	}
+}
+
+func convertDropTableSpaceStmt(n *nodes.DropTableSpaceStmt) *pg.DropTableSpaceStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.DropTableSpaceStmt{
+		Tablespacename: n.Tablespacename,
+		MissingOk:      n.MissingOk,
+	}
+}
+
+func convertDropUserMappingStmt(n *nodes.DropUserMappingStmt) *pg.DropUserMappingStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.DropUserMappingStmt{
+		User:       convertRoleSpec(n.User),
+		Servername: n.Servername,
+		MissingOk:  n.MissingOk,
+	}
+}
+
+func convertDropdbStmt(n *nodes.DropdbStmt) *pg.DropdbStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.DropdbStmt{
+		Dbname:    n.Dbname,
+		MissingOk: n.MissingOk,
+	}
+}
+
+func convertExecuteStmt(n *nodes.ExecuteStmt) *pg.ExecuteStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.ExecuteStmt{
+		Name:   n.Name,
+		Params: convertList(n.Params),
+	}
+}
+
+func convertExplainStmt(n *nodes.ExplainStmt) *pg.ExplainStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.ExplainStmt{
+		Query:   convertNode(n.Query),
+		Options: convertList(n.Options),
+	}
+}
+
+func convertExpr(n *nodes.Expr) *pg.Expr {
+	if n == nil {
+		return nil
+	}
+	return &pg.Expr{}
+}
+
+func convertFetchStmt(n *nodes.FetchStmt) *pg.FetchStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.FetchStmt{
+		Direction:  pg.FetchDirection(n.Direction),
+		HowMany:    n.HowMany,
+		Portalname: n.Portalname,
+		Ismove:     n.Ismove,
+	}
+}
+
+func convertFieldSelect(n *nodes.FieldSelect) *pg.FieldSelect {
+	if n == nil {
+		return nil
+	}
+	return &pg.FieldSelect{
+		Xpr:          convertNode(n.Xpr),
+		Arg:          convertNode(n.Arg),
+		Fieldnum:     pg.AttrNumber(n.Fieldnum),
+		Resulttype:   pg.Oid(n.Resulttype),
+		Resulttypmod: n.Resulttypmod,
+		Resultcollid: pg.Oid(n.Resultcollid),
+	}
+}
+
+func convertFieldStore(n *nodes.FieldStore) *pg.FieldStore {
+	if n == nil {
+		return nil
+	}
+	return &pg.FieldStore{
+		Xpr:        convertNode(n.Xpr),
+		Arg:        convertNode(n.Arg),
+		Newvals:    convertList(n.Newvals),
+		Fieldnums:  convertList(n.Fieldnums),
+		Resulttype: pg.Oid(n.Resulttype),
+	}
+}
+
+func convertFloat(n *nodes.Float) *pg.Float {
+	if n == nil {
+		return nil
+	}
+	return &pg.Float{
+		Str: n.Str,
+	}
+}
+
+func convertFromExpr(n *nodes.FromExpr) *pg.FromExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.FromExpr{
+		Fromlist: convertList(n.Fromlist),
+		Quals:    convertNode(n.Quals),
+	}
+}
+
+func convertFuncCall(n *nodes.FuncCall) *pg.FuncCall {
+	if n == nil {
+		return nil
+	}
+	return &pg.FuncCall{
+		Funcname:       convertList(n.Funcname),
+		Args:           convertList(n.Args),
+		AggOrder:       convertList(n.AggOrder),
+		AggFilter:      convertNode(n.AggFilter),
+		AggWithinGroup: n.AggWithinGroup,
+		AggStar:        n.AggStar,
+		AggDistinct:    n.AggDistinct,
+		FuncVariadic:   n.FuncVariadic,
+		Over:           convertWindowDef(n.Over),
+		Location:       n.Location,
+	}
+}
+
+func convertFuncExpr(n *nodes.FuncExpr) *pg.FuncExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.FuncExpr{
+		Xpr:            convertNode(n.Xpr),
+		Funcid:         pg.Oid(n.Funcid),
+		Funcresulttype: pg.Oid(n.Funcresulttype),
+		Funcretset:     n.Funcretset,
+		Funcvariadic:   n.Funcvariadic,
+		Funcformat:     pg.CoercionForm(n.Funcformat),
+		Funccollid:     pg.Oid(n.Funccollid),
+		Inputcollid:    pg.Oid(n.Inputcollid),
+		Args:           convertList(n.Args),
+		Location:       n.Location,
+	}
+}
+
+func convertFunctionParameter(n *nodes.FunctionParameter) *pg.FunctionParameter {
+	if n == nil {
+		return nil
+	}
+	return &pg.FunctionParameter{
+		Name:    n.Name,
+		ArgType: convertTypeName(n.ArgType),
+		Mode:    pg.FunctionParameterMode(n.Mode),
+		Defexpr: convertNode(n.Defexpr),
+	}
+}
+
+func convertGrantRoleStmt(n *nodes.GrantRoleStmt) *pg.GrantRoleStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.GrantRoleStmt{
+		GrantedRoles: convertList(n.GrantedRoles),
+		GranteeRoles: convertList(n.GranteeRoles),
+		IsGrant:      n.IsGrant,
+		AdminOpt:     n.AdminOpt,
+		Grantor:      convertRoleSpec(n.Grantor),
+		Behavior:     pg.DropBehavior(n.Behavior),
+	}
+}
+
+func convertGrantStmt(n *nodes.GrantStmt) *pg.GrantStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.GrantStmt{
+		IsGrant:     n.IsGrant,
+		Targtype:    pg.GrantTargetType(n.Targtype),
+		Objtype:     pg.GrantObjectType(n.Objtype),
+		Objects:     convertList(n.Objects),
+		Privileges:  convertList(n.Privileges),
+		Grantees:    convertList(n.Grantees),
+		GrantOption: n.GrantOption,
+		Behavior:    pg.DropBehavior(n.Behavior),
+	}
+}
+
+func convertGroupingFunc(n *nodes.GroupingFunc) *pg.GroupingFunc {
+	if n == nil {
+		return nil
+	}
+	return &pg.GroupingFunc{
+		Xpr:         convertNode(n.Xpr),
+		Args:        convertList(n.Args),
+		Refs:        convertList(n.Refs),
+		Cols:        convertList(n.Cols),
+		Agglevelsup: pg.Index(n.Agglevelsup),
+		Location:    n.Location,
+	}
+}
+
+func convertGroupingSet(n *nodes.GroupingSet) *pg.GroupingSet {
+	if n == nil {
+		return nil
+	}
+	return &pg.GroupingSet{
+		Kind:     pg.GroupingSetKind(n.Kind),
+		Content:  convertList(n.Content),
+		Location: n.Location,
+	}
+}
+
+func convertImportForeignSchemaStmt(n *nodes.ImportForeignSchemaStmt) *pg.ImportForeignSchemaStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.ImportForeignSchemaStmt{
+		ServerName:   n.ServerName,
+		RemoteSchema: n.RemoteSchema,
+		LocalSchema:  n.LocalSchema,
+		ListType:     pg.ImportForeignSchemaType(n.ListType),
+		TableList:    convertList(n.TableList),
+		Options:      convertList(n.Options),
+	}
+}
+
+func convertIndexElem(n *nodes.IndexElem) *pg.IndexElem {
+	if n == nil {
+		return nil
+	}
+	return &pg.IndexElem{
+		Name:          n.Name,
+		Expr:          convertNode(n.Expr),
+		Indexcolname:  n.Indexcolname,
+		Collation:     convertList(n.Collation),
+		Opclass:       convertList(n.Opclass),
+		Ordering:      pg.SortByDir(n.Ordering),
+		NullsOrdering: pg.SortByNulls(n.NullsOrdering),
+	}
+}
+
+func convertIndexStmt(n *nodes.IndexStmt) *pg.IndexStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.IndexStmt{
+		Idxname:        n.Idxname,
+		Relation:       convertRangeVar(n.Relation),
+		AccessMethod:   n.AccessMethod,
+		TableSpace:     n.TableSpace,
+		IndexParams:    convertList(n.IndexParams),
+		Options:        convertList(n.Options),
+		WhereClause:    convertNode(n.WhereClause),
+		ExcludeOpNames: convertList(n.ExcludeOpNames),
+		Idxcomment:     n.Idxcomment,
+		IndexOid:       pg.Oid(n.IndexOid),
+		OldNode:        pg.Oid(n.OldNode),
+		Unique:         n.Unique,
+		Primary:        n.Primary,
+		Isconstraint:   n.Isconstraint,
+		Deferrable:     n.Deferrable,
+		Initdeferred:   n.Initdeferred,
+		Transformed:    n.Transformed,
+		Concurrent:     n.Concurrent,
+		IfNotExists:    n.IfNotExists,
+	}
+}
+
+func convertInferClause(n *nodes.InferClause) *pg.InferClause {
+	if n == nil {
+		return nil
+	}
+	return &pg.InferClause{
+		IndexElems:  convertList(n.IndexElems),
+		WhereClause: convertNode(n.WhereClause),
+		Conname:     n.Conname,
+		Location:    n.Location,
+	}
+}
+
+func convertInferenceElem(n *nodes.InferenceElem) *pg.InferenceElem {
+	if n == nil {
+		return nil
+	}
+	return &pg.InferenceElem{
+		Xpr:          convertNode(n.Xpr),
+		Expr:         convertNode(n.Expr),
+		Infercollid:  pg.Oid(n.Infercollid),
+		Inferopclass: pg.Oid(n.Inferopclass),
+	}
+}
+
+func convertInlineCodeBlock(n *nodes.InlineCodeBlock) *pg.InlineCodeBlock {
+	if n == nil {
+		return nil
+	}
+	return &pg.InlineCodeBlock{
+		SourceText:    n.SourceText,
+		LangOid:       pg.Oid(n.LangOid),
+		LangIsTrusted: n.LangIsTrusted,
+	}
+}
+
+func convertInsertStmt(n *nodes.InsertStmt) *pg.InsertStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.InsertStmt{
+		Relation:         convertRangeVar(n.Relation),
+		Cols:             convertList(n.Cols),
+		SelectStmt:       convertNode(n.SelectStmt),
+		OnConflictClause: convertOnConflictClause(n.OnConflictClause),
+		ReturningList:    convertList(n.ReturningList),
+		WithClause:       convertWithClause(n.WithClause),
+		Override:         pg.OverridingKind(n.Override),
+	}
+}
+
+func convertInteger(n *nodes.Integer) *pg.Integer {
+	if n == nil {
+		return nil
+	}
+	return &pg.Integer{
+		Ival: n.Ival,
+	}
+}
+
+func convertIntoClause(n *nodes.IntoClause) *pg.IntoClause {
+	if n == nil {
+		return nil
+	}
+	return &pg.IntoClause{
+		Rel:            convertRangeVar(n.Rel),
+		ColNames:       convertList(n.ColNames),
+		Options:        convertList(n.Options),
+		OnCommit:       pg.OnCommitAction(n.OnCommit),
+		TableSpaceName: n.TableSpaceName,
+		ViewQuery:      convertNode(n.ViewQuery),
+		SkipData:       n.SkipData,
+	}
+}
+
+func convertJoinExpr(n *nodes.JoinExpr) *pg.JoinExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.JoinExpr{
+		Jointype:    pg.JoinType(n.Jointype),
+		IsNatural:   n.IsNatural,
+		Larg:        convertNode(n.Larg),
+		Rarg:        convertNode(n.Rarg),
+		UsingClause: convertList(n.UsingClause),
+		Quals:       convertNode(n.Quals),
+		Alias:       convertAlias(n.Alias),
+		Rtindex:     n.Rtindex,
+	}
+}
+
+func convertListenStmt(n *nodes.ListenStmt) *pg.ListenStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.ListenStmt{
+		Conditionname: n.Conditionname,
+	}
+}
+
+func convertLoadStmt(n *nodes.LoadStmt) *pg.LoadStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.LoadStmt{
+		Filename: n.Filename,
+	}
+}
+
+func convertLockStmt(n *nodes.LockStmt) *pg.LockStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.LockStmt{
+		Relations: convertList(n.Relations),
+		Mode:      n.Mode,
+		Nowait:    n.Nowait,
+	}
+}
+
+func convertLockingClause(n *nodes.LockingClause) *pg.LockingClause {
+	if n == nil {
+		return nil
+	}
+	return &pg.LockingClause{
+		LockedRels: convertList(n.LockedRels),
+		Strength:   pg.LockClauseStrength(n.Strength),
+		WaitPolicy: pg.LockWaitPolicy(n.WaitPolicy),
+	}
+}
+
+func convertMinMaxExpr(n *nodes.MinMaxExpr) *pg.MinMaxExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.MinMaxExpr{
+		Xpr:          convertNode(n.Xpr),
+		Minmaxtype:   pg.Oid(n.Minmaxtype),
+		Minmaxcollid: pg.Oid(n.Minmaxcollid),
+		Inputcollid:  pg.Oid(n.Inputcollid),
+		Op:           pg.MinMaxOp(n.Op),
+		Args:         convertList(n.Args),
+		Location:     n.Location,
+	}
+}
+
+func convertMultiAssignRef(n *nodes.MultiAssignRef) *pg.MultiAssignRef {
+	if n == nil {
+		return nil
+	}
+	return &pg.MultiAssignRef{
+		Source:   convertNode(n.Source),
+		Colno:    n.Colno,
+		Ncolumns: n.Ncolumns,
+	}
+}
+
+func convertNamedArgExpr(n *nodes.NamedArgExpr) *pg.NamedArgExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.NamedArgExpr{
+		Xpr:       convertNode(n.Xpr),
+		Arg:       convertNode(n.Arg),
+		Name:      n.Name,
+		Argnumber: n.Argnumber,
+		Location:  n.Location,
+	}
+}
+
+func convertNextValueExpr(n *nodes.NextValueExpr) *pg.NextValueExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.NextValueExpr{
+		Xpr:    convertNode(n.Xpr),
+		Seqid:  pg.Oid(n.Seqid),
+		TypeId: pg.Oid(n.TypeId),
+	}
+}
+
+func convertNotifyStmt(n *nodes.NotifyStmt) *pg.NotifyStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.NotifyStmt{
+		Conditionname: n.Conditionname,
+		Payload:       n.Payload,
+	}
+}
+
+func convertNull(n *nodes.Null) *pg.Null {
+	if n == nil {
+		return nil
+	}
+	return &pg.Null{}
+}
+
+func convertNullTest(n *nodes.NullTest) *pg.NullTest {
+	if n == nil {
+		return nil
+	}
+	return &pg.NullTest{
+		Xpr:          convertNode(n.Xpr),
+		Arg:          convertNode(n.Arg),
+		Nulltesttype: pg.NullTestType(n.Nulltesttype),
+		Argisrow:     n.Argisrow,
+		Location:     n.Location,
+	}
+}
+
+func convertObjectWithArgs(n *nodes.ObjectWithArgs) *pg.ObjectWithArgs {
+	if n == nil {
+		return nil
+	}
+	return &pg.ObjectWithArgs{
+		Objname:         convertList(n.Objname),
+		Objargs:         convertList(n.Objargs),
+		ArgsUnspecified: n.ArgsUnspecified,
+	}
+}
+
+func convertOnConflictClause(n *nodes.OnConflictClause) *pg.OnConflictClause {
+	if n == nil {
+		return nil
+	}
+	return &pg.OnConflictClause{
+		Action:      pg.OnConflictAction(n.Action),
+		Infer:       convertInferClause(n.Infer),
+		TargetList:  convertList(n.TargetList),
+		WhereClause: convertNode(n.WhereClause),
+		Location:    n.Location,
+	}
+}
+
+func convertOnConflictExpr(n *nodes.OnConflictExpr) *pg.OnConflictExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.OnConflictExpr{
+		Action:          pg.OnConflictAction(n.Action),
+		ArbiterElems:    convertList(n.ArbiterElems),
+		ArbiterWhere:    convertNode(n.ArbiterWhere),
+		Constraint:      pg.Oid(n.Constraint),
+		OnConflictSet:   convertList(n.OnConflictSet),
+		OnConflictWhere: convertNode(n.OnConflictWhere),
+		ExclRelIndex:    n.ExclRelIndex,
+		ExclRelTlist:    convertList(n.ExclRelTlist),
+	}
+}
+
+func convertOpExpr(n *nodes.OpExpr) *pg.OpExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.OpExpr{
+		Xpr:          convertNode(n.Xpr),
+		Opno:         pg.Oid(n.Opno),
+		Opfuncid:     pg.Oid(n.Opfuncid),
+		Opresulttype: pg.Oid(n.Opresulttype),
+		Opretset:     n.Opretset,
+		Opcollid:     pg.Oid(n.Opcollid),
+		Inputcollid:  pg.Oid(n.Inputcollid),
+		Args:         convertList(n.Args),
+		Location:     n.Location,
+	}
+}
+
+func convertParam(n *nodes.Param) *pg.Param {
+	if n == nil {
+		return nil
+	}
+	return &pg.Param{
+		Xpr:         convertNode(n.Xpr),
+		Paramkind:   pg.ParamKind(n.Paramkind),
+		Paramid:     n.Paramid,
+		Paramtype:   pg.Oid(n.Paramtype),
+		Paramtypmod: n.Paramtypmod,
+		Paramcollid: pg.Oid(n.Paramcollid),
+		Location:    n.Location,
+	}
+}
+
+func convertParamExecData(n *nodes.ParamExecData) *pg.ParamExecData {
+	if n == nil {
+		return nil
+	}
+	return &pg.ParamExecData{
+		ExecPlan: &ast.TODO{},
+		Value:    pg.Datum(n.Value),
+		Isnull:   n.Isnull,
+	}
+}
+
+func convertParamExternData(n *nodes.ParamExternData) *pg.ParamExternData {
+	if n == nil {
+		return nil
+	}
+	return &pg.ParamExternData{
+		Value:  pg.Datum(n.Value),
+		Isnull: n.Isnull,
+		Pflags: n.Pflags,
+		Ptype:  pg.Oid(n.Ptype),
+	}
+}
+
+func convertParamListInfoData(n *nodes.ParamListInfoData) *pg.ParamListInfoData {
+	if n == nil {
+		return nil
+	}
+	return &pg.ParamListInfoData{
+		ParamFetchArg:  &ast.TODO{},
+		ParserSetupArg: &ast.TODO{},
+		NumParams:      n.NumParams,
+		ParamMask:      n.ParamMask,
+	}
+}
+
+func convertParamRef(n *nodes.ParamRef) *pg.ParamRef {
+	if n == nil {
+		return nil
+	}
+	return &pg.ParamRef{
+		Number:   n.Number,
+		Location: n.Location,
+	}
+}
+
+func convertPartitionBoundSpec(n *nodes.PartitionBoundSpec) *pg.PartitionBoundSpec {
+	if n == nil {
+		return nil
+	}
+	return &pg.PartitionBoundSpec{
+		Strategy:    n.Strategy,
+		Listdatums:  convertList(n.Listdatums),
+		Lowerdatums: convertList(n.Lowerdatums),
+		Upperdatums: convertList(n.Upperdatums),
+		Location:    n.Location,
+	}
+}
+
+func convertPartitionCmd(n *nodes.PartitionCmd) *pg.PartitionCmd {
+	if n == nil {
+		return nil
+	}
+	return &pg.PartitionCmd{
+		Name:  convertRangeVar(n.Name),
+		Bound: convertPartitionBoundSpec(n.Bound),
+	}
+}
+
+func convertPartitionElem(n *nodes.PartitionElem) *pg.PartitionElem {
+	if n == nil {
+		return nil
+	}
+	return &pg.PartitionElem{
+		Name:      n.Name,
+		Expr:      convertNode(n.Expr),
+		Collation: convertList(n.Collation),
+		Opclass:   convertList(n.Opclass),
+		Location:  n.Location,
+	}
+}
+
+func convertPartitionRangeDatum(n *nodes.PartitionRangeDatum) *pg.PartitionRangeDatum {
+	if n == nil {
+		return nil
+	}
+	return &pg.PartitionRangeDatum{
+		Kind:     pg.PartitionRangeDatumKind(n.Kind),
+		Value:    convertNode(n.Value),
+		Location: n.Location,
+	}
+}
+
+func convertPartitionSpec(n *nodes.PartitionSpec) *pg.PartitionSpec {
+	if n == nil {
+		return nil
+	}
+	return &pg.PartitionSpec{
+		Strategy:   n.Strategy,
+		PartParams: convertList(n.PartParams),
+		Location:   n.Location,
+	}
+}
+
+func convertPrepareStmt(n *nodes.PrepareStmt) *pg.PrepareStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.PrepareStmt{
+		Name:     n.Name,
+		Argtypes: convertList(n.Argtypes),
+		Query:    convertNode(n.Query),
+	}
+}
+
+func convertQuery(n *nodes.Query) *pg.Query {
+	if n == nil {
+		return nil
+	}
+	return &pg.Query{
+		CommandType:      pg.CmdType(n.CommandType),
+		QuerySource:      pg.QuerySource(n.QuerySource),
+		QueryId:          n.QueryId,
+		CanSetTag:        n.CanSetTag,
+		UtilityStmt:      convertNode(n.UtilityStmt),
+		ResultRelation:   n.ResultRelation,
+		HasAggs:          n.HasAggs,
+		HasWindowFuncs:   n.HasWindowFuncs,
+		HasTargetSrfs:    n.HasTargetSrfs,
+		HasSubLinks:      n.HasSubLinks,
+		HasDistinctOn:    n.HasDistinctOn,
+		HasRecursive:     n.HasRecursive,
+		HasModifyingCte:  n.HasModifyingCte,
+		HasForUpdate:     n.HasForUpdate,
+		HasRowSecurity:   n.HasRowSecurity,
+		CteList:          convertList(n.CteList),
+		Rtable:           convertList(n.Rtable),
+		Jointree:         convertFromExpr(n.Jointree),
+		TargetList:       convertList(n.TargetList),
+		Override:         pg.OverridingKind(n.Override),
+		OnConflict:       convertOnConflictExpr(n.OnConflict),
+		ReturningList:    convertList(n.ReturningList),
+		GroupClause:      convertList(n.GroupClause),
+		GroupingSets:     convertList(n.GroupingSets),
+		HavingQual:       convertNode(n.HavingQual),
+		WindowClause:     convertList(n.WindowClause),
+		DistinctClause:   convertList(n.DistinctClause),
+		SortClause:       convertList(n.SortClause),
+		LimitOffset:      convertNode(n.LimitOffset),
+		LimitCount:       convertNode(n.LimitCount),
+		RowMarks:         convertList(n.RowMarks),
+		SetOperations:    convertNode(n.SetOperations),
+		ConstraintDeps:   convertList(n.ConstraintDeps),
+		WithCheckOptions: convertList(n.WithCheckOptions),
+		StmtLocation:     n.StmtLocation,
+		StmtLen:          n.StmtLen,
+	}
+}
+
+func convertRangeFunction(n *nodes.RangeFunction) *pg.RangeFunction {
+	if n == nil {
+		return nil
+	}
+	return &pg.RangeFunction{
+		Lateral:    n.Lateral,
+		Ordinality: n.Ordinality,
+		IsRowsfrom: n.IsRowsfrom,
+		Functions:  convertList(n.Functions),
+		Alias:      convertAlias(n.Alias),
+		Coldeflist: convertList(n.Coldeflist),
+	}
+}
+
+func convertRangeSubselect(n *nodes.RangeSubselect) *pg.RangeSubselect {
+	if n == nil {
+		return nil
+	}
+	return &pg.RangeSubselect{
+		Lateral:  n.Lateral,
+		Subquery: convertNode(n.Subquery),
+		Alias:    convertAlias(n.Alias),
+	}
+}
+
+func convertRangeTableFunc(n *nodes.RangeTableFunc) *pg.RangeTableFunc {
+	if n == nil {
+		return nil
+	}
+	return &pg.RangeTableFunc{
+		Lateral:    n.Lateral,
+		Docexpr:    convertNode(n.Docexpr),
+		Rowexpr:    convertNode(n.Rowexpr),
+		Namespaces: convertList(n.Namespaces),
+		Columns:    convertList(n.Columns),
+		Alias:      convertAlias(n.Alias),
+		Location:   n.Location,
+	}
+}
+
+func convertRangeTableFuncCol(n *nodes.RangeTableFuncCol) *pg.RangeTableFuncCol {
+	if n == nil {
+		return nil
+	}
+	return &pg.RangeTableFuncCol{
+		Colname:       n.Colname,
+		TypeName:      convertTypeName(n.TypeName),
+		ForOrdinality: n.ForOrdinality,
+		IsNotNull:     n.IsNotNull,
+		Colexpr:       convertNode(n.Colexpr),
+		Coldefexpr:    convertNode(n.Coldefexpr),
+		Location:      n.Location,
+	}
+}
+
+func convertRangeTableSample(n *nodes.RangeTableSample) *pg.RangeTableSample {
+	if n == nil {
+		return nil
+	}
+	return &pg.RangeTableSample{
+		Relation:   convertNode(n.Relation),
+		Method:     convertList(n.Method),
+		Args:       convertList(n.Args),
+		Repeatable: convertNode(n.Repeatable),
+		Location:   n.Location,
+	}
+}
+
+func convertRangeTblEntry(n *nodes.RangeTblEntry) *pg.RangeTblEntry {
+	if n == nil {
+		return nil
+	}
+	return &pg.RangeTblEntry{
+		Rtekind:         pg.RTEKind(n.Rtekind),
+		Relid:           pg.Oid(n.Relid),
+		Relkind:         n.Relkind,
+		Tablesample:     convertTableSampleClause(n.Tablesample),
+		Subquery:        convertQuery(n.Subquery),
+		SecurityBarrier: n.SecurityBarrier,
+		Jointype:        pg.JoinType(n.Jointype),
+		Joinaliasvars:   convertList(n.Joinaliasvars),
+		Functions:       convertList(n.Functions),
+		Funcordinality:  n.Funcordinality,
+		Tablefunc:       convertTableFunc(n.Tablefunc),
+		ValuesLists:     convertList(n.ValuesLists),
+		Ctename:         n.Ctename,
+		Ctelevelsup:     pg.Index(n.Ctelevelsup),
+		SelfReference:   n.SelfReference,
+		Coltypes:        convertList(n.Coltypes),
+		Coltypmods:      convertList(n.Coltypmods),
+		Colcollations:   convertList(n.Colcollations),
+		Enrname:         n.Enrname,
+		Enrtuples:       n.Enrtuples,
+		Alias:           convertAlias(n.Alias),
+		Eref:            convertAlias(n.Eref),
+		Lateral:         n.Lateral,
+		Inh:             n.Inh,
+		InFromCl:        n.InFromCl,
+		RequiredPerms:   pg.AclMode(n.RequiredPerms),
+		CheckAsUser:     pg.Oid(n.CheckAsUser),
+		SelectedCols:    n.SelectedCols,
+		InsertedCols:    n.InsertedCols,
+		UpdatedCols:     n.UpdatedCols,
+		SecurityQuals:   convertList(n.SecurityQuals),
+	}
+}
+
+func convertRangeTblFunction(n *nodes.RangeTblFunction) *pg.RangeTblFunction {
+	if n == nil {
+		return nil
+	}
+	return &pg.RangeTblFunction{
+		Funcexpr:          convertNode(n.Funcexpr),
+		Funccolcount:      n.Funccolcount,
+		Funccolnames:      convertList(n.Funccolnames),
+		Funccoltypes:      convertList(n.Funccoltypes),
+		Funccoltypmods:    convertList(n.Funccoltypmods),
+		Funccolcollations: convertList(n.Funccolcollations),
+		Funcparams:        n.Funcparams,
+	}
+}
+
+func convertRangeTblRef(n *nodes.RangeTblRef) *pg.RangeTblRef {
+	if n == nil {
+		return nil
+	}
+	return &pg.RangeTblRef{
+		Rtindex: n.Rtindex,
+	}
+}
+
+func convertRangeVar(n *nodes.RangeVar) *pg.RangeVar {
+	if n == nil {
+		return nil
+	}
+	return &pg.RangeVar{
+		Catalogname:    n.Catalogname,
+		Schemaname:     n.Schemaname,
+		Relname:        n.Relname,
+		Inh:            n.Inh,
+		Relpersistence: n.Relpersistence,
+		Alias:          convertAlias(n.Alias),
+		Location:       n.Location,
+	}
+}
+
+func convertRawStmt(n *nodes.RawStmt) *pg.RawStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.RawStmt{
+		Stmt:         convertNode(n.Stmt),
+		StmtLocation: n.StmtLocation,
+		StmtLen:      n.StmtLen,
+	}
+}
+
+func convertReassignOwnedStmt(n *nodes.ReassignOwnedStmt) *pg.ReassignOwnedStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.ReassignOwnedStmt{
+		Roles:   convertList(n.Roles),
+		Newrole: convertRoleSpec(n.Newrole),
+	}
+}
+
+func convertRefreshMatViewStmt(n *nodes.RefreshMatViewStmt) *pg.RefreshMatViewStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.RefreshMatViewStmt{
+		Concurrent: n.Concurrent,
+		SkipData:   n.SkipData,
+		Relation:   convertRangeVar(n.Relation),
+	}
+}
+
+func convertReindexStmt(n *nodes.ReindexStmt) *pg.ReindexStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.ReindexStmt{
+		Kind:     pg.ReindexObjectType(n.Kind),
+		Relation: convertRangeVar(n.Relation),
+		Name:     n.Name,
+		Options:  n.Options,
+	}
+}
+
+func convertRelabelType(n *nodes.RelabelType) *pg.RelabelType {
+	if n == nil {
+		return nil
+	}
+	return &pg.RelabelType{
+		Xpr:           convertNode(n.Xpr),
+		Arg:           convertNode(n.Arg),
+		Resulttype:    pg.Oid(n.Resulttype),
+		Resulttypmod:  n.Resulttypmod,
+		Resultcollid:  pg.Oid(n.Resultcollid),
+		Relabelformat: pg.CoercionForm(n.Relabelformat),
+		Location:      n.Location,
+	}
+}
+
+func convertRenameStmt(n *nodes.RenameStmt) *pg.RenameStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.RenameStmt{
+		RenameType:   pg.ObjectType(n.RenameType),
+		RelationType: pg.ObjectType(n.RelationType),
+		Relation:     convertRangeVar(n.Relation),
+		Object:       convertNode(n.Object),
+		Subname:      n.Subname,
+		Newname:      n.Newname,
+		Behavior:     pg.DropBehavior(n.Behavior),
+		MissingOk:    n.MissingOk,
+	}
+}
+
+func convertReplicaIdentityStmt(n *nodes.ReplicaIdentityStmt) *pg.ReplicaIdentityStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.ReplicaIdentityStmt{
+		IdentityType: n.IdentityType,
+		Name:         n.Name,
+	}
+}
+
+func convertResTarget(n *nodes.ResTarget) *pg.ResTarget {
+	if n == nil {
+		return nil
+	}
+	return &pg.ResTarget{
+		Name:        n.Name,
+		Indirection: convertList(n.Indirection),
+		Val:         convertNode(n.Val),
+		Location:    n.Location,
+	}
+}
+
+func convertRoleSpec(n *nodes.RoleSpec) *pg.RoleSpec {
+	if n == nil {
+		return nil
+	}
+	return &pg.RoleSpec{
+		Roletype: pg.RoleSpecType(n.Roletype),
+		Rolename: n.Rolename,
+		Location: n.Location,
+	}
+}
+
+func convertRowCompareExpr(n *nodes.RowCompareExpr) *pg.RowCompareExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.RowCompareExpr{
+		Xpr:          convertNode(n.Xpr),
+		Rctype:       pg.RowCompareType(n.Rctype),
+		Opnos:        convertList(n.Opnos),
+		Opfamilies:   convertList(n.Opfamilies),
+		Inputcollids: convertList(n.Inputcollids),
+		Largs:        convertList(n.Largs),
+		Rargs:        convertList(n.Rargs),
+	}
+}
+
+func convertRowExpr(n *nodes.RowExpr) *pg.RowExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.RowExpr{
+		Xpr:       convertNode(n.Xpr),
+		Args:      convertList(n.Args),
+		RowTypeid: pg.Oid(n.RowTypeid),
+		RowFormat: pg.CoercionForm(n.RowFormat),
+		Colnames:  convertList(n.Colnames),
+		Location:  n.Location,
+	}
+}
+
+func convertRowMarkClause(n *nodes.RowMarkClause) *pg.RowMarkClause {
+	if n == nil {
+		return nil
+	}
+	return &pg.RowMarkClause{
+		Rti:        pg.Index(n.Rti),
+		Strength:   pg.LockClauseStrength(n.Strength),
+		WaitPolicy: pg.LockWaitPolicy(n.WaitPolicy),
+		PushedDown: n.PushedDown,
+	}
+}
+
+func convertRuleStmt(n *nodes.RuleStmt) *pg.RuleStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.RuleStmt{
+		Relation:    convertRangeVar(n.Relation),
+		Rulename:    n.Rulename,
+		WhereClause: convertNode(n.WhereClause),
+		Event:       pg.CmdType(n.Event),
+		Instead:     n.Instead,
+		Actions:     convertList(n.Actions),
+		Replace:     n.Replace,
+	}
+}
+
+func convertSQLValueFunction(n *nodes.SQLValueFunction) *pg.SQLValueFunction {
+	if n == nil {
+		return nil
+	}
+	return &pg.SQLValueFunction{
+		Xpr:      convertNode(n.Xpr),
+		Op:       pg.SQLValueFunctionOp(n.Op),
+		Type:     pg.Oid(n.Type),
+		Typmod:   n.Typmod,
+		Location: n.Location,
+	}
+}
+
+func convertScalarArrayOpExpr(n *nodes.ScalarArrayOpExpr) *pg.ScalarArrayOpExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.ScalarArrayOpExpr{
+		Xpr:         convertNode(n.Xpr),
+		Opno:        pg.Oid(n.Opno),
+		Opfuncid:    pg.Oid(n.Opfuncid),
+		UseOr:       n.UseOr,
+		Inputcollid: pg.Oid(n.Inputcollid),
+		Args:        convertList(n.Args),
+		Location:    n.Location,
+	}
+}
+
+func convertSecLabelStmt(n *nodes.SecLabelStmt) *pg.SecLabelStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.SecLabelStmt{
+		Objtype:  pg.ObjectType(n.Objtype),
+		Object:   convertNode(n.Object),
+		Provider: n.Provider,
+		Label:    n.Label,
+	}
+}
+
+func convertSelectStmt(n *nodes.SelectStmt) *pg.SelectStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.SelectStmt{
+		DistinctClause: convertList(n.DistinctClause),
+		IntoClause:     convertIntoClause(n.IntoClause),
+		TargetList:     convertList(n.TargetList),
+		FromClause:     convertList(n.FromClause),
+		WhereClause:    convertNode(n.WhereClause),
+		GroupClause:    convertList(n.GroupClause),
+		HavingClause:   convertNode(n.HavingClause),
+		WindowClause:   convertList(n.WindowClause),
+		ValuesLists:    convertValuesList(n.ValuesLists),
+		SortClause:     convertList(n.SortClause),
+		LimitOffset:    convertNode(n.LimitOffset),
+		LimitCount:     convertNode(n.LimitCount),
+		LockingClause:  convertList(n.LockingClause),
+		WithClause:     convertWithClause(n.WithClause),
+		Op:             pg.SetOperation(n.Op),
+		All:            n.All,
+		Larg:           convertSelectStmt(n.Larg),
+		Rarg:           convertSelectStmt(n.Rarg),
+	}
+}
+
+func convertSetOperationStmt(n *nodes.SetOperationStmt) *pg.SetOperationStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.SetOperationStmt{
+		Op:            pg.SetOperation(n.Op),
+		All:           n.All,
+		Larg:          convertNode(n.Larg),
+		Rarg:          convertNode(n.Rarg),
+		ColTypes:      convertList(n.ColTypes),
+		ColTypmods:    convertList(n.ColTypmods),
+		ColCollations: convertList(n.ColCollations),
+		GroupClauses:  convertList(n.GroupClauses),
+	}
+}
+
+func convertSetToDefault(n *nodes.SetToDefault) *pg.SetToDefault {
+	if n == nil {
+		return nil
+	}
+	return &pg.SetToDefault{
+		Xpr:       convertNode(n.Xpr),
+		TypeId:    pg.Oid(n.TypeId),
+		TypeMod:   n.TypeMod,
+		Collation: pg.Oid(n.Collation),
+		Location:  n.Location,
+	}
+}
+
+func convertSortBy(n *nodes.SortBy) *pg.SortBy {
+	if n == nil {
+		return nil
+	}
+	return &pg.SortBy{
+		Node:        convertNode(n.Node),
+		SortbyDir:   pg.SortByDir(n.SortbyDir),
+		SortbyNulls: pg.SortByNulls(n.SortbyNulls),
+		UseOp:       convertList(n.UseOp),
+		Location:    n.Location,
+	}
+}
+
+func convertSortGroupClause(n *nodes.SortGroupClause) *pg.SortGroupClause {
+	if n == nil {
+		return nil
+	}
+	return &pg.SortGroupClause{
+		TleSortGroupRef: pg.Index(n.TleSortGroupRef),
+		Eqop:            pg.Oid(n.Eqop),
+		Sortop:          pg.Oid(n.Sortop),
+		NullsFirst:      n.NullsFirst,
+		Hashable:        n.Hashable,
+	}
+}
+
+func convertString(n *nodes.String) *pg.String {
+	if n == nil {
+		return nil
+	}
+	return &pg.String{
+		Str: n.Str,
+	}
+}
+
+func convertSubLink(n *nodes.SubLink) *pg.SubLink {
+	if n == nil {
+		return nil
+	}
+	return &pg.SubLink{
+		Xpr:         convertNode(n.Xpr),
+		SubLinkType: pg.SubLinkType(n.SubLinkType),
+		SubLinkId:   n.SubLinkId,
+		Testexpr:    convertNode(n.Testexpr),
+		OperName:    convertList(n.OperName),
+		Subselect:   convertNode(n.Subselect),
+		Location:    n.Location,
+	}
+}
+
+func convertSubPlan(n *nodes.SubPlan) *pg.SubPlan {
+	if n == nil {
+		return nil
+	}
+	return &pg.SubPlan{
+		Xpr:               convertNode(n.Xpr),
+		SubLinkType:       pg.SubLinkType(n.SubLinkType),
+		Testexpr:          convertNode(n.Testexpr),
+		ParamIds:          convertList(n.ParamIds),
+		PlanId:            n.PlanId,
+		PlanName:          n.PlanName,
+		FirstColType:      pg.Oid(n.FirstColType),
+		FirstColTypmod:    n.FirstColTypmod,
+		FirstColCollation: pg.Oid(n.FirstColCollation),
+		UseHashTable:      n.UseHashTable,
+		UnknownEqFalse:    n.UnknownEqFalse,
+		ParallelSafe:      n.ParallelSafe,
+		SetParam:          convertList(n.SetParam),
+		ParParam:          convertList(n.ParParam),
+		Args:              convertList(n.Args),
+		StartupCost:       pg.Cost(n.StartupCost),
+		PerCallCost:       pg.Cost(n.PerCallCost),
+	}
+}
+
+func convertTableFunc(n *nodes.TableFunc) *pg.TableFunc {
+	if n == nil {
+		return nil
+	}
+	return &pg.TableFunc{
+		NsUris:        convertList(n.NsUris),
+		NsNames:       convertList(n.NsNames),
+		Docexpr:       convertNode(n.Docexpr),
+		Rowexpr:       convertNode(n.Rowexpr),
+		Colnames:      convertList(n.Colnames),
+		Coltypes:      convertList(n.Coltypes),
+		Coltypmods:    convertList(n.Coltypmods),
+		Colcollations: convertList(n.Colcollations),
+		Colexprs:      convertList(n.Colexprs),
+		Coldefexprs:   convertList(n.Coldefexprs),
+		Notnulls:      n.Notnulls,
+		Ordinalitycol: n.Ordinalitycol,
+		Location:      n.Location,
+	}
+}
+
+func convertTableLikeClause(n *nodes.TableLikeClause) *pg.TableLikeClause {
+	if n == nil {
+		return nil
+	}
+	return &pg.TableLikeClause{
+		Relation: convertRangeVar(n.Relation),
+		Options:  n.Options,
+	}
+}
+
+func convertTableSampleClause(n *nodes.TableSampleClause) *pg.TableSampleClause {
+	if n == nil {
+		return nil
+	}
+	return &pg.TableSampleClause{
+		Tsmhandler: pg.Oid(n.Tsmhandler),
+		Args:       convertList(n.Args),
+		Repeatable: convertNode(n.Repeatable),
+	}
+}
+
+func convertTargetEntry(n *nodes.TargetEntry) *pg.TargetEntry {
+	if n == nil {
+		return nil
+	}
+	return &pg.TargetEntry{
+		Xpr:             convertNode(n.Xpr),
+		Expr:            convertNode(n.Expr),
+		Resno:           pg.AttrNumber(n.Resno),
+		Resname:         n.Resname,
+		Ressortgroupref: pg.Index(n.Ressortgroupref),
+		Resorigtbl:      pg.Oid(n.Resorigtbl),
+		Resorigcol:      pg.AttrNumber(n.Resorigcol),
+		Resjunk:         n.Resjunk,
+	}
+}
+
+func convertTransactionStmt(n *nodes.TransactionStmt) *pg.TransactionStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.TransactionStmt{
+		Kind:    pg.TransactionStmtKind(n.Kind),
+		Options: convertList(n.Options),
+		Gid:     n.Gid,
+	}
+}
+
+func convertTriggerTransition(n *nodes.TriggerTransition) *pg.TriggerTransition {
+	if n == nil {
+		return nil
+	}
+	return &pg.TriggerTransition{
+		Name:    n.Name,
+		IsNew:   n.IsNew,
+		IsTable: n.IsTable,
+	}
+}
+
+func convertTruncateStmt(n *nodes.TruncateStmt) *pg.TruncateStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.TruncateStmt{
+		Relations:   convertList(n.Relations),
+		RestartSeqs: n.RestartSeqs,
+		Behavior:    pg.DropBehavior(n.Behavior),
+	}
+}
+
+func convertTypeCast(n *nodes.TypeCast) *pg.TypeCast {
+	if n == nil {
+		return nil
+	}
+	return &pg.TypeCast{
+		Arg:      convertNode(n.Arg),
+		TypeName: convertTypeName(n.TypeName),
+		Location: n.Location,
+	}
+}
+
+func convertTypeName(n *nodes.TypeName) *pg.TypeName {
+	if n == nil {
+		return nil
+	}
+	return &pg.TypeName{
+		Names:       convertList(n.Names),
+		TypeOid:     pg.Oid(n.TypeOid),
+		Setof:       n.Setof,
+		PctType:     n.PctType,
+		Typmods:     convertList(n.Typmods),
+		Typemod:     n.Typemod,
+		ArrayBounds: convertList(n.ArrayBounds),
+		Location:    n.Location,
+	}
+}
+
+func convertUnlistenStmt(n *nodes.UnlistenStmt) *pg.UnlistenStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.UnlistenStmt{
+		Conditionname: n.Conditionname,
+	}
+}
+
+func convertUpdateStmt(n *nodes.UpdateStmt) *pg.UpdateStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.UpdateStmt{
+		Relation:      convertRangeVar(n.Relation),
+		TargetList:    convertList(n.TargetList),
+		WhereClause:   convertNode(n.WhereClause),
+		FromClause:    convertList(n.FromClause),
+		ReturningList: convertList(n.ReturningList),
+		WithClause:    convertWithClause(n.WithClause),
+	}
+}
+
+func convertVacuumStmt(n *nodes.VacuumStmt) *pg.VacuumStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.VacuumStmt{
+		Options:  n.Options,
+		Relation: convertRangeVar(n.Relation),
+		VaCols:   convertList(n.VaCols),
+	}
+}
+
+func convertVar(n *nodes.Var) *pg.Var {
+	if n == nil {
+		return nil
+	}
+	return &pg.Var{
+		Xpr:         convertNode(n.Xpr),
+		Varno:       pg.Index(n.Varno),
+		Varattno:    pg.AttrNumber(n.Varattno),
+		Vartype:     pg.Oid(n.Vartype),
+		Vartypmod:   n.Vartypmod,
+		Varcollid:   pg.Oid(n.Varcollid),
+		Varlevelsup: pg.Index(n.Varlevelsup),
+		Varnoold:    pg.Index(n.Varnoold),
+		Varoattno:   pg.AttrNumber(n.Varoattno),
+		Location:    n.Location,
+	}
+}
+
+func convertVariableSetStmt(n *nodes.VariableSetStmt) *pg.VariableSetStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.VariableSetStmt{
+		Kind:    pg.VariableSetKind(n.Kind),
+		Name:    n.Name,
+		Args:    convertList(n.Args),
+		IsLocal: n.IsLocal,
+	}
+}
+
+func convertVariableShowStmt(n *nodes.VariableShowStmt) *pg.VariableShowStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.VariableShowStmt{
+		Name: n.Name,
+	}
+}
+
+func convertViewStmt(n *nodes.ViewStmt) *pg.ViewStmt {
+	if n == nil {
+		return nil
+	}
+	return &pg.ViewStmt{
+		View:            convertRangeVar(n.View),
+		Aliases:         convertList(n.Aliases),
+		Query:           convertNode(n.Query),
+		Replace:         n.Replace,
+		Options:         convertList(n.Options),
+		WithCheckOption: pg.ViewCheckOption(n.WithCheckOption),
+	}
+}
+
+func convertWindowClause(n *nodes.WindowClause) *pg.WindowClause {
+	if n == nil {
+		return nil
+	}
+	return &pg.WindowClause{
+		Name:            n.Name,
+		Refname:         n.Refname,
+		PartitionClause: convertList(n.PartitionClause),
+		OrderClause:     convertList(n.OrderClause),
+		FrameOptions:    n.FrameOptions,
+		StartOffset:     convertNode(n.StartOffset),
+		EndOffset:       convertNode(n.EndOffset),
+		Winref:          pg.Index(n.Winref),
+		CopiedOrder:     n.CopiedOrder,
+	}
+}
+
+func convertWindowDef(n *nodes.WindowDef) *pg.WindowDef {
+	if n == nil {
+		return nil
+	}
+	return &pg.WindowDef{
+		Name:            n.Name,
+		Refname:         n.Refname,
+		PartitionClause: convertList(n.PartitionClause),
+		OrderClause:     convertList(n.OrderClause),
+		FrameOptions:    n.FrameOptions,
+		StartOffset:     convertNode(n.StartOffset),
+		EndOffset:       convertNode(n.EndOffset),
+		Location:        n.Location,
+	}
+}
+
+func convertWindowFunc(n *nodes.WindowFunc) *pg.WindowFunc {
+	if n == nil {
+		return nil
+	}
+	return &pg.WindowFunc{
+		Xpr:         convertNode(n.Xpr),
+		Winfnoid:    pg.Oid(n.Winfnoid),
+		Wintype:     pg.Oid(n.Wintype),
+		Wincollid:   pg.Oid(n.Wincollid),
+		Inputcollid: pg.Oid(n.Inputcollid),
+		Args:        convertList(n.Args),
+		Aggfilter:   convertNode(n.Aggfilter),
+		Winref:      pg.Index(n.Winref),
+		Winstar:     n.Winstar,
+		Winagg:      n.Winagg,
+		Location:    n.Location,
+	}
+}
+
+func convertWithCheckOption(n *nodes.WithCheckOption) *pg.WithCheckOption {
+	if n == nil {
+		return nil
+	}
+	return &pg.WithCheckOption{
+		Kind:     pg.WCOKind(n.Kind),
+		Relname:  n.Relname,
+		Polname:  n.Polname,
+		Qual:     convertNode(n.Qual),
+		Cascaded: n.Cascaded,
+	}
+}
+
+func convertWithClause(n *nodes.WithClause) *pg.WithClause {
+	if n == nil {
+		return nil
+	}
+	return &pg.WithClause{
+		Ctes:      convertList(n.Ctes),
+		Recursive: n.Recursive,
+		Location:  n.Location,
+	}
+}
+
+func convertXmlExpr(n *nodes.XmlExpr) *pg.XmlExpr {
+	if n == nil {
+		return nil
+	}
+	return &pg.XmlExpr{
+		Xpr:       convertNode(n.Xpr),
+		Op:        pg.XmlExprOp(n.Op),
+		Name:      n.Name,
+		NamedArgs: convertList(n.NamedArgs),
+		ArgNames:  convertList(n.ArgNames),
+		Args:      convertList(n.Args),
+		Xmloption: pg.XmlOptionType(n.Xmloption),
+		Type:      pg.Oid(n.Type),
+		Typmod:    n.Typmod,
+		Location:  n.Location,
+	}
+}
+
+func convertXmlSerialize(n *nodes.XmlSerialize) *pg.XmlSerialize {
+	if n == nil {
+		return nil
+	}
+	return &pg.XmlSerialize{
+		Xmloption: pg.XmlOptionType(n.Xmloption),
+		Expr:      convertNode(n.Expr),
+		TypeName:  convertTypeName(n.TypeName),
+		Location:  n.Location,
+	}
+}
+
+func convertNode(node nodes.Node) ast.Node {
+	switch n := node.(type) {
+
+	case nodes.A_ArrayExpr:
+		return convertA_ArrayExpr(&n)
+
+	case nodes.A_Const:
+		return convertA_Const(&n)
+
+	case nodes.A_Expr:
+		return convertA_Expr(&n)
+
+	case nodes.A_Indices:
+		return convertA_Indices(&n)
+
+	case nodes.A_Indirection:
+		return convertA_Indirection(&n)
+
+	case nodes.A_Star:
+		return convertA_Star(&n)
+
+	case nodes.AccessPriv:
+		return convertAccessPriv(&n)
+
+	case nodes.Aggref:
+		return convertAggref(&n)
+
+	case nodes.Alias:
+		return convertAlias(&n)
+
+	case nodes.AlterCollationStmt:
+		return convertAlterCollationStmt(&n)
+
+	case nodes.AlterDatabaseSetStmt:
+		return convertAlterDatabaseSetStmt(&n)
+
+	case nodes.AlterDatabaseStmt:
+		return convertAlterDatabaseStmt(&n)
+
+	case nodes.AlterDefaultPrivilegesStmt:
+		return convertAlterDefaultPrivilegesStmt(&n)
+
+	case nodes.AlterDomainStmt:
+		return convertAlterDomainStmt(&n)
+
+	case nodes.AlterEnumStmt:
+		return convertAlterEnumStmt(&n)
+
+	case nodes.AlterEventTrigStmt:
+		return convertAlterEventTrigStmt(&n)
+
+	case nodes.AlterExtensionContentsStmt:
+		return convertAlterExtensionContentsStmt(&n)
+
+	case nodes.AlterExtensionStmt:
+		return convertAlterExtensionStmt(&n)
+
+	case nodes.AlterFdwStmt:
+		return convertAlterFdwStmt(&n)
+
+	case nodes.AlterForeignServerStmt:
+		return convertAlterForeignServerStmt(&n)
+
+	case nodes.AlterFunctionStmt:
+		return convertAlterFunctionStmt(&n)
+
+	case nodes.AlterObjectDependsStmt:
+		return convertAlterObjectDependsStmt(&n)
+
+	case nodes.AlterObjectSchemaStmt:
+		return convertAlterObjectSchemaStmt(&n)
+
+	case nodes.AlterOpFamilyStmt:
+		return convertAlterOpFamilyStmt(&n)
+
+	case nodes.AlterOperatorStmt:
+		return convertAlterOperatorStmt(&n)
+
+	case nodes.AlterOwnerStmt:
+		return convertAlterOwnerStmt(&n)
+
+	case nodes.AlterPolicyStmt:
+		return convertAlterPolicyStmt(&n)
+
+	case nodes.AlterPublicationStmt:
+		return convertAlterPublicationStmt(&n)
+
+	case nodes.AlterRoleSetStmt:
+		return convertAlterRoleSetStmt(&n)
+
+	case nodes.AlterRoleStmt:
+		return convertAlterRoleStmt(&n)
+
+	case nodes.AlterSeqStmt:
+		return convertAlterSeqStmt(&n)
+
+	case nodes.AlterSubscriptionStmt:
+		return convertAlterSubscriptionStmt(&n)
+
+	case nodes.AlterSystemStmt:
+		return convertAlterSystemStmt(&n)
+
+	case nodes.AlterTSConfigurationStmt:
+		return convertAlterTSConfigurationStmt(&n)
+
+	case nodes.AlterTSDictionaryStmt:
+		return convertAlterTSDictionaryStmt(&n)
+
+	case nodes.AlterTableCmd:
+		return convertAlterTableCmd(&n)
+
+	case nodes.AlterTableMoveAllStmt:
+		return convertAlterTableMoveAllStmt(&n)
+
+	case nodes.AlterTableSpaceOptionsStmt:
+		return convertAlterTableSpaceOptionsStmt(&n)
+
+	case nodes.AlterTableStmt:
+		return convertAlterTableStmt(&n)
+
+	case nodes.AlterUserMappingStmt:
+		return convertAlterUserMappingStmt(&n)
+
+	case nodes.AlternativeSubPlan:
+		return convertAlternativeSubPlan(&n)
+
+	case nodes.ArrayCoerceExpr:
+		return convertArrayCoerceExpr(&n)
+
+	case nodes.ArrayExpr:
+		return convertArrayExpr(&n)
+
+	case nodes.ArrayRef:
+		return convertArrayRef(&n)
+
+	case nodes.BitString:
+		return convertBitString(&n)
+
+	case nodes.BlockIdData:
+		return convertBlockIdData(&n)
+
+	case nodes.BoolExpr:
+		return convertBoolExpr(&n)
+
+	case nodes.BooleanTest:
+		return convertBooleanTest(&n)
+
+	case nodes.CaseExpr:
+		return convertCaseExpr(&n)
+
+	case nodes.CaseTestExpr:
+		return convertCaseTestExpr(&n)
+
+	case nodes.CaseWhen:
+		return convertCaseWhen(&n)
+
+	case nodes.CheckPointStmt:
+		return convertCheckPointStmt(&n)
+
+	case nodes.ClosePortalStmt:
+		return convertClosePortalStmt(&n)
+
+	case nodes.ClusterStmt:
+		return convertClusterStmt(&n)
+
+	case nodes.CoalesceExpr:
+		return convertCoalesceExpr(&n)
+
+	case nodes.CoerceToDomain:
+		return convertCoerceToDomain(&n)
+
+	case nodes.CoerceToDomainValue:
+		return convertCoerceToDomainValue(&n)
+
+	case nodes.CoerceViaIO:
+		return convertCoerceViaIO(&n)
+
+	case nodes.CollateClause:
+		return convertCollateClause(&n)
+
+	case nodes.CollateExpr:
+		return convertCollateExpr(&n)
+
+	case nodes.ColumnDef:
+		return convertColumnDef(&n)
+
+	case nodes.ColumnRef:
+		return convertColumnRef(&n)
+
+	case nodes.CommentStmt:
+		return convertCommentStmt(&n)
+
+	case nodes.CommonTableExpr:
+		return convertCommonTableExpr(&n)
+
+	case nodes.CompositeTypeStmt:
+		return convertCompositeTypeStmt(&n)
+
+	case nodes.Const:
+		return convertConst(&n)
+
+	case nodes.Constraint:
+		return convertConstraint(&n)
+
+	case nodes.ConstraintsSetStmt:
+		return convertConstraintsSetStmt(&n)
+
+	case nodes.ConvertRowtypeExpr:
+		return convertConvertRowtypeExpr(&n)
+
+	case nodes.CopyStmt:
+		return convertCopyStmt(&n)
+
+	case nodes.CreateAmStmt:
+		return convertCreateAmStmt(&n)
+
+	case nodes.CreateCastStmt:
+		return convertCreateCastStmt(&n)
+
+	case nodes.CreateConversionStmt:
+		return convertCreateConversionStmt(&n)
+
+	case nodes.CreateDomainStmt:
+		return convertCreateDomainStmt(&n)
+
+	case nodes.CreateEnumStmt:
+		return convertCreateEnumStmt(&n)
+
+	case nodes.CreateEventTrigStmt:
+		return convertCreateEventTrigStmt(&n)
+
+	case nodes.CreateExtensionStmt:
+		return convertCreateExtensionStmt(&n)
+
+	case nodes.CreateFdwStmt:
+		return convertCreateFdwStmt(&n)
+
+	case nodes.CreateForeignServerStmt:
+		return convertCreateForeignServerStmt(&n)
+
+	case nodes.CreateForeignTableStmt:
+		return convertCreateForeignTableStmt(&n)
+
+	case nodes.CreateFunctionStmt:
+		return convertCreateFunctionStmt(&n)
+
+	case nodes.CreateOpClassItem:
+		return convertCreateOpClassItem(&n)
+
+	case nodes.CreateOpClassStmt:
+		return convertCreateOpClassStmt(&n)
+
+	case nodes.CreateOpFamilyStmt:
+		return convertCreateOpFamilyStmt(&n)
+
+	case nodes.CreatePLangStmt:
+		return convertCreatePLangStmt(&n)
+
+	case nodes.CreatePolicyStmt:
+		return convertCreatePolicyStmt(&n)
+
+	case nodes.CreatePublicationStmt:
+		return convertCreatePublicationStmt(&n)
+
+	case nodes.CreateRangeStmt:
+		return convertCreateRangeStmt(&n)
+
+	case nodes.CreateRoleStmt:
+		return convertCreateRoleStmt(&n)
+
+	case nodes.CreateSchemaStmt:
+		return convertCreateSchemaStmt(&n)
+
+	case nodes.CreateSeqStmt:
+		return convertCreateSeqStmt(&n)
+
+	case nodes.CreateStatsStmt:
+		return convertCreateStatsStmt(&n)
+
+	case nodes.CreateStmt:
+		return convertCreateStmt(&n)
+
+	case nodes.CreateSubscriptionStmt:
+		return convertCreateSubscriptionStmt(&n)
+
+	case nodes.CreateTableAsStmt:
+		return convertCreateTableAsStmt(&n)
+
+	case nodes.CreateTableSpaceStmt:
+		return convertCreateTableSpaceStmt(&n)
+
+	case nodes.CreateTransformStmt:
+		return convertCreateTransformStmt(&n)
+
+	case nodes.CreateTrigStmt:
+		return convertCreateTrigStmt(&n)
+
+	case nodes.CreateUserMappingStmt:
+		return convertCreateUserMappingStmt(&n)
+
+	case nodes.CreatedbStmt:
+		return convertCreatedbStmt(&n)
+
+	case nodes.CurrentOfExpr:
+		return convertCurrentOfExpr(&n)
+
+	case nodes.DeallocateStmt:
+		return convertDeallocateStmt(&n)
+
+	case nodes.DeclareCursorStmt:
+		return convertDeclareCursorStmt(&n)
+
+	case nodes.DefElem:
+		return convertDefElem(&n)
+
+	case nodes.DefineStmt:
+		return convertDefineStmt(&n)
+
+	case nodes.DeleteStmt:
+		return convertDeleteStmt(&n)
+
+	case nodes.DiscardStmt:
+		return convertDiscardStmt(&n)
+
+	case nodes.DoStmt:
+		return convertDoStmt(&n)
+
+	case nodes.DropOwnedStmt:
+		return convertDropOwnedStmt(&n)
+
+	case nodes.DropRoleStmt:
+		return convertDropRoleStmt(&n)
+
+	case nodes.DropStmt:
+		return convertDropStmt(&n)
+
+	case nodes.DropSubscriptionStmt:
+		return convertDropSubscriptionStmt(&n)
+
+	case nodes.DropTableSpaceStmt:
+		return convertDropTableSpaceStmt(&n)
+
+	case nodes.DropUserMappingStmt:
+		return convertDropUserMappingStmt(&n)
+
+	case nodes.DropdbStmt:
+		return convertDropdbStmt(&n)
+
+	case nodes.ExecuteStmt:
+		return convertExecuteStmt(&n)
+
+	case nodes.ExplainStmt:
+		return convertExplainStmt(&n)
+
+	case nodes.Expr:
+		return convertExpr(&n)
+
+	case nodes.FetchStmt:
+		return convertFetchStmt(&n)
+
+	case nodes.FieldSelect:
+		return convertFieldSelect(&n)
+
+	case nodes.FieldStore:
+		return convertFieldStore(&n)
+
+	case nodes.Float:
+		return convertFloat(&n)
+
+	case nodes.FromExpr:
+		return convertFromExpr(&n)
+
+	case nodes.FuncCall:
+		return convertFuncCall(&n)
+
+	case nodes.FuncExpr:
+		return convertFuncExpr(&n)
+
+	case nodes.FunctionParameter:
+		return convertFunctionParameter(&n)
+
+	case nodes.GrantRoleStmt:
+		return convertGrantRoleStmt(&n)
+
+	case nodes.GrantStmt:
+		return convertGrantStmt(&n)
+
+	case nodes.GroupingFunc:
+		return convertGroupingFunc(&n)
+
+	case nodes.GroupingSet:
+		return convertGroupingSet(&n)
+
+	case nodes.ImportForeignSchemaStmt:
+		return convertImportForeignSchemaStmt(&n)
+
+	case nodes.IndexElem:
+		return convertIndexElem(&n)
+
+	case nodes.IndexStmt:
+		return convertIndexStmt(&n)
+
+	case nodes.InferClause:
+		return convertInferClause(&n)
+
+	case nodes.InferenceElem:
+		return convertInferenceElem(&n)
+
+	case nodes.InlineCodeBlock:
+		return convertInlineCodeBlock(&n)
+
+	case nodes.InsertStmt:
+		return convertInsertStmt(&n)
+
+	case nodes.Integer:
+		return convertInteger(&n)
+
+	case nodes.IntoClause:
+		return convertIntoClause(&n)
+
+	case nodes.JoinExpr:
+		return convertJoinExpr(&n)
+
+	case nodes.ListenStmt:
+		return convertListenStmt(&n)
+
+	case nodes.LoadStmt:
+		return convertLoadStmt(&n)
+
+	case nodes.LockStmt:
+		return convertLockStmt(&n)
+
+	case nodes.LockingClause:
+		return convertLockingClause(&n)
+
+	case nodes.MinMaxExpr:
+		return convertMinMaxExpr(&n)
+
+	case nodes.MultiAssignRef:
+		return convertMultiAssignRef(&n)
+
+	case nodes.NamedArgExpr:
+		return convertNamedArgExpr(&n)
+
+	case nodes.NextValueExpr:
+		return convertNextValueExpr(&n)
+
+	case nodes.NotifyStmt:
+		return convertNotifyStmt(&n)
+
+	case nodes.Null:
+		return convertNull(&n)
+
+	case nodes.NullTest:
+		return convertNullTest(&n)
+
+	case nodes.ObjectWithArgs:
+		return convertObjectWithArgs(&n)
+
+	case nodes.OnConflictClause:
+		return convertOnConflictClause(&n)
+
+	case nodes.OnConflictExpr:
+		return convertOnConflictExpr(&n)
+
+	case nodes.OpExpr:
+		return convertOpExpr(&n)
+
+	case nodes.Param:
+		return convertParam(&n)
+
+	case nodes.ParamExecData:
+		return convertParamExecData(&n)
+
+	case nodes.ParamExternData:
+		return convertParamExternData(&n)
+
+	case nodes.ParamListInfoData:
+		return convertParamListInfoData(&n)
+
+	case nodes.ParamRef:
+		return convertParamRef(&n)
+
+	case nodes.PartitionBoundSpec:
+		return convertPartitionBoundSpec(&n)
+
+	case nodes.PartitionCmd:
+		return convertPartitionCmd(&n)
+
+	case nodes.PartitionElem:
+		return convertPartitionElem(&n)
+
+	case nodes.PartitionRangeDatum:
+		return convertPartitionRangeDatum(&n)
+
+	case nodes.PartitionSpec:
+		return convertPartitionSpec(&n)
+
+	case nodes.PrepareStmt:
+		return convertPrepareStmt(&n)
+
+	case nodes.Query:
+		return convertQuery(&n)
+
+	case nodes.RangeFunction:
+		return convertRangeFunction(&n)
+
+	case nodes.RangeSubselect:
+		return convertRangeSubselect(&n)
+
+	case nodes.RangeTableFunc:
+		return convertRangeTableFunc(&n)
+
+	case nodes.RangeTableFuncCol:
+		return convertRangeTableFuncCol(&n)
+
+	case nodes.RangeTableSample:
+		return convertRangeTableSample(&n)
+
+	case nodes.RangeTblEntry:
+		return convertRangeTblEntry(&n)
+
+	case nodes.RangeTblFunction:
+		return convertRangeTblFunction(&n)
+
+	case nodes.RangeTblRef:
+		return convertRangeTblRef(&n)
+
+	case nodes.RangeVar:
+		return convertRangeVar(&n)
+
+	case nodes.RawStmt:
+		return convertRawStmt(&n)
+
+	case nodes.ReassignOwnedStmt:
+		return convertReassignOwnedStmt(&n)
+
+	case nodes.RefreshMatViewStmt:
+		return convertRefreshMatViewStmt(&n)
+
+	case nodes.ReindexStmt:
+		return convertReindexStmt(&n)
+
+	case nodes.RelabelType:
+		return convertRelabelType(&n)
+
+	case nodes.RenameStmt:
+		return convertRenameStmt(&n)
+
+	case nodes.ReplicaIdentityStmt:
+		return convertReplicaIdentityStmt(&n)
+
+	case nodes.ResTarget:
+		return convertResTarget(&n)
+
+	case nodes.RoleSpec:
+		return convertRoleSpec(&n)
+
+	case nodes.RowCompareExpr:
+		return convertRowCompareExpr(&n)
+
+	case nodes.RowExpr:
+		return convertRowExpr(&n)
+
+	case nodes.RowMarkClause:
+		return convertRowMarkClause(&n)
+
+	case nodes.RuleStmt:
+		return convertRuleStmt(&n)
+
+	case nodes.SQLValueFunction:
+		return convertSQLValueFunction(&n)
+
+	case nodes.ScalarArrayOpExpr:
+		return convertScalarArrayOpExpr(&n)
+
+	case nodes.SecLabelStmt:
+		return convertSecLabelStmt(&n)
+
+	case nodes.SelectStmt:
+		return convertSelectStmt(&n)
+
+	case nodes.SetOperationStmt:
+		return convertSetOperationStmt(&n)
+
+	case nodes.SetToDefault:
+		return convertSetToDefault(&n)
+
+	case nodes.SortBy:
+		return convertSortBy(&n)
+
+	case nodes.SortGroupClause:
+		return convertSortGroupClause(&n)
+
+	case nodes.String:
+		return convertString(&n)
+
+	case nodes.SubLink:
+		return convertSubLink(&n)
+
+	case nodes.SubPlan:
+		return convertSubPlan(&n)
+
+	case nodes.TableFunc:
+		return convertTableFunc(&n)
+
+	case nodes.TableLikeClause:
+		return convertTableLikeClause(&n)
+
+	case nodes.TableSampleClause:
+		return convertTableSampleClause(&n)
+
+	case nodes.TargetEntry:
+		return convertTargetEntry(&n)
+
+	case nodes.TransactionStmt:
+		return convertTransactionStmt(&n)
+
+	case nodes.TriggerTransition:
+		return convertTriggerTransition(&n)
+
+	case nodes.TruncateStmt:
+		return convertTruncateStmt(&n)
+
+	case nodes.TypeCast:
+		return convertTypeCast(&n)
+
+	case nodes.TypeName:
+		return convertTypeName(&n)
+
+	case nodes.UnlistenStmt:
+		return convertUnlistenStmt(&n)
+
+	case nodes.UpdateStmt:
+		return convertUpdateStmt(&n)
+
+	case nodes.VacuumStmt:
+		return convertVacuumStmt(&n)
+
+	case nodes.Var:
+		return convertVar(&n)
+
+	case nodes.VariableSetStmt:
+		return convertVariableSetStmt(&n)
+
+	case nodes.VariableShowStmt:
+		return convertVariableShowStmt(&n)
+
+	case nodes.ViewStmt:
+		return convertViewStmt(&n)
+
+	case nodes.WindowClause:
+		return convertWindowClause(&n)
+
+	case nodes.WindowDef:
+		return convertWindowDef(&n)
+
+	case nodes.WindowFunc:
+		return convertWindowFunc(&n)
+
+	case nodes.WithCheckOption:
+		return convertWithCheckOption(&n)
+
+	case nodes.WithClause:
+		return convertWithClause(&n)
+
+	case nodes.XmlExpr:
+		return convertXmlExpr(&n)
+
+	case nodes.XmlSerialize:
+		return convertXmlSerialize(&n)
+
+	default:
+		return &ast.TODO{}
+	}
+}

--- a/internal/postgresql/parse.go
+++ b/internal/postgresql/parse.go
@@ -523,6 +523,6 @@ func translate(node nodes.Node) (ast.Node, error) {
 		return nil, errSkip
 
 	default:
-		return nil, errSkip
+		return convert(n)
 	}
 }

--- a/internal/postgresql/rewrite_test.go
+++ b/internal/postgresql/rewrite_test.go
@@ -1,0 +1,45 @@
+package postgresql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kyleconroy/sqlc/internal/sql/ast/pg"
+	"github.com/kyleconroy/sqlc/internal/sql/astutils"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestApply(t *testing.T) {
+	p := NewParser()
+
+	input, err := p.Parse(strings.NewReader("SELECT sqlc.arg(name)"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := p.Parse(strings.NewReader("SELECT $1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := &output[0]
+	actual := astutils.Apply(&input[0], func(cr *astutils.Cursor) bool {
+		fun, ok := cr.Node().(*pg.FuncCall)
+		if !ok {
+			return true
+		}
+		if astutils.Join(fun.Funcname, ".") == "sqlc.arg" {
+			cr.Replace(&pg.ParamRef{
+				Number:   1,
+				Location: fun.Location,
+			})
+			return false
+		}
+
+		return true
+	}, nil)
+
+	if diff := cmp.Diff(expect, actual); diff != "" {
+		t.Errorf("rewrite mismatch:\n%s", diff)
+	}
+}

--- a/internal/sql/ast/ast.go
+++ b/internal/sql/ast/ast.go
@@ -8,6 +8,10 @@ type Statement struct {
 	Raw *RawStmt
 }
 
+func (n *Statement) Pos() int {
+	return 0
+}
+
 type RawStmt struct {
 	Stmt Node
 }

--- a/internal/sql/ast/pg/a_array_expr.go
+++ b/internal/sql/ast/pg/a_array_expr.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type A_ArrayExpr struct {
+	Elements *ast.List
+	Location int
+}
+
+func (n *A_ArrayExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/a_const.go
+++ b/internal/sql/ast/pg/a_const.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type A_Const struct {
+	Val      ast.Node
+	Location int
+}
+
+func (n *A_Const) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/a_expr.go
+++ b/internal/sql/ast/pg/a_expr.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type A_Expr struct {
+	Kind     A_Expr_Kind
+	Name     *ast.List
+	Lexpr    ast.Node
+	Rexpr    ast.Node
+	Location int
+}
+
+func (n *A_Expr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/a_expr_kind.go
+++ b/internal/sql/ast/pg/a_expr_kind.go
@@ -1,0 +1,7 @@
+package pg
+
+type A_Expr_Kind uint
+
+func (n *A_Expr_Kind) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/a_indices.go
+++ b/internal/sql/ast/pg/a_indices.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type A_Indices struct {
+	IsSlice bool
+	Lidx    ast.Node
+	Uidx    ast.Node
+}
+
+func (n *A_Indices) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/a_indirection.go
+++ b/internal/sql/ast/pg/a_indirection.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type A_Indirection struct {
+	Arg         ast.Node
+	Indirection *ast.List
+}
+
+func (n *A_Indirection) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/a_star.go
+++ b/internal/sql/ast/pg/a_star.go
@@ -1,0 +1,8 @@
+package pg
+
+type A_Star struct {
+}
+
+func (n *A_Star) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/access_priv.go
+++ b/internal/sql/ast/pg/access_priv.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AccessPriv struct {
+	PrivName *string
+	Cols     *ast.List
+}
+
+func (n *AccessPriv) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/agg_split.go
+++ b/internal/sql/ast/pg/agg_split.go
@@ -1,0 +1,7 @@
+package pg
+
+type AggSplit uint
+
+func (n *AggSplit) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/agg_strategy.go
+++ b/internal/sql/ast/pg/agg_strategy.go
@@ -1,0 +1,7 @@
+package pg
+
+type AggStrategy uint
+
+func (n *AggStrategy) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/aggref.go
+++ b/internal/sql/ast/pg/aggref.go
@@ -1,0 +1,30 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type Aggref struct {
+	Xpr           ast.Node
+	Aggfnoid      Oid
+	Aggtype       Oid
+	Aggcollid     Oid
+	Inputcollid   Oid
+	Aggtranstype  Oid
+	Aggargtypes   *ast.List
+	Aggdirectargs *ast.List
+	Args          *ast.List
+	Aggorder      *ast.List
+	Aggdistinct   *ast.List
+	Aggfilter     ast.Node
+	Aggstar       bool
+	Aggvariadic   bool
+	Aggkind       byte
+	Agglevelsup   Index
+	Aggsplit      AggSplit
+	Location      int
+}
+
+func (n *Aggref) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/alias.go
+++ b/internal/sql/ast/pg/alias.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type Alias struct {
+	Aliasname *string
+	Colnames  *ast.List
+}
+
+func (n *Alias) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_collation_stmt.go
+++ b/internal/sql/ast/pg/alter_collation_stmt.go
@@ -1,0 +1,13 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterCollationStmt struct {
+	Collname *ast.List
+}
+
+func (n *AlterCollationStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_database_set_stmt.go
+++ b/internal/sql/ast/pg/alter_database_set_stmt.go
@@ -1,0 +1,10 @@
+package pg
+
+type AlterDatabaseSetStmt struct {
+	Dbname  *string
+	Setstmt *VariableSetStmt
+}
+
+func (n *AlterDatabaseSetStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_database_stmt.go
+++ b/internal/sql/ast/pg/alter_database_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterDatabaseStmt struct {
+	Dbname  *string
+	Options *ast.List
+}
+
+func (n *AlterDatabaseStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_default_privileges_stmt.go
+++ b/internal/sql/ast/pg/alter_default_privileges_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterDefaultPrivilegesStmt struct {
+	Options *ast.List
+	Action  *GrantStmt
+}
+
+func (n *AlterDefaultPrivilegesStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_domain_stmt.go
+++ b/internal/sql/ast/pg/alter_domain_stmt.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterDomainStmt struct {
+	Subtype   byte
+	TypeName  *ast.List
+	Name      *string
+	Def       ast.Node
+	Behavior  DropBehavior
+	MissingOk bool
+}
+
+func (n *AlterDomainStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_enum_stmt.go
+++ b/internal/sql/ast/pg/alter_enum_stmt.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterEnumStmt struct {
+	TypeName           *ast.List
+	OldVal             *string
+	NewVal             *string
+	NewValNeighbor     *string
+	NewValIsAfter      bool
+	SkipIfNewValExists bool
+}
+
+func (n *AlterEnumStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_event_trig_stmt.go
+++ b/internal/sql/ast/pg/alter_event_trig_stmt.go
@@ -1,0 +1,10 @@
+package pg
+
+type AlterEventTrigStmt struct {
+	Trigname  *string
+	Tgenabled byte
+}
+
+func (n *AlterEventTrigStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_extension_contents_stmt.go
+++ b/internal/sql/ast/pg/alter_extension_contents_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterExtensionContentsStmt struct {
+	Extname *string
+	Action  int
+	Objtype ObjectType
+	Object  ast.Node
+}
+
+func (n *AlterExtensionContentsStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_extension_stmt.go
+++ b/internal/sql/ast/pg/alter_extension_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterExtensionStmt struct {
+	Extname *string
+	Options *ast.List
+}
+
+func (n *AlterExtensionStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_fdw_stmt.go
+++ b/internal/sql/ast/pg/alter_fdw_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterFdwStmt struct {
+	Fdwname     *string
+	FuncOptions *ast.List
+	Options     *ast.List
+}
+
+func (n *AlterFdwStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_foreign_server_stmt.go
+++ b/internal/sql/ast/pg/alter_foreign_server_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterForeignServerStmt struct {
+	Servername *string
+	Version    *string
+	Options    *ast.List
+	HasVersion bool
+}
+
+func (n *AlterForeignServerStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_function_stmt.go
+++ b/internal/sql/ast/pg/alter_function_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterFunctionStmt struct {
+	Func    *ObjectWithArgs
+	Actions *ast.List
+}
+
+func (n *AlterFunctionStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_object_depends_stmt.go
+++ b/internal/sql/ast/pg/alter_object_depends_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterObjectDependsStmt struct {
+	ObjectType ObjectType
+	Relation   *RangeVar
+	Object     ast.Node
+	Extname    ast.Node
+}
+
+func (n *AlterObjectDependsStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_object_schema_stmt.go
+++ b/internal/sql/ast/pg/alter_object_schema_stmt.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterObjectSchemaStmt struct {
+	ObjectType ObjectType
+	Relation   *RangeVar
+	Object     ast.Node
+	Newschema  *string
+	MissingOk  bool
+}
+
+func (n *AlterObjectSchemaStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_op_family_stmt.go
+++ b/internal/sql/ast/pg/alter_op_family_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterOpFamilyStmt struct {
+	Opfamilyname *ast.List
+	Amname       *string
+	IsDrop       bool
+	Items        *ast.List
+}
+
+func (n *AlterOpFamilyStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_operator_stmt.go
+++ b/internal/sql/ast/pg/alter_operator_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterOperatorStmt struct {
+	Opername *ObjectWithArgs
+	Options  *ast.List
+}
+
+func (n *AlterOperatorStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_owner_stmt.go
+++ b/internal/sql/ast/pg/alter_owner_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterOwnerStmt struct {
+	ObjectType ObjectType
+	Relation   *RangeVar
+	Object     ast.Node
+	Newowner   *RoleSpec
+}
+
+func (n *AlterOwnerStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_policy_stmt.go
+++ b/internal/sql/ast/pg/alter_policy_stmt.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterPolicyStmt struct {
+	PolicyName *string
+	Table      *RangeVar
+	Roles      *ast.List
+	Qual       ast.Node
+	WithCheck  ast.Node
+}
+
+func (n *AlterPolicyStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_publication_stmt.go
+++ b/internal/sql/ast/pg/alter_publication_stmt.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterPublicationStmt struct {
+	Pubname      *string
+	Options      *ast.List
+	Tables       *ast.List
+	ForAllTables bool
+	TableAction  DefElemAction
+}
+
+func (n *AlterPublicationStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_role_set_stmt.go
+++ b/internal/sql/ast/pg/alter_role_set_stmt.go
@@ -1,0 +1,11 @@
+package pg
+
+type AlterRoleSetStmt struct {
+	Role     *RoleSpec
+	Database *string
+	Setstmt  *VariableSetStmt
+}
+
+func (n *AlterRoleSetStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_role_stmt.go
+++ b/internal/sql/ast/pg/alter_role_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterRoleStmt struct {
+	Role    *RoleSpec
+	Options *ast.List
+	Action  int
+}
+
+func (n *AlterRoleStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_seq_stmt.go
+++ b/internal/sql/ast/pg/alter_seq_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterSeqStmt struct {
+	Sequence    *RangeVar
+	Options     *ast.List
+	ForIdentity bool
+	MissingOk   bool
+}
+
+func (n *AlterSeqStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_subscription_stmt.go
+++ b/internal/sql/ast/pg/alter_subscription_stmt.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterSubscriptionStmt struct {
+	Kind        AlterSubscriptionType
+	Subname     *string
+	Conninfo    *string
+	Publication *ast.List
+	Options     *ast.List
+}
+
+func (n *AlterSubscriptionStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_subscription_type.go
+++ b/internal/sql/ast/pg/alter_subscription_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type AlterSubscriptionType uint
+
+func (n *AlterSubscriptionType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_system_stmt.go
+++ b/internal/sql/ast/pg/alter_system_stmt.go
@@ -1,0 +1,9 @@
+package pg
+
+type AlterSystemStmt struct {
+	Setstmt *VariableSetStmt
+}
+
+func (n *AlterSystemStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_table_cmd.go
+++ b/internal/sql/ast/pg/alter_table_cmd.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterTableCmd struct {
+	Subtype   AlterTableType
+	Name      *string
+	Newowner  *RoleSpec
+	Def       ast.Node
+	Behavior  DropBehavior
+	MissingOk bool
+}
+
+func (n *AlterTableCmd) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_table_move_all_stmt.go
+++ b/internal/sql/ast/pg/alter_table_move_all_stmt.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterTableMoveAllStmt struct {
+	OrigTablespacename *string
+	Objtype            ObjectType
+	Roles              *ast.List
+	NewTablespacename  *string
+	Nowait             bool
+}
+
+func (n *AlterTableMoveAllStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_table_space_options_stmt.go
+++ b/internal/sql/ast/pg/alter_table_space_options_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterTableSpaceOptionsStmt struct {
+	Tablespacename *string
+	Options        *ast.List
+	IsReset        bool
+}
+
+func (n *AlterTableSpaceOptionsStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_table_stmt.go
+++ b/internal/sql/ast/pg/alter_table_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterTableStmt struct {
+	Relation  *RangeVar
+	Cmds      *ast.List
+	Relkind   ObjectType
+	MissingOk bool
+}
+
+func (n *AlterTableStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_table_type.go
+++ b/internal/sql/ast/pg/alter_table_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type AlterTableType uint
+
+func (n *AlterTableType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_ts_config_type.go
+++ b/internal/sql/ast/pg/alter_ts_config_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type AlterTSConfigType uint
+
+func (n *AlterTSConfigType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_ts_configuration_stmt.go
+++ b/internal/sql/ast/pg/alter_ts_configuration_stmt.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterTSConfigurationStmt struct {
+	Kind      AlterTSConfigType
+	Cfgname   *ast.List
+	Tokentype *ast.List
+	Dicts     *ast.List
+	Override  bool
+	Replace   bool
+	MissingOk bool
+}
+
+func (n *AlterTSConfigurationStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_ts_dictionary_stmt.go
+++ b/internal/sql/ast/pg/alter_ts_dictionary_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterTSDictionaryStmt struct {
+	Dictname *ast.List
+	Options  *ast.List
+}
+
+func (n *AlterTSDictionaryStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alter_user_mapping_stmt.go
+++ b/internal/sql/ast/pg/alter_user_mapping_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlterUserMappingStmt struct {
+	User       *RoleSpec
+	Servername *string
+	Options    *ast.List
+}
+
+func (n *AlterUserMappingStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/alternative_sub_plan.go
+++ b/internal/sql/ast/pg/alternative_sub_plan.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type AlternativeSubPlan struct {
+	Xpr      ast.Node
+	Subplans *ast.List
+}
+
+func (n *AlternativeSubPlan) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/array_coerce_expr.go
+++ b/internal/sql/ast/pg/array_coerce_expr.go
@@ -1,0 +1,21 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ArrayCoerceExpr struct {
+	Xpr          ast.Node
+	Arg          ast.Node
+	Elemfuncid   Oid
+	Resulttype   Oid
+	Resulttypmod int32
+	Resultcollid Oid
+	IsExplicit   bool
+	Coerceformat CoercionForm
+	Location     int
+}
+
+func (n *ArrayCoerceExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/array_expr.go
+++ b/internal/sql/ast/pg/array_expr.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ArrayExpr struct {
+	Xpr           ast.Node
+	ArrayTypeid   Oid
+	ArrayCollid   Oid
+	ElementTypeid Oid
+	Elements      *ast.List
+	Multidims     bool
+	Location      int
+}
+
+func (n *ArrayExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/array_ref.go
+++ b/internal/sql/ast/pg/array_ref.go
@@ -1,0 +1,21 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ArrayRef struct {
+	Xpr             ast.Node
+	Refarraytype    Oid
+	Refelemtype     Oid
+	Reftypmod       int32
+	Refcollid       Oid
+	Refupperindexpr *ast.List
+	Reflowerindexpr *ast.List
+	Refexpr         ast.Node
+	Refassgnexpr    ast.Node
+}
+
+func (n *ArrayRef) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/bit_string.go
+++ b/internal/sql/ast/pg/bit_string.go
@@ -1,0 +1,9 @@
+package pg
+
+type BitString struct {
+	Str string
+}
+
+func (n *BitString) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/block_id_data.go
+++ b/internal/sql/ast/pg/block_id_data.go
@@ -1,0 +1,10 @@
+package pg
+
+type BlockIdData struct {
+	BiHi uint16
+	BiLo uint16
+}
+
+func (n *BlockIdData) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/bool_expr.go
+++ b/internal/sql/ast/pg/bool_expr.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type BoolExpr struct {
+	Xpr      ast.Node
+	Boolop   BoolExprType
+	Args     *ast.List
+	Location int
+}
+
+func (n *BoolExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/bool_expr_type.go
+++ b/internal/sql/ast/pg/bool_expr_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type BoolExprType uint
+
+func (n *BoolExprType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/bool_test_type.go
+++ b/internal/sql/ast/pg/bool_test_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type BoolTestType uint
+
+func (n *BoolTestType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/boolean_test_expr.go
+++ b/internal/sql/ast/pg/boolean_test_expr.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type BooleanTest struct {
+	Xpr          ast.Node
+	Arg          ast.Node
+	Booltesttype BoolTestType
+	Location     int
+}
+
+func (n *BooleanTest) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/case_expr.go
+++ b/internal/sql/ast/pg/case_expr.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CaseExpr struct {
+	Xpr        ast.Node
+	Casetype   Oid
+	Casecollid Oid
+	Arg        ast.Node
+	Args       *ast.List
+	Defresult  ast.Node
+	Location   int
+}
+
+func (n *CaseExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/case_test_expr.go
+++ b/internal/sql/ast/pg/case_test_expr.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CaseTestExpr struct {
+	Xpr       ast.Node
+	TypeId    Oid
+	TypeMod   int32
+	Collation Oid
+}
+
+func (n *CaseTestExpr) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/case_when.go
+++ b/internal/sql/ast/pg/case_when.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CaseWhen struct {
+	Xpr      ast.Node
+	Expr     ast.Node
+	Result   ast.Node
+	Location int
+}
+
+func (n *CaseWhen) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/check_point_stmt.go
+++ b/internal/sql/ast/pg/check_point_stmt.go
@@ -1,0 +1,8 @@
+package pg
+
+type CheckPointStmt struct {
+}
+
+func (n *CheckPointStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/close_portal_stmt.go
+++ b/internal/sql/ast/pg/close_portal_stmt.go
@@ -1,0 +1,9 @@
+package pg
+
+type ClosePortalStmt struct {
+	Portalname *string
+}
+
+func (n *ClosePortalStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/cluster_stmt.go
+++ b/internal/sql/ast/pg/cluster_stmt.go
@@ -1,0 +1,11 @@
+package pg
+
+type ClusterStmt struct {
+	Relation  *RangeVar
+	Indexname *string
+	Verbose   bool
+}
+
+func (n *ClusterStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/cmd_type.go
+++ b/internal/sql/ast/pg/cmd_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type CmdType uint
+
+func (n *CmdType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/coalesce_expr.go
+++ b/internal/sql/ast/pg/coalesce_expr.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CoalesceExpr struct {
+	Xpr            ast.Node
+	Coalescetype   Oid
+	Coalescecollid Oid
+	Args           *ast.List
+	Location       int
+}
+
+func (n *CoalesceExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/coerce_to_domain.go
+++ b/internal/sql/ast/pg/coerce_to_domain.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CoerceToDomain struct {
+	Xpr            ast.Node
+	Arg            ast.Node
+	Resulttype     Oid
+	Resulttypmod   int32
+	Resultcollid   Oid
+	Coercionformat CoercionForm
+	Location       int
+}
+
+func (n *CoerceToDomain) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/coerce_to_domain_value.go
+++ b/internal/sql/ast/pg/coerce_to_domain_value.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CoerceToDomainValue struct {
+	Xpr       ast.Node
+	TypeId    Oid
+	TypeMod   int32
+	Collation Oid
+	Location  int
+}
+
+func (n *CoerceToDomainValue) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/coerce_via_io.go
+++ b/internal/sql/ast/pg/coerce_via_io.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CoerceViaIO struct {
+	Xpr          ast.Node
+	Arg          ast.Node
+	Resulttype   Oid
+	Resultcollid Oid
+	Coerceformat CoercionForm
+	Location     int
+}
+
+func (n *CoerceViaIO) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/coercion_context.go
+++ b/internal/sql/ast/pg/coercion_context.go
@@ -1,0 +1,7 @@
+package pg
+
+type CoercionContext uint
+
+func (n *CoercionContext) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/coercion_form.go
+++ b/internal/sql/ast/pg/coercion_form.go
@@ -1,0 +1,7 @@
+package pg
+
+type CoercionForm uint
+
+func (n *CoercionForm) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/collate_clause.go
+++ b/internal/sql/ast/pg/collate_clause.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CollateClause struct {
+	Arg      ast.Node
+	Collname *ast.List
+	Location int
+}
+
+func (n *CollateClause) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/collate_expr.go
+++ b/internal/sql/ast/pg/collate_expr.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CollateExpr struct {
+	Xpr      ast.Node
+	Arg      ast.Node
+	CollOid  Oid
+	Location int
+}
+
+func (n *CollateExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/column_def.go
+++ b/internal/sql/ast/pg/column_def.go
@@ -1,0 +1,28 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ColumnDef struct {
+	Colname       *string
+	TypeName      *TypeName
+	Inhcount      int
+	IsLocal       bool
+	IsNotNull     bool
+	IsFromType    bool
+	IsFromParent  bool
+	Storage       byte
+	RawDefault    ast.Node
+	CookedDefault ast.Node
+	Identity      byte
+	CollClause    *CollateClause
+	CollOid       Oid
+	Constraints   *ast.List
+	Fdwoptions    *ast.List
+	Location      int
+}
+
+func (n *ColumnDef) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/column_ref.go
+++ b/internal/sql/ast/pg/column_ref.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ColumnRef struct {
+	Fields   *ast.List
+	Location int
+}
+
+func (n *ColumnRef) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/comment_stmt.go
+++ b/internal/sql/ast/pg/comment_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CommentStmt struct {
+	Objtype ObjectType
+	Object  ast.Node
+	Comment *string
+}
+
+func (n *CommentStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/common_table_expr.go
+++ b/internal/sql/ast/pg/common_table_expr.go
@@ -1,0 +1,22 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CommonTableExpr struct {
+	Ctename          *string
+	Aliascolnames    *ast.List
+	Ctequery         ast.Node
+	Location         int
+	Cterecursive     bool
+	Cterefcount      int
+	Ctecolnames      *ast.List
+	Ctecoltypes      *ast.List
+	Ctecoltypmods    *ast.List
+	Ctecolcollations *ast.List
+}
+
+func (n *CommonTableExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/composite_type_stmt.go
+++ b/internal/sql/ast/pg/composite_type_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CompositeTypeStmt struct {
+	Typevar    *RangeVar
+	Coldeflist *ast.List
+}
+
+func (n *CompositeTypeStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/const.go
+++ b/internal/sql/ast/pg/const.go
@@ -1,0 +1,21 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type Const struct {
+	Xpr         ast.Node
+	Consttype   Oid
+	Consttypmod int32
+	Constcollid Oid
+	Constlen    int
+	Constvalue  Datum
+	Constisnull bool
+	Constbyval  bool
+	Location    int
+}
+
+func (n *Const) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/constr_type.go
+++ b/internal/sql/ast/pg/constr_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type ConstrType uint
+
+func (n *ConstrType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/constraint.go
+++ b/internal/sql/ast/pg/constraint.go
@@ -1,0 +1,38 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type Constraint struct {
+	Contype        ConstrType
+	Conname        *string
+	Deferrable     bool
+	Initdeferred   bool
+	Location       int
+	IsNoInherit    bool
+	RawExpr        ast.Node
+	CookedExpr     *string
+	GeneratedWhen  byte
+	Keys           *ast.List
+	Exclusions     *ast.List
+	Options        *ast.List
+	Indexname      *string
+	Indexspace     *string
+	AccessMethod   *string
+	WhereClause    ast.Node
+	Pktable        *RangeVar
+	FkAttrs        *ast.List
+	PkAttrs        *ast.List
+	FkMatchtype    byte
+	FkUpdAction    byte
+	FkDelAction    byte
+	OldConpfeqop   *ast.List
+	OldPktableOid  Oid
+	SkipValidation bool
+	InitiallyValid bool
+}
+
+func (n *Constraint) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/constraints_set_stmt.go
+++ b/internal/sql/ast/pg/constraints_set_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ConstraintsSetStmt struct {
+	Constraints *ast.List
+	Deferred    bool
+}
+
+func (n *ConstraintsSetStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/convert_rowtype_expr.go
+++ b/internal/sql/ast/pg/convert_rowtype_expr.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ConvertRowtypeExpr struct {
+	Xpr           ast.Node
+	Arg           ast.Node
+	Resulttype    Oid
+	Convertformat CoercionForm
+	Location      int
+}
+
+func (n *ConvertRowtypeExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/copy_stmt.go
+++ b/internal/sql/ast/pg/copy_stmt.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CopyStmt struct {
+	Relation  *RangeVar
+	Query     ast.Node
+	Attlist   *ast.List
+	IsFrom    bool
+	IsProgram bool
+	Filename  *string
+	Options   *ast.List
+}
+
+func (n *CopyStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_am_stmt.go
+++ b/internal/sql/ast/pg/create_am_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateAmStmt struct {
+	Amname      *string
+	HandlerName *ast.List
+	Amtype      byte
+}
+
+func (n *CreateAmStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_cast_stmt.go
+++ b/internal/sql/ast/pg/create_cast_stmt.go
@@ -1,0 +1,13 @@
+package pg
+
+type CreateCastStmt struct {
+	Sourcetype *TypeName
+	Targettype *TypeName
+	Func       *ObjectWithArgs
+	Context    CoercionContext
+	Inout      bool
+}
+
+func (n *CreateCastStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_conversion_stmt.go
+++ b/internal/sql/ast/pg/create_conversion_stmt.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateConversionStmt struct {
+	ConversionName  *ast.List
+	ForEncodingName *string
+	ToEncodingName  *string
+	FuncName        *ast.List
+	Def             bool
+}
+
+func (n *CreateConversionStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_domain_stmt.go
+++ b/internal/sql/ast/pg/create_domain_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateDomainStmt struct {
+	Domainname  *ast.List
+	TypeName    *TypeName
+	CollClause  *CollateClause
+	Constraints *ast.List
+}
+
+func (n *CreateDomainStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_enum_stmt.go
+++ b/internal/sql/ast/pg/create_enum_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateEnumStmt struct {
+	TypeName *ast.List
+	Vals     *ast.List
+}
+
+func (n *CreateEnumStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_event_trig_stmt.go
+++ b/internal/sql/ast/pg/create_event_trig_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateEventTrigStmt struct {
+	Trigname   *string
+	Eventname  *string
+	Whenclause *ast.List
+	Funcname   *ast.List
+}
+
+func (n *CreateEventTrigStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_extension_stmt.go
+++ b/internal/sql/ast/pg/create_extension_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateExtensionStmt struct {
+	Extname     *string
+	IfNotExists bool
+	Options     *ast.List
+}
+
+func (n *CreateExtensionStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_fdw_stmt.go
+++ b/internal/sql/ast/pg/create_fdw_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateFdwStmt struct {
+	Fdwname     *string
+	FuncOptions *ast.List
+	Options     *ast.List
+}
+
+func (n *CreateFdwStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_foreign_server_stmt.go
+++ b/internal/sql/ast/pg/create_foreign_server_stmt.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateForeignServerStmt struct {
+	Servername  *string
+	Servertype  *string
+	Version     *string
+	Fdwname     *string
+	IfNotExists bool
+	Options     *ast.List
+}
+
+func (n *CreateForeignServerStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_foreign_table_stmt.go
+++ b/internal/sql/ast/pg/create_foreign_table_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateForeignTableStmt struct {
+	Base       *CreateStmt
+	Servername *string
+	Options    *ast.List
+}
+
+func (n *CreateForeignTableStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_function_stmt.go
+++ b/internal/sql/ast/pg/create_function_stmt.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateFunctionStmt struct {
+	Replace    bool
+	Funcname   *ast.List
+	Parameters *ast.List
+	ReturnType *TypeName
+	Options    *ast.List
+	WithClause *ast.List
+}
+
+func (n *CreateFunctionStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_op_class_item.go
+++ b/internal/sql/ast/pg/create_op_class_item.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateOpClassItem struct {
+	Itemtype    int
+	Name        *ObjectWithArgs
+	Number      int
+	OrderFamily *ast.List
+	ClassArgs   *ast.List
+	Storedtype  *TypeName
+}
+
+func (n *CreateOpClassItem) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_op_class_stmt.go
+++ b/internal/sql/ast/pg/create_op_class_stmt.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateOpClassStmt struct {
+	Opclassname  *ast.List
+	Opfamilyname *ast.List
+	Amname       *string
+	Datatype     *TypeName
+	Items        *ast.List
+	IsDefault    bool
+}
+
+func (n *CreateOpClassStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_op_family_stmt.go
+++ b/internal/sql/ast/pg/create_op_family_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateOpFamilyStmt struct {
+	Opfamilyname *ast.List
+	Amname       *string
+}
+
+func (n *CreateOpFamilyStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_p_lang_stmt.go
+++ b/internal/sql/ast/pg/create_p_lang_stmt.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreatePLangStmt struct {
+	Replace     bool
+	Plname      *string
+	Plhandler   *ast.List
+	Plinline    *ast.List
+	Plvalidator *ast.List
+	Pltrusted   bool
+}
+
+func (n *CreatePLangStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_policy_stmt.go
+++ b/internal/sql/ast/pg/create_policy_stmt.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreatePolicyStmt struct {
+	PolicyName *string
+	Table      *RangeVar
+	CmdName    *string
+	Permissive bool
+	Roles      *ast.List
+	Qual       ast.Node
+	WithCheck  ast.Node
+}
+
+func (n *CreatePolicyStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_publication_stmt.go
+++ b/internal/sql/ast/pg/create_publication_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreatePublicationStmt struct {
+	Pubname      *string
+	Options      *ast.List
+	Tables       *ast.List
+	ForAllTables bool
+}
+
+func (n *CreatePublicationStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_range_stmt.go
+++ b/internal/sql/ast/pg/create_range_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateRangeStmt struct {
+	TypeName *ast.List
+	Params   *ast.List
+}
+
+func (n *CreateRangeStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_role_stmt.go
+++ b/internal/sql/ast/pg/create_role_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateRoleStmt struct {
+	StmtType RoleStmtType
+	Role     *string
+	Options  *ast.List
+}
+
+func (n *CreateRoleStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_schema_stmt.go
+++ b/internal/sql/ast/pg/create_schema_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateSchemaStmt struct {
+	Schemaname  *string
+	Authrole    *RoleSpec
+	SchemaElts  *ast.List
+	IfNotExists bool
+}
+
+func (n *CreateSchemaStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_seq_stmt.go
+++ b/internal/sql/ast/pg/create_seq_stmt.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateSeqStmt struct {
+	Sequence    *RangeVar
+	Options     *ast.List
+	OwnerId     Oid
+	ForIdentity bool
+	IfNotExists bool
+}
+
+func (n *CreateSeqStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_stats_stmt.go
+++ b/internal/sql/ast/pg/create_stats_stmt.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateStatsStmt struct {
+	Defnames    *ast.List
+	StatTypes   *ast.List
+	Exprs       *ast.List
+	Relations   *ast.List
+	IfNotExists bool
+}
+
+func (n *CreateStatsStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_stmt.go
+++ b/internal/sql/ast/pg/create_stmt.go
@@ -1,0 +1,23 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateStmt struct {
+	Relation       *RangeVar
+	TableElts      *ast.List
+	InhRelations   *ast.List
+	Partbound      *PartitionBoundSpec
+	Partspec       *PartitionSpec
+	OfTypename     *TypeName
+	Constraints    *ast.List
+	Options        *ast.List
+	Oncommit       OnCommitAction
+	Tablespacename *string
+	IfNotExists    bool
+}
+
+func (n *CreateStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_subscription_stmt.go
+++ b/internal/sql/ast/pg/create_subscription_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateSubscriptionStmt struct {
+	Subname     *string
+	Conninfo    *string
+	Publication *ast.List
+	Options     *ast.List
+}
+
+func (n *CreateSubscriptionStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_table_as_stmt.go
+++ b/internal/sql/ast/pg/create_table_as_stmt.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateTableAsStmt struct {
+	Query        ast.Node
+	Into         *IntoClause
+	Relkind      ObjectType
+	IsSelectInto bool
+	IfNotExists  bool
+}
+
+func (n *CreateTableAsStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_table_space_stmt.go
+++ b/internal/sql/ast/pg/create_table_space_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateTableSpaceStmt struct {
+	Tablespacename *string
+	Owner          *RoleSpec
+	Location       *string
+	Options        *ast.List
+}
+
+func (n *CreateTableSpaceStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_transform_stmt.go
+++ b/internal/sql/ast/pg/create_transform_stmt.go
@@ -1,0 +1,13 @@
+package pg
+
+type CreateTransformStmt struct {
+	Replace  bool
+	TypeName *TypeName
+	Lang     *string
+	Fromsql  *ObjectWithArgs
+	Tosql    *ObjectWithArgs
+}
+
+func (n *CreateTransformStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_trig_stmt.go
+++ b/internal/sql/ast/pg/create_trig_stmt.go
@@ -1,0 +1,26 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateTrigStmt struct {
+	Trigname       *string
+	Relation       *RangeVar
+	Funcname       *ast.List
+	Args           *ast.List
+	Row            bool
+	Timing         int16
+	Events         int16
+	Columns        *ast.List
+	WhenClause     ast.Node
+	Isconstraint   bool
+	TransitionRels *ast.List
+	Deferrable     bool
+	Initdeferred   bool
+	Constrrel      *RangeVar
+}
+
+func (n *CreateTrigStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/create_user_mapping_stmt.go
+++ b/internal/sql/ast/pg/create_user_mapping_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreateUserMappingStmt struct {
+	User        *RoleSpec
+	Servername  *string
+	IfNotExists bool
+	Options     *ast.List
+}
+
+func (n *CreateUserMappingStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/createdb_stmt.go
+++ b/internal/sql/ast/pg/createdb_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CreatedbStmt struct {
+	Dbname  *string
+	Options *ast.List
+}
+
+func (n *CreatedbStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/current_of_expr.go
+++ b/internal/sql/ast/pg/current_of_expr.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type CurrentOfExpr struct {
+	Xpr         ast.Node
+	Cvarno      Index
+	CursorName  *string
+	CursorParam int
+}
+
+func (n *CurrentOfExpr) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/deallocate_stmt.go
+++ b/internal/sql/ast/pg/deallocate_stmt.go
@@ -1,0 +1,9 @@
+package pg
+
+type DeallocateStmt struct {
+	Name *string
+}
+
+func (n *DeallocateStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/declare_cursor_stmt.go
+++ b/internal/sql/ast/pg/declare_cursor_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type DeclareCursorStmt struct {
+	Portalname *string
+	Options    int
+	Query      ast.Node
+}
+
+func (n *DeclareCursorStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/def_elem.go
+++ b/internal/sql/ast/pg/def_elem.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type DefElem struct {
+	Defnamespace *string
+	Defname      *string
+	Arg          ast.Node
+	Defaction    DefElemAction
+	Location     int
+}
+
+func (n *DefElem) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/def_elem_action.go
+++ b/internal/sql/ast/pg/def_elem_action.go
@@ -1,0 +1,7 @@
+package pg
+
+type DefElemAction uint
+
+func (n *DefElemAction) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/define_stmt.go
+++ b/internal/sql/ast/pg/define_stmt.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type DefineStmt struct {
+	Kind        ObjectType
+	Oldstyle    bool
+	Defnames    *ast.List
+	Args        *ast.List
+	Definition  *ast.List
+	IfNotExists bool
+}
+
+func (n *DefineStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/delete_stmt.go
+++ b/internal/sql/ast/pg/delete_stmt.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type DeleteStmt struct {
+	Relation      *RangeVar
+	UsingClause   *ast.List
+	WhereClause   ast.Node
+	ReturningList *ast.List
+	WithClause    *WithClause
+}
+
+func (n *DeleteStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/discard_mode.go
+++ b/internal/sql/ast/pg/discard_mode.go
@@ -1,0 +1,7 @@
+package pg
+
+type DiscardMode uint
+
+func (n *DiscardMode) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/discard_stmt.go
+++ b/internal/sql/ast/pg/discard_stmt.go
@@ -1,0 +1,9 @@
+package pg
+
+type DiscardStmt struct {
+	Target DiscardMode
+}
+
+func (n *DiscardStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/do_stmt.go
+++ b/internal/sql/ast/pg/do_stmt.go
@@ -1,0 +1,13 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type DoStmt struct {
+	Args *ast.List
+}
+
+func (n *DoStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/drop_behavior.go
+++ b/internal/sql/ast/pg/drop_behavior.go
@@ -1,0 +1,7 @@
+package pg
+
+type DropBehavior uint
+
+func (n *DropBehavior) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/drop_owned_stmt.go
+++ b/internal/sql/ast/pg/drop_owned_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type DropOwnedStmt struct {
+	Roles    *ast.List
+	Behavior DropBehavior
+}
+
+func (n *DropOwnedStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/drop_role_stmt.go
+++ b/internal/sql/ast/pg/drop_role_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type DropRoleStmt struct {
+	Roles     *ast.List
+	MissingOk bool
+}
+
+func (n *DropRoleStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/drop_stmt.go
+++ b/internal/sql/ast/pg/drop_stmt.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type DropStmt struct {
+	Objects    *ast.List
+	RemoveType ObjectType
+	Behavior   DropBehavior
+	MissingOk  bool
+	Concurrent bool
+}
+
+func (n *DropStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/drop_subscription_stmt.go
+++ b/internal/sql/ast/pg/drop_subscription_stmt.go
@@ -1,0 +1,11 @@
+package pg
+
+type DropSubscriptionStmt struct {
+	Subname   *string
+	MissingOk bool
+	Behavior  DropBehavior
+}
+
+func (n *DropSubscriptionStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/drop_table_space_stmt.go
+++ b/internal/sql/ast/pg/drop_table_space_stmt.go
@@ -1,0 +1,10 @@
+package pg
+
+type DropTableSpaceStmt struct {
+	Tablespacename *string
+	MissingOk      bool
+}
+
+func (n *DropTableSpaceStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/drop_user_mapping_stmt.go
+++ b/internal/sql/ast/pg/drop_user_mapping_stmt.go
@@ -1,0 +1,11 @@
+package pg
+
+type DropUserMappingStmt struct {
+	User       *RoleSpec
+	Servername *string
+	MissingOk  bool
+}
+
+func (n *DropUserMappingStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/dropdb_stmt.go
+++ b/internal/sql/ast/pg/dropdb_stmt.go
@@ -1,0 +1,10 @@
+package pg
+
+type DropdbStmt struct {
+	Dbname    *string
+	MissingOk bool
+}
+
+func (n *DropdbStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/execute_stmt.go
+++ b/internal/sql/ast/pg/execute_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ExecuteStmt struct {
+	Name   *string
+	Params *ast.List
+}
+
+func (n *ExecuteStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/explain_stmt.go
+++ b/internal/sql/ast/pg/explain_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ExplainStmt struct {
+	Query   ast.Node
+	Options *ast.List
+}
+
+func (n *ExplainStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/expr.go
+++ b/internal/sql/ast/pg/expr.go
@@ -1,0 +1,8 @@
+package pg
+
+type Expr struct {
+}
+
+func (n *Expr) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/fetch_direction.go
+++ b/internal/sql/ast/pg/fetch_direction.go
@@ -1,0 +1,7 @@
+package pg
+
+type FetchDirection uint
+
+func (n *FetchDirection) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/fetch_stmt.go
+++ b/internal/sql/ast/pg/fetch_stmt.go
@@ -1,0 +1,12 @@
+package pg
+
+type FetchStmt struct {
+	Direction  FetchDirection
+	HowMany    int64
+	Portalname *string
+	Ismove     bool
+}
+
+func (n *FetchStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/field_select.go
+++ b/internal/sql/ast/pg/field_select.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type FieldSelect struct {
+	Xpr          ast.Node
+	Arg          ast.Node
+	Fieldnum     AttrNumber
+	Resulttype   Oid
+	Resulttypmod int32
+	Resultcollid Oid
+}
+
+func (n *FieldSelect) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/field_store.go
+++ b/internal/sql/ast/pg/field_store.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type FieldStore struct {
+	Xpr        ast.Node
+	Arg        ast.Node
+	Newvals    *ast.List
+	Fieldnums  *ast.List
+	Resulttype Oid
+}
+
+func (n *FieldStore) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/float.go
+++ b/internal/sql/ast/pg/float.go
@@ -1,0 +1,9 @@
+package pg
+
+type Float struct {
+	Str string
+}
+
+func (n *Float) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/from_expr.go
+++ b/internal/sql/ast/pg/from_expr.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type FromExpr struct {
+	Fromlist *ast.List
+	Quals    ast.Node
+}
+
+func (n *FromExpr) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/func_call.go
+++ b/internal/sql/ast/pg/func_call.go
@@ -1,0 +1,22 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type FuncCall struct {
+	Funcname       *ast.List
+	Args           *ast.List
+	AggOrder       *ast.List
+	AggFilter      ast.Node
+	AggWithinGroup bool
+	AggStar        bool
+	AggDistinct    bool
+	FuncVariadic   bool
+	Over           *WindowDef
+	Location       int
+}
+
+func (n *FuncCall) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/func_expr.go
+++ b/internal/sql/ast/pg/func_expr.go
@@ -1,0 +1,22 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type FuncExpr struct {
+	Xpr            ast.Node
+	Funcid         Oid
+	Funcresulttype Oid
+	Funcretset     bool
+	Funcvariadic   bool
+	Funcformat     CoercionForm
+	Funccollid     Oid
+	Inputcollid    Oid
+	Args           *ast.List
+	Location       int
+}
+
+func (n *FuncExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/function_parameter.go
+++ b/internal/sql/ast/pg/function_parameter.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type FunctionParameter struct {
+	Name    *string
+	ArgType *TypeName
+	Mode    FunctionParameterMode
+	Defexpr ast.Node
+}
+
+func (n *FunctionParameter) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/function_parameter_mode.go
+++ b/internal/sql/ast/pg/function_parameter_mode.go
@@ -1,0 +1,7 @@
+package pg
+
+type FunctionParameterMode uint
+
+func (n *FunctionParameterMode) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/grant_object_type.go
+++ b/internal/sql/ast/pg/grant_object_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type GrantObjectType uint
+
+func (n *GrantObjectType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/grant_role_stmt.go
+++ b/internal/sql/ast/pg/grant_role_stmt.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type GrantRoleStmt struct {
+	GrantedRoles *ast.List
+	GranteeRoles *ast.List
+	IsGrant      bool
+	AdminOpt     bool
+	Grantor      *RoleSpec
+	Behavior     DropBehavior
+}
+
+func (n *GrantRoleStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/grant_stmt.go
+++ b/internal/sql/ast/pg/grant_stmt.go
@@ -1,0 +1,20 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type GrantStmt struct {
+	IsGrant     bool
+	Targtype    GrantTargetType
+	Objtype     GrantObjectType
+	Objects     *ast.List
+	Privileges  *ast.List
+	Grantees    *ast.List
+	GrantOption bool
+	Behavior    DropBehavior
+}
+
+func (n *GrantStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/grant_target_type.go
+++ b/internal/sql/ast/pg/grant_target_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type GrantTargetType uint
+
+func (n *GrantTargetType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/grouping_func.go
+++ b/internal/sql/ast/pg/grouping_func.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type GroupingFunc struct {
+	Xpr         ast.Node
+	Args        *ast.List
+	Refs        *ast.List
+	Cols        *ast.List
+	Agglevelsup Index
+	Location    int
+}
+
+func (n *GroupingFunc) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/grouping_set.go
+++ b/internal/sql/ast/pg/grouping_set.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type GroupingSet struct {
+	Kind     GroupingSetKind
+	Content  *ast.List
+	Location int
+}
+
+func (n *GroupingSet) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/grouping_set_kind.go
+++ b/internal/sql/ast/pg/grouping_set_kind.go
@@ -1,0 +1,7 @@
+package pg
+
+type GroupingSetKind uint
+
+func (n *GroupingSetKind) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/import_foreign_schema_stmt.go
+++ b/internal/sql/ast/pg/import_foreign_schema_stmt.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ImportForeignSchemaStmt struct {
+	ServerName   *string
+	RemoteSchema *string
+	LocalSchema  *string
+	ListType     ImportForeignSchemaType
+	TableList    *ast.List
+	Options      *ast.List
+}
+
+func (n *ImportForeignSchemaStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/import_foreign_schema_type.go
+++ b/internal/sql/ast/pg/import_foreign_schema_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type ImportForeignSchemaType uint
+
+func (n *ImportForeignSchemaType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/index_elem.go
+++ b/internal/sql/ast/pg/index_elem.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type IndexElem struct {
+	Name          *string
+	Expr          ast.Node
+	Indexcolname  *string
+	Collation     *ast.List
+	Opclass       *ast.List
+	Ordering      SortByDir
+	NullsOrdering SortByNulls
+}
+
+func (n *IndexElem) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/index_stmt.go
+++ b/internal/sql/ast/pg/index_stmt.go
@@ -1,0 +1,31 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type IndexStmt struct {
+	Idxname        *string
+	Relation       *RangeVar
+	AccessMethod   *string
+	TableSpace     *string
+	IndexParams    *ast.List
+	Options        *ast.List
+	WhereClause    ast.Node
+	ExcludeOpNames *ast.List
+	Idxcomment     *string
+	IndexOid       Oid
+	OldNode        Oid
+	Unique         bool
+	Primary        bool
+	Isconstraint   bool
+	Deferrable     bool
+	Initdeferred   bool
+	Transformed    bool
+	Concurrent     bool
+	IfNotExists    bool
+}
+
+func (n *IndexStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/infer_clause.go
+++ b/internal/sql/ast/pg/infer_clause.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type InferClause struct {
+	IndexElems  *ast.List
+	WhereClause ast.Node
+	Conname     *string
+	Location    int
+}
+
+func (n *InferClause) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/inference_elem.go
+++ b/internal/sql/ast/pg/inference_elem.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type InferenceElem struct {
+	Xpr          ast.Node
+	Expr         ast.Node
+	Infercollid  Oid
+	Inferopclass Oid
+}
+
+func (n *InferenceElem) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/inline_code_block.go
+++ b/internal/sql/ast/pg/inline_code_block.go
@@ -1,0 +1,11 @@
+package pg
+
+type InlineCodeBlock struct {
+	SourceText    *string
+	LangOid       Oid
+	LangIsTrusted bool
+}
+
+func (n *InlineCodeBlock) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/insert_stmt.go
+++ b/internal/sql/ast/pg/insert_stmt.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type InsertStmt struct {
+	Relation         *RangeVar
+	Cols             *ast.List
+	SelectStmt       ast.Node
+	OnConflictClause *OnConflictClause
+	ReturningList    *ast.List
+	WithClause       *WithClause
+	Override         OverridingKind
+}
+
+func (n *InsertStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/integer.go
+++ b/internal/sql/ast/pg/integer.go
@@ -1,0 +1,9 @@
+package pg
+
+type Integer struct {
+	Ival int64
+}
+
+func (n *Integer) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/into_clause.go
+++ b/internal/sql/ast/pg/into_clause.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type IntoClause struct {
+	Rel            *RangeVar
+	ColNames       *ast.List
+	Options        *ast.List
+	OnCommit       OnCommitAction
+	TableSpaceName *string
+	ViewQuery      ast.Node
+	SkipData       bool
+}
+
+func (n *IntoClause) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/join_expr.go
+++ b/internal/sql/ast/pg/join_expr.go
@@ -1,0 +1,20 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type JoinExpr struct {
+	Jointype    JoinType
+	IsNatural   bool
+	Larg        ast.Node
+	Rarg        ast.Node
+	UsingClause *ast.List
+	Quals       ast.Node
+	Alias       *Alias
+	Rtindex     int
+}
+
+func (n *JoinExpr) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/join_type.go
+++ b/internal/sql/ast/pg/join_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type JoinType uint
+
+func (n *JoinType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/listen_stmt.go
+++ b/internal/sql/ast/pg/listen_stmt.go
@@ -1,0 +1,9 @@
+package pg
+
+type ListenStmt struct {
+	Conditionname *string
+}
+
+func (n *ListenStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/load_stmt.go
+++ b/internal/sql/ast/pg/load_stmt.go
@@ -1,0 +1,9 @@
+package pg
+
+type LoadStmt struct {
+	Filename *string
+}
+
+func (n *LoadStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/lock_clause_strength.go
+++ b/internal/sql/ast/pg/lock_clause_strength.go
@@ -1,0 +1,7 @@
+package pg
+
+type LockClauseStrength uint
+
+func (n *LockClauseStrength) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/lock_stmt.go
+++ b/internal/sql/ast/pg/lock_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type LockStmt struct {
+	Relations *ast.List
+	Mode      int
+	Nowait    bool
+}
+
+func (n *LockStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/lock_wait_policy.go
+++ b/internal/sql/ast/pg/lock_wait_policy.go
@@ -1,0 +1,7 @@
+package pg
+
+type LockWaitPolicy uint
+
+func (n *LockWaitPolicy) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/locking_clause.go
+++ b/internal/sql/ast/pg/locking_clause.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type LockingClause struct {
+	LockedRels *ast.List
+	Strength   LockClauseStrength
+	WaitPolicy LockWaitPolicy
+}
+
+func (n *LockingClause) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/min_max_expr.go
+++ b/internal/sql/ast/pg/min_max_expr.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type MinMaxExpr struct {
+	Xpr          ast.Node
+	Minmaxtype   Oid
+	Minmaxcollid Oid
+	Inputcollid  Oid
+	Op           MinMaxOp
+	Args         *ast.List
+	Location     int
+}
+
+func (n *MinMaxExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/min_max_op.go
+++ b/internal/sql/ast/pg/min_max_op.go
@@ -1,0 +1,7 @@
+package pg
+
+type MinMaxOp uint
+
+func (n *MinMaxOp) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/multi_assign_ref.go
+++ b/internal/sql/ast/pg/multi_assign_ref.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type MultiAssignRef struct {
+	Source   ast.Node
+	Colno    int
+	Ncolumns int
+}
+
+func (n *MultiAssignRef) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/named_arg_expr.go
+++ b/internal/sql/ast/pg/named_arg_expr.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type NamedArgExpr struct {
+	Xpr       ast.Node
+	Arg       ast.Node
+	Name      *string
+	Argnumber int
+	Location  int
+}
+
+func (n *NamedArgExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/next_value_expr.go
+++ b/internal/sql/ast/pg/next_value_expr.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type NextValueExpr struct {
+	Xpr    ast.Node
+	Seqid  Oid
+	TypeId Oid
+}
+
+func (n *NextValueExpr) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/notify_stmt.go
+++ b/internal/sql/ast/pg/notify_stmt.go
@@ -1,0 +1,10 @@
+package pg
+
+type NotifyStmt struct {
+	Conditionname *string
+	Payload       *string
+}
+
+func (n *NotifyStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/null.go
+++ b/internal/sql/ast/pg/null.go
@@ -1,0 +1,8 @@
+package pg
+
+type Null struct {
+}
+
+func (n *Null) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/null_test_expr.go
+++ b/internal/sql/ast/pg/null_test_expr.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type NullTest struct {
+	Xpr          ast.Node
+	Arg          ast.Node
+	Nulltesttype NullTestType
+	Argisrow     bool
+	Location     int
+}
+
+func (n *NullTest) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/null_test_type.go
+++ b/internal/sql/ast/pg/null_test_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type NullTestType uint
+
+func (n *NullTestType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/object_type.go
+++ b/internal/sql/ast/pg/object_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type ObjectType uint
+
+func (n *ObjectType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/object_with_args.go
+++ b/internal/sql/ast/pg/object_with_args.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ObjectWithArgs struct {
+	Objname         *ast.List
+	Objargs         *ast.List
+	ArgsUnspecified bool
+}
+
+func (n *ObjectWithArgs) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/on_commit_action.go
+++ b/internal/sql/ast/pg/on_commit_action.go
@@ -1,0 +1,7 @@
+package pg
+
+type OnCommitAction uint
+
+func (n *OnCommitAction) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/on_conflict_action.go
+++ b/internal/sql/ast/pg/on_conflict_action.go
@@ -1,0 +1,7 @@
+package pg
+
+type OnConflictAction uint
+
+func (n *OnConflictAction) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/on_conflict_clause.go
+++ b/internal/sql/ast/pg/on_conflict_clause.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type OnConflictClause struct {
+	Action      OnConflictAction
+	Infer       *InferClause
+	TargetList  *ast.List
+	WhereClause ast.Node
+	Location    int
+}
+
+func (n *OnConflictClause) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/on_conflict_expr.go
+++ b/internal/sql/ast/pg/on_conflict_expr.go
@@ -1,0 +1,20 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type OnConflictExpr struct {
+	Action          OnConflictAction
+	ArbiterElems    *ast.List
+	ArbiterWhere    ast.Node
+	Constraint      Oid
+	OnConflictSet   *ast.List
+	OnConflictWhere ast.Node
+	ExclRelIndex    int
+	ExclRelTlist    *ast.List
+}
+
+func (n *OnConflictExpr) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/op_expr.go
+++ b/internal/sql/ast/pg/op_expr.go
@@ -1,0 +1,21 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type OpExpr struct {
+	Xpr          ast.Node
+	Opno         Oid
+	Opfuncid     Oid
+	Opresulttype Oid
+	Opretset     bool
+	Opcollid     Oid
+	Inputcollid  Oid
+	Args         *ast.List
+	Location     int
+}
+
+func (n *OpExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/overriding_kind.go
+++ b/internal/sql/ast/pg/overriding_kind.go
@@ -1,0 +1,7 @@
+package pg
+
+type OverridingKind uint
+
+func (n *OverridingKind) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/param.go
+++ b/internal/sql/ast/pg/param.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type Param struct {
+	Xpr         ast.Node
+	Paramkind   ParamKind
+	Paramid     int
+	Paramtype   Oid
+	Paramtypmod int32
+	Paramcollid Oid
+	Location    int
+}
+
+func (n *Param) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/param_exec_data.go
+++ b/internal/sql/ast/pg/param_exec_data.go
@@ -1,0 +1,11 @@
+package pg
+
+type ParamExecData struct {
+	ExecPlan interface{}
+	Value    Datum
+	Isnull   bool
+}
+
+func (n *ParamExecData) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/param_extern_data.go
+++ b/internal/sql/ast/pg/param_extern_data.go
@@ -1,0 +1,12 @@
+package pg
+
+type ParamExternData struct {
+	Value  Datum
+	Isnull bool
+	Pflags uint16
+	Ptype  Oid
+}
+
+func (n *ParamExternData) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/param_kind.go
+++ b/internal/sql/ast/pg/param_kind.go
@@ -1,0 +1,7 @@
+package pg
+
+type ParamKind uint
+
+func (n *ParamKind) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/param_list_info_data.go
+++ b/internal/sql/ast/pg/param_list_info_data.go
@@ -1,0 +1,12 @@
+package pg
+
+type ParamListInfoData struct {
+	ParamFetchArg  interface{}
+	ParserSetupArg interface{}
+	NumParams      int
+	ParamMask      []uint32
+}
+
+func (n *ParamListInfoData) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/param_ref.go
+++ b/internal/sql/ast/pg/param_ref.go
@@ -1,0 +1,10 @@
+package pg
+
+type ParamRef struct {
+	Number   int
+	Location int
+}
+
+func (n *ParamRef) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/partition_bound_spec.go
+++ b/internal/sql/ast/pg/partition_bound_spec.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type PartitionBoundSpec struct {
+	Strategy    byte
+	Listdatums  *ast.List
+	Lowerdatums *ast.List
+	Upperdatums *ast.List
+	Location    int
+}
+
+func (n *PartitionBoundSpec) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/partition_cmd.go
+++ b/internal/sql/ast/pg/partition_cmd.go
@@ -1,0 +1,10 @@
+package pg
+
+type PartitionCmd struct {
+	Name  *RangeVar
+	Bound *PartitionBoundSpec
+}
+
+func (n *PartitionCmd) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/partition_elem.go
+++ b/internal/sql/ast/pg/partition_elem.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type PartitionElem struct {
+	Name      *string
+	Expr      ast.Node
+	Collation *ast.List
+	Opclass   *ast.List
+	Location  int
+}
+
+func (n *PartitionElem) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/partition_range_datum.go
+++ b/internal/sql/ast/pg/partition_range_datum.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type PartitionRangeDatum struct {
+	Kind     PartitionRangeDatumKind
+	Value    ast.Node
+	Location int
+}
+
+func (n *PartitionRangeDatum) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/partition_range_datum_kind.go
+++ b/internal/sql/ast/pg/partition_range_datum_kind.go
@@ -1,0 +1,7 @@
+package pg
+
+type PartitionRangeDatumKind uint
+
+func (n *PartitionRangeDatumKind) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/partition_spec.go
+++ b/internal/sql/ast/pg/partition_spec.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type PartitionSpec struct {
+	Strategy   *string
+	PartParams *ast.List
+	Location   int
+}
+
+func (n *PartitionSpec) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/prepare_stmt.go
+++ b/internal/sql/ast/pg/prepare_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type PrepareStmt struct {
+	Name     *string
+	Argtypes *ast.List
+	Query    ast.Node
+}
+
+func (n *PrepareStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/query.go
+++ b/internal/sql/ast/pg/query.go
@@ -1,0 +1,48 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type Query struct {
+	CommandType      CmdType
+	QuerySource      QuerySource
+	QueryId          uint32
+	CanSetTag        bool
+	UtilityStmt      ast.Node
+	ResultRelation   int
+	HasAggs          bool
+	HasWindowFuncs   bool
+	HasTargetSrfs    bool
+	HasSubLinks      bool
+	HasDistinctOn    bool
+	HasRecursive     bool
+	HasModifyingCte  bool
+	HasForUpdate     bool
+	HasRowSecurity   bool
+	CteList          *ast.List
+	Rtable           *ast.List
+	Jointree         *FromExpr
+	TargetList       *ast.List
+	Override         OverridingKind
+	OnConflict       *OnConflictExpr
+	ReturningList    *ast.List
+	GroupClause      *ast.List
+	GroupingSets     *ast.List
+	HavingQual       ast.Node
+	WindowClause     *ast.List
+	DistinctClause   *ast.List
+	SortClause       *ast.List
+	LimitOffset      ast.Node
+	LimitCount       ast.Node
+	RowMarks         *ast.List
+	SetOperations    ast.Node
+	ConstraintDeps   *ast.List
+	WithCheckOptions *ast.List
+	StmtLocation     int
+	StmtLen          int
+}
+
+func (n *Query) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/query_source.go
+++ b/internal/sql/ast/pg/query_source.go
@@ -1,0 +1,7 @@
+package pg
+
+type QuerySource uint
+
+func (n *QuerySource) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/range_function.go
+++ b/internal/sql/ast/pg/range_function.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type RangeFunction struct {
+	Lateral    bool
+	Ordinality bool
+	IsRowsfrom bool
+	Functions  *ast.List
+	Alias      *Alias
+	Coldeflist *ast.List
+}
+
+func (n *RangeFunction) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/range_subselect.go
+++ b/internal/sql/ast/pg/range_subselect.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type RangeSubselect struct {
+	Lateral  bool
+	Subquery ast.Node
+	Alias    *Alias
+}
+
+func (n *RangeSubselect) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/range_table_func.go
+++ b/internal/sql/ast/pg/range_table_func.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type RangeTableFunc struct {
+	Lateral    bool
+	Docexpr    ast.Node
+	Rowexpr    ast.Node
+	Namespaces *ast.List
+	Columns    *ast.List
+	Alias      *Alias
+	Location   int
+}
+
+func (n *RangeTableFunc) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/range_table_func_col.go
+++ b/internal/sql/ast/pg/range_table_func_col.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type RangeTableFuncCol struct {
+	Colname       *string
+	TypeName      *TypeName
+	ForOrdinality bool
+	IsNotNull     bool
+	Colexpr       ast.Node
+	Coldefexpr    ast.Node
+	Location      int
+}
+
+func (n *RangeTableFuncCol) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/range_table_sample.go
+++ b/internal/sql/ast/pg/range_table_sample.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type RangeTableSample struct {
+	Relation   ast.Node
+	Method     *ast.List
+	Args       *ast.List
+	Repeatable ast.Node
+	Location   int
+}
+
+func (n *RangeTableSample) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/range_tbl_entry.go
+++ b/internal/sql/ast/pg/range_tbl_entry.go
@@ -1,0 +1,43 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type RangeTblEntry struct {
+	Rtekind         RTEKind
+	Relid           Oid
+	Relkind         byte
+	Tablesample     *TableSampleClause
+	Subquery        *Query
+	SecurityBarrier bool
+	Jointype        JoinType
+	Joinaliasvars   *ast.List
+	Functions       *ast.List
+	Funcordinality  bool
+	Tablefunc       *TableFunc
+	ValuesLists     *ast.List
+	Ctename         *string
+	Ctelevelsup     Index
+	SelfReference   bool
+	Coltypes        *ast.List
+	Coltypmods      *ast.List
+	Colcollations   *ast.List
+	Enrname         *string
+	Enrtuples       float64
+	Alias           *Alias
+	Eref            *Alias
+	Lateral         bool
+	Inh             bool
+	InFromCl        bool
+	RequiredPerms   AclMode
+	CheckAsUser     Oid
+	SelectedCols    []uint32
+	InsertedCols    []uint32
+	UpdatedCols     []uint32
+	SecurityQuals   *ast.List
+}
+
+func (n *RangeTblEntry) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/range_tbl_function.go
+++ b/internal/sql/ast/pg/range_tbl_function.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type RangeTblFunction struct {
+	Funcexpr          ast.Node
+	Funccolcount      int
+	Funccolnames      *ast.List
+	Funccoltypes      *ast.List
+	Funccoltypmods    *ast.List
+	Funccolcollations *ast.List
+	Funcparams        []uint32
+}
+
+func (n *RangeTblFunction) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/range_tbl_ref.go
+++ b/internal/sql/ast/pg/range_tbl_ref.go
@@ -1,0 +1,9 @@
+package pg
+
+type RangeTblRef struct {
+	Rtindex int
+}
+
+func (n *RangeTblRef) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/range_var.go
+++ b/internal/sql/ast/pg/range_var.go
@@ -1,0 +1,15 @@
+package pg
+
+type RangeVar struct {
+	Catalogname    *string
+	Schemaname     *string
+	Relname        *string
+	Inh            bool
+	Relpersistence byte
+	Alias          *Alias
+	Location       int
+}
+
+func (n *RangeVar) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/raw_stmt.go
+++ b/internal/sql/ast/pg/raw_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type RawStmt struct {
+	Stmt         ast.Node
+	StmtLocation int
+	StmtLen      int
+}
+
+func (n *RawStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/reassign_owned_stmt.go
+++ b/internal/sql/ast/pg/reassign_owned_stmt.go
@@ -1,0 +1,14 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ReassignOwnedStmt struct {
+	Roles   *ast.List
+	Newrole *RoleSpec
+}
+
+func (n *ReassignOwnedStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/refresh_mat_view_stmt.go
+++ b/internal/sql/ast/pg/refresh_mat_view_stmt.go
@@ -1,0 +1,11 @@
+package pg
+
+type RefreshMatViewStmt struct {
+	Concurrent bool
+	SkipData   bool
+	Relation   *RangeVar
+}
+
+func (n *RefreshMatViewStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/reindex_object_type.go
+++ b/internal/sql/ast/pg/reindex_object_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type ReindexObjectType uint
+
+func (n *ReindexObjectType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/reindex_stmt.go
+++ b/internal/sql/ast/pg/reindex_stmt.go
@@ -1,0 +1,12 @@
+package pg
+
+type ReindexStmt struct {
+	Kind     ReindexObjectType
+	Relation *RangeVar
+	Name     *string
+	Options  int
+}
+
+func (n *ReindexStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/relabel_type.go
+++ b/internal/sql/ast/pg/relabel_type.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type RelabelType struct {
+	Xpr           ast.Node
+	Arg           ast.Node
+	Resulttype    Oid
+	Resulttypmod  int32
+	Resultcollid  Oid
+	Relabelformat CoercionForm
+	Location      int
+}
+
+func (n *RelabelType) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/rename_stmt.go
+++ b/internal/sql/ast/pg/rename_stmt.go
@@ -1,0 +1,20 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type RenameStmt struct {
+	RenameType   ObjectType
+	RelationType ObjectType
+	Relation     *RangeVar
+	Object       ast.Node
+	Subname      *string
+	Newname      *string
+	Behavior     DropBehavior
+	MissingOk    bool
+}
+
+func (n *RenameStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/replica_identity_stmt.go
+++ b/internal/sql/ast/pg/replica_identity_stmt.go
@@ -1,0 +1,10 @@
+package pg
+
+type ReplicaIdentityStmt struct {
+	IdentityType byte
+	Name         *string
+}
+
+func (n *ReplicaIdentityStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/res_target.go
+++ b/internal/sql/ast/pg/res_target.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ResTarget struct {
+	Name        *string
+	Indirection *ast.List
+	Val         ast.Node
+	Location    int
+}
+
+func (n *ResTarget) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/role_spec.go
+++ b/internal/sql/ast/pg/role_spec.go
@@ -1,0 +1,11 @@
+package pg
+
+type RoleSpec struct {
+	Roletype RoleSpecType
+	Rolename *string
+	Location int
+}
+
+func (n *RoleSpec) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/role_spec_type.go
+++ b/internal/sql/ast/pg/role_spec_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type RoleSpecType uint
+
+func (n *RoleSpecType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/role_stmt_type.go
+++ b/internal/sql/ast/pg/role_stmt_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type RoleStmtType uint
+
+func (n *RoleStmtType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/row_compare_expr.go
+++ b/internal/sql/ast/pg/row_compare_expr.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type RowCompareExpr struct {
+	Xpr          ast.Node
+	Rctype       RowCompareType
+	Opnos        *ast.List
+	Opfamilies   *ast.List
+	Inputcollids *ast.List
+	Largs        *ast.List
+	Rargs        *ast.List
+}
+
+func (n *RowCompareExpr) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/row_compare_type.go
+++ b/internal/sql/ast/pg/row_compare_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type RowCompareType uint
+
+func (n *RowCompareType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/row_expr.go
+++ b/internal/sql/ast/pg/row_expr.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type RowExpr struct {
+	Xpr       ast.Node
+	Args      *ast.List
+	RowTypeid Oid
+	RowFormat CoercionForm
+	Colnames  *ast.List
+	Location  int
+}
+
+func (n *RowExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/row_mark_clause.go
+++ b/internal/sql/ast/pg/row_mark_clause.go
@@ -1,0 +1,12 @@
+package pg
+
+type RowMarkClause struct {
+	Rti        Index
+	Strength   LockClauseStrength
+	WaitPolicy LockWaitPolicy
+	PushedDown bool
+}
+
+func (n *RowMarkClause) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/rte_kind.go
+++ b/internal/sql/ast/pg/rte_kind.go
@@ -1,0 +1,7 @@
+package pg
+
+type RTEKind uint
+
+func (n *RTEKind) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/rule_stmt.go
+++ b/internal/sql/ast/pg/rule_stmt.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type RuleStmt struct {
+	Relation    *RangeVar
+	Rulename    *string
+	WhereClause ast.Node
+	Event       CmdType
+	Instead     bool
+	Actions     *ast.List
+	Replace     bool
+}
+
+func (n *RuleStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/scalar_array_op_expr.go
+++ b/internal/sql/ast/pg/scalar_array_op_expr.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ScalarArrayOpExpr struct {
+	Xpr         ast.Node
+	Opno        Oid
+	Opfuncid    Oid
+	UseOr       bool
+	Inputcollid Oid
+	Args        *ast.List
+	Location    int
+}
+
+func (n *ScalarArrayOpExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/scan_direction.go
+++ b/internal/sql/ast/pg/scan_direction.go
@@ -1,0 +1,7 @@
+package pg
+
+type ScanDirection uint
+
+func (n *ScanDirection) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/sec_label_stmt.go
+++ b/internal/sql/ast/pg/sec_label_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type SecLabelStmt struct {
+	Objtype  ObjectType
+	Object   ast.Node
+	Provider *string
+	Label    *string
+}
+
+func (n *SecLabelStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/select_stmt.go
+++ b/internal/sql/ast/pg/select_stmt.go
@@ -1,0 +1,30 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type SelectStmt struct {
+	DistinctClause *ast.List
+	IntoClause     *IntoClause
+	TargetList     *ast.List
+	FromClause     *ast.List
+	WhereClause    ast.Node
+	GroupClause    *ast.List
+	HavingClause   ast.Node
+	WindowClause   *ast.List
+	ValuesLists    [][]ast.Node
+	SortClause     *ast.List
+	LimitOffset    ast.Node
+	LimitCount     ast.Node
+	LockingClause  *ast.List
+	WithClause     *WithClause
+	Op             SetOperation
+	All            bool
+	Larg           *SelectStmt
+	Rarg           *SelectStmt
+}
+
+func (n *SelectStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/set_op_cmd.go
+++ b/internal/sql/ast/pg/set_op_cmd.go
@@ -1,0 +1,7 @@
+package pg
+
+type SetOpCmd uint
+
+func (n *SetOpCmd) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/set_op_strategy.go
+++ b/internal/sql/ast/pg/set_op_strategy.go
@@ -1,0 +1,7 @@
+package pg
+
+type SetOpStrategy uint
+
+func (n *SetOpStrategy) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/set_operation.go
+++ b/internal/sql/ast/pg/set_operation.go
@@ -1,0 +1,7 @@
+package pg
+
+type SetOperation uint
+
+func (n *SetOperation) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/set_operation_stmt.go
+++ b/internal/sql/ast/pg/set_operation_stmt.go
@@ -1,0 +1,20 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type SetOperationStmt struct {
+	Op            SetOperation
+	All           bool
+	Larg          ast.Node
+	Rarg          ast.Node
+	ColTypes      *ast.List
+	ColTypmods    *ast.List
+	ColCollations *ast.List
+	GroupClauses  *ast.List
+}
+
+func (n *SetOperationStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/set_to_default.go
+++ b/internal/sql/ast/pg/set_to_default.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type SetToDefault struct {
+	Xpr       ast.Node
+	TypeId    Oid
+	TypeMod   int32
+	Collation Oid
+	Location  int
+}
+
+func (n *SetToDefault) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/sort_by.go
+++ b/internal/sql/ast/pg/sort_by.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type SortBy struct {
+	Node        ast.Node
+	SortbyDir   SortByDir
+	SortbyNulls SortByNulls
+	UseOp       *ast.List
+	Location    int
+}
+
+func (n *SortBy) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/sort_by_dir.go
+++ b/internal/sql/ast/pg/sort_by_dir.go
@@ -1,0 +1,7 @@
+package pg
+
+type SortByDir uint
+
+func (n *SortByDir) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/sort_by_nulls.go
+++ b/internal/sql/ast/pg/sort_by_nulls.go
@@ -1,0 +1,7 @@
+package pg
+
+type SortByNulls uint
+
+func (n *SortByNulls) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/sort_group_clause.go
+++ b/internal/sql/ast/pg/sort_group_clause.go
@@ -1,0 +1,13 @@
+package pg
+
+type SortGroupClause struct {
+	TleSortGroupRef Index
+	Eqop            Oid
+	Sortop          Oid
+	NullsFirst      bool
+	Hashable        bool
+}
+
+func (n *SortGroupClause) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/sql_value_function.go
+++ b/internal/sql/ast/pg/sql_value_function.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type SQLValueFunction struct {
+	Xpr      ast.Node
+	Op       SQLValueFunctionOp
+	Type     Oid
+	Typmod   int32
+	Location int
+}
+
+func (n *SQLValueFunction) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/sql_value_function_op.go
+++ b/internal/sql/ast/pg/sql_value_function_op.go
@@ -1,0 +1,7 @@
+package pg
+
+type SQLValueFunctionOp uint
+
+func (n *SQLValueFunctionOp) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/string.go
+++ b/internal/sql/ast/pg/string.go
@@ -1,0 +1,9 @@
+package pg
+
+type String struct {
+	Str string
+}
+
+func (n *String) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/sub_link.go
+++ b/internal/sql/ast/pg/sub_link.go
@@ -1,0 +1,19 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type SubLink struct {
+	Xpr         ast.Node
+	SubLinkType SubLinkType
+	SubLinkId   int
+	Testexpr    ast.Node
+	OperName    *ast.List
+	Subselect   ast.Node
+	Location    int
+}
+
+func (n *SubLink) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/sub_link_type.go
+++ b/internal/sql/ast/pg/sub_link_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type SubLinkType uint
+
+func (n *SubLinkType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/sub_plan.go
+++ b/internal/sql/ast/pg/sub_plan.go
@@ -1,0 +1,29 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type SubPlan struct {
+	Xpr               ast.Node
+	SubLinkType       SubLinkType
+	Testexpr          ast.Node
+	ParamIds          *ast.List
+	PlanId            int
+	PlanName          *string
+	FirstColType      Oid
+	FirstColTypmod    int32
+	FirstColCollation Oid
+	UseHashTable      bool
+	UnknownEqFalse    bool
+	ParallelSafe      bool
+	SetParam          *ast.List
+	ParParam          *ast.List
+	Args              *ast.List
+	StartupCost       Cost
+	PerCallCost       Cost
+}
+
+func (n *SubPlan) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/table_func.go
+++ b/internal/sql/ast/pg/table_func.go
@@ -1,0 +1,25 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type TableFunc struct {
+	NsUris        *ast.List
+	NsNames       *ast.List
+	Docexpr       ast.Node
+	Rowexpr       ast.Node
+	Colnames      *ast.List
+	Coltypes      *ast.List
+	Coltypmods    *ast.List
+	Colcollations *ast.List
+	Colexprs      *ast.List
+	Coldefexprs   *ast.List
+	Notnulls      []uint32
+	Ordinalitycol int
+	Location      int
+}
+
+func (n *TableFunc) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/table_like_clause.go
+++ b/internal/sql/ast/pg/table_like_clause.go
@@ -1,0 +1,10 @@
+package pg
+
+type TableLikeClause struct {
+	Relation *RangeVar
+	Options  uint32
+}
+
+func (n *TableLikeClause) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/table_like_option.go
+++ b/internal/sql/ast/pg/table_like_option.go
@@ -1,0 +1,7 @@
+package pg
+
+type TableLikeOption uint
+
+func (n *TableLikeOption) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/table_sample_clause.go
+++ b/internal/sql/ast/pg/table_sample_clause.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type TableSampleClause struct {
+	Tsmhandler Oid
+	Args       *ast.List
+	Repeatable ast.Node
+}
+
+func (n *TableSampleClause) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/target_entry.go
+++ b/internal/sql/ast/pg/target_entry.go
@@ -1,0 +1,20 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type TargetEntry struct {
+	Xpr             ast.Node
+	Expr            ast.Node
+	Resno           AttrNumber
+	Resname         *string
+	Ressortgroupref Index
+	Resorigtbl      Oid
+	Resorigcol      AttrNumber
+	Resjunk         bool
+}
+
+func (n *TargetEntry) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/transaction_stmt.go
+++ b/internal/sql/ast/pg/transaction_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type TransactionStmt struct {
+	Kind    TransactionStmtKind
+	Options *ast.List
+	Gid     *string
+}
+
+func (n *TransactionStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/transaction_stmt_kind.go
+++ b/internal/sql/ast/pg/transaction_stmt_kind.go
@@ -1,0 +1,7 @@
+package pg
+
+type TransactionStmtKind uint
+
+func (n *TransactionStmtKind) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/trigger_transition.go
+++ b/internal/sql/ast/pg/trigger_transition.go
@@ -1,0 +1,11 @@
+package pg
+
+type TriggerTransition struct {
+	Name    *string
+	IsNew   bool
+	IsTable bool
+}
+
+func (n *TriggerTransition) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/truncate_stmt.go
+++ b/internal/sql/ast/pg/truncate_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type TruncateStmt struct {
+	Relations   *ast.List
+	RestartSeqs bool
+	Behavior    DropBehavior
+}
+
+func (n *TruncateStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/type_cast.go
+++ b/internal/sql/ast/pg/type_cast.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type TypeCast struct {
+	Arg      ast.Node
+	TypeName *TypeName
+	Location int
+}
+
+func (n *TypeCast) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/type_name.go
+++ b/internal/sql/ast/pg/type_name.go
@@ -1,0 +1,20 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type TypeName struct {
+	Names       *ast.List
+	TypeOid     Oid
+	Setof       bool
+	PctType     bool
+	Typmods     *ast.List
+	Typemod     int32
+	ArrayBounds *ast.List
+	Location    int
+}
+
+func (n *TypeName) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/typedefs.go
+++ b/internal/sql/ast/pg/typedefs.go
@@ -1,0 +1,139 @@
+package pg
+
+type AclMode uint32
+
+func (n *AclMode) Pos() int {
+	return 0
+}
+
+type DistinctExpr OpExpr
+
+func (n *DistinctExpr) Pos() int {
+	return 0
+}
+
+type NullIfExpr OpExpr
+
+func (n *NullIfExpr) Pos() int {
+	return 0
+}
+
+type Selectivity float64
+
+func (n *Selectivity) Pos() int {
+	return 0
+}
+
+type Cost float64
+
+func (n *Cost) Pos() int {
+	return 0
+}
+
+type ParamListInfo ParamListInfoData
+
+func (n *ParamListInfo) Pos() int {
+	return 0
+}
+
+type AttrNumber int16
+
+func (n *AttrNumber) Pos() int {
+	return 0
+}
+
+type Pointer byte
+
+func (n *Pointer) Pos() int {
+	return 0
+}
+
+type Index uint64
+
+func (n *Index) Pos() int {
+	return 0
+}
+
+type Offset int64
+
+func (n *Offset) Pos() int {
+	return 0
+}
+
+type regproc Oid
+
+func (n *regproc) Pos() int {
+	return 0
+}
+
+type RegProcedure regproc
+
+func (n *RegProcedure) Pos() int {
+	return 0
+}
+
+type TransactionId uint32
+
+func (n *TransactionId) Pos() int {
+	return 0
+}
+
+type LocalTransactionId uint32
+
+func (n *LocalTransactionId) Pos() int {
+	return 0
+}
+
+type SubTransactionId uint32
+
+func (n *SubTransactionId) Pos() int {
+	return 0
+}
+
+type MultiXactId TransactionId
+
+func (n *MultiXactId) Pos() int {
+	return 0
+}
+
+type MultiXactOffset uint32
+
+func (n *MultiXactOffset) Pos() int {
+	return 0
+}
+
+type CommandId uint32
+
+func (n *CommandId) Pos() int {
+	return 0
+}
+
+type Datum uintptr
+
+func (n *Datum) Pos() int {
+	return 0
+}
+
+type DatumPtr Datum
+
+func (n *DatumPtr) Pos() int {
+	return 0
+}
+
+type Oid uint64
+
+func (n *Oid) Pos() int {
+	return 0
+}
+
+type BlockNumber uint32
+
+func (n *BlockNumber) Pos() int {
+	return 0
+}
+
+type BlockId BlockIdData
+
+func (n *BlockId) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/unlisten_stmt.go
+++ b/internal/sql/ast/pg/unlisten_stmt.go
@@ -1,0 +1,9 @@
+package pg
+
+type UnlistenStmt struct {
+	Conditionname *string
+}
+
+func (n *UnlistenStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/update_stmt.go
+++ b/internal/sql/ast/pg/update_stmt.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type UpdateStmt struct {
+	Relation      *RangeVar
+	TargetList    *ast.List
+	WhereClause   ast.Node
+	FromClause    *ast.List
+	ReturningList *ast.List
+	WithClause    *WithClause
+}
+
+func (n *UpdateStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/vacuum_option.go
+++ b/internal/sql/ast/pg/vacuum_option.go
@@ -1,0 +1,7 @@
+package pg
+
+type VacuumOption uint
+
+func (n *VacuumOption) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/vacuum_stmt.go
+++ b/internal/sql/ast/pg/vacuum_stmt.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type VacuumStmt struct {
+	Options  int
+	Relation *RangeVar
+	VaCols   *ast.List
+}
+
+func (n *VacuumStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/var.go
+++ b/internal/sql/ast/pg/var.go
@@ -1,0 +1,22 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type Var struct {
+	Xpr         ast.Node
+	Varno       Index
+	Varattno    AttrNumber
+	Vartype     Oid
+	Vartypmod   int32
+	Varcollid   Oid
+	Varlevelsup Index
+	Varnoold    Index
+	Varoattno   AttrNumber
+	Location    int
+}
+
+func (n *Var) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/varatt_external.go
+++ b/internal/sql/ast/pg/varatt_external.go
@@ -1,0 +1,12 @@
+package pg
+
+type varatt_external struct {
+	VaRawsize    int32
+	VaExtsize    int32
+	VaValueid    Oid
+	VaToastrelid Oid
+}
+
+func (n *varatt_external) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/variable_set_kind.go
+++ b/internal/sql/ast/pg/variable_set_kind.go
@@ -1,0 +1,7 @@
+package pg
+
+type VariableSetKind uint
+
+func (n *VariableSetKind) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/variable_set_stmt.go
+++ b/internal/sql/ast/pg/variable_set_stmt.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type VariableSetStmt struct {
+	Kind    VariableSetKind
+	Name    *string
+	Args    *ast.List
+	IsLocal bool
+}
+
+func (n *VariableSetStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/variable_show_stmt.go
+++ b/internal/sql/ast/pg/variable_show_stmt.go
@@ -1,0 +1,9 @@
+package pg
+
+type VariableShowStmt struct {
+	Name *string
+}
+
+func (n *VariableShowStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/vartag_external.go
+++ b/internal/sql/ast/pg/vartag_external.go
@@ -1,0 +1,7 @@
+package pg
+
+type vartag_external uint
+
+func (n *vartag_external) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/view_check_option.go
+++ b/internal/sql/ast/pg/view_check_option.go
@@ -1,0 +1,7 @@
+package pg
+
+type ViewCheckOption uint
+
+func (n *ViewCheckOption) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/view_stmt.go
+++ b/internal/sql/ast/pg/view_stmt.go
@@ -1,0 +1,18 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type ViewStmt struct {
+	View            *RangeVar
+	Aliases         *ast.List
+	Query           ast.Node
+	Replace         bool
+	Options         *ast.List
+	WithCheckOption ViewCheckOption
+}
+
+func (n *ViewStmt) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/wco_kind.go
+++ b/internal/sql/ast/pg/wco_kind.go
@@ -1,0 +1,7 @@
+package pg
+
+type WCOKind uint
+
+func (n *WCOKind) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/window_clause.go
+++ b/internal/sql/ast/pg/window_clause.go
@@ -1,0 +1,21 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type WindowClause struct {
+	Name            *string
+	Refname         *string
+	PartitionClause *ast.List
+	OrderClause     *ast.List
+	FrameOptions    int
+	StartOffset     ast.Node
+	EndOffset       ast.Node
+	Winref          Index
+	CopiedOrder     bool
+}
+
+func (n *WindowClause) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/window_def.go
+++ b/internal/sql/ast/pg/window_def.go
@@ -1,0 +1,20 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type WindowDef struct {
+	Name            *string
+	Refname         *string
+	PartitionClause *ast.List
+	OrderClause     *ast.List
+	FrameOptions    int
+	StartOffset     ast.Node
+	EndOffset       ast.Node
+	Location        int
+}
+
+func (n *WindowDef) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/window_func.go
+++ b/internal/sql/ast/pg/window_func.go
@@ -1,0 +1,23 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type WindowFunc struct {
+	Xpr         ast.Node
+	Winfnoid    Oid
+	Wintype     Oid
+	Wincollid   Oid
+	Inputcollid Oid
+	Args        *ast.List
+	Aggfilter   ast.Node
+	Winref      Index
+	Winstar     bool
+	Winagg      bool
+	Location    int
+}
+
+func (n *WindowFunc) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/with_check_option.go
+++ b/internal/sql/ast/pg/with_check_option.go
@@ -1,0 +1,17 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type WithCheckOption struct {
+	Kind     WCOKind
+	Relname  *string
+	Polname  *string
+	Qual     ast.Node
+	Cascaded bool
+}
+
+func (n *WithCheckOption) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/with_clause.go
+++ b/internal/sql/ast/pg/with_clause.go
@@ -1,0 +1,15 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type WithClause struct {
+	Ctes      *ast.List
+	Recursive bool
+	Location  int
+}
+
+func (n *WithClause) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/xml_expr.go
+++ b/internal/sql/ast/pg/xml_expr.go
@@ -1,0 +1,22 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type XmlExpr struct {
+	Xpr       ast.Node
+	Op        XmlExprOp
+	Name      *string
+	NamedArgs *ast.List
+	ArgNames  *ast.List
+	Args      *ast.List
+	Xmloption XmlOptionType
+	Type      Oid
+	Typmod    int32
+	Location  int
+}
+
+func (n *XmlExpr) Pos() int {
+	return n.Location
+}

--- a/internal/sql/ast/pg/xml_expr_op.go
+++ b/internal/sql/ast/pg/xml_expr_op.go
@@ -1,0 +1,7 @@
+package pg
+
+type XmlExprOp uint
+
+func (n *XmlExprOp) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/xml_option_type.go
+++ b/internal/sql/ast/pg/xml_option_type.go
@@ -1,0 +1,7 @@
+package pg
+
+type XmlOptionType uint
+
+func (n *XmlOptionType) Pos() int {
+	return 0
+}

--- a/internal/sql/ast/pg/xml_serialize.go
+++ b/internal/sql/ast/pg/xml_serialize.go
@@ -1,0 +1,16 @@
+package pg
+
+import (
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+type XmlSerialize struct {
+	Xmloption XmlOptionType
+	Expr      ast.Node
+	TypeName  *TypeName
+	Location  int
+}
+
+func (n *XmlSerialize) Pos() int {
+	return n.Location
+}

--- a/internal/sql/astutils/join.go
+++ b/internal/sql/astutils/join.go
@@ -1,0 +1,21 @@
+package astutils
+
+import (
+	"strings"
+
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/kyleconroy/sqlc/internal/sql/ast/pg"
+)
+
+func Join(list *ast.List, sep string) string {
+	items := []string{}
+	for _, item := range list.Items {
+		if n, ok := item.(*ast.String); ok {
+			items = append(items, n.Str)
+		}
+		if n, ok := item.(*pg.String); ok {
+			items = append(items, n.Str)
+		}
+	}
+	return strings.Join(items, sep)
+}

--- a/internal/sql/astutils/rewrite.go
+++ b/internal/sql/astutils/rewrite.go
@@ -1,0 +1,1275 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package astutils
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/kyleconroy/sqlc/internal/sql/ast/pg"
+)
+
+// An ApplyFunc is invoked by Apply for each node n, even if n is nil,
+// before and/or after the node's children, using a Cursor describing
+// the current node and providing operations on it.
+//
+// The return value of ApplyFunc controls the syntax tree traversal.
+// See Apply for details.
+type ApplyFunc func(*Cursor) bool
+
+// Apply traverses a syntax tree recursively, starting with root,
+// and calling pre and post for each node as described below.
+// Apply returns the syntax tree, possibly modified.
+//
+// If pre is not nil, it is called for each node before the node's
+// children are traversed (pre-order). If pre returns false, no
+// children are traversed, and post is not called for that node.
+//
+// If post is not nil, and a prior call of pre didn't return false,
+// post is called for each node after its children are traversed
+// (post-order). If post returns false, traversal is terminated and
+// Apply returns immediately.
+//
+// Only fields that refer to AST nodes are considered children;
+// i.e., token.Pos, Scopes, Objects, and fields of basic types
+// (strings, etc.) are ignored.
+//
+// Children are traversed in the order in which they appear in the
+// respective node's struct definition. A package's files are
+// traversed in the filenames' alphabetical order.
+//
+func Apply(root ast.Node, pre, post ApplyFunc) (result ast.Node) {
+	parent := &struct{ ast.Node }{root}
+	defer func() {
+		if r := recover(); r != nil && r != abort {
+			panic(r)
+		}
+		result = parent.Node
+	}()
+	a := &application{pre: pre, post: post}
+	a.apply(parent, "Node", nil, root)
+	return
+}
+
+var abort = new(int) // singleton, to signal termination of Apply
+
+// A Cursor describes a node encountered during Apply.
+// Information about the node and its parent is available
+// from the Node, Parent, Name, and Index methods.
+//
+// If p is a variable of type and value of the current parent node
+// c.Parent(), and f is the field identifier with name c.Name(),
+// the following invariants hold:
+//
+//   p.f            == c.Node()  if c.Index() <  0
+//   p.f[c.Index()] == c.Node()  if c.Index() >= 0
+//
+// The methods Replace, Delete, InsertBefore, and InsertAfter
+// can be used to change the AST without disrupting Apply.
+type Cursor struct {
+	parent ast.Node
+	name   string
+	iter   *iterator // valid if non-nil
+	node   ast.Node
+}
+
+// Node returns the current Node.
+func (c *Cursor) Node() ast.Node { return c.node }
+
+// Parent returns the parent of the current Node.
+func (c *Cursor) Parent() ast.Node { return c.parent }
+
+// Name returns the name of the parent Node field that contains the current Node.
+// If the parent is a *ast.Package and the current Node is a *ast.File, Name returns
+// the filename for the current Node.
+func (c *Cursor) Name() string { return c.name }
+
+// Index reports the index >= 0 of the current Node in the slice of Nodes that
+// contains it, or a value < 0 if the current Node is not part of a slice.
+// The index of the current node changes if InsertBefore is called while
+// processing the current node.
+func (c *Cursor) Index() int {
+	if c.iter != nil {
+		return c.iter.index
+	}
+	return -1
+}
+
+// field returns the current node's parent field value.
+func (c *Cursor) field() reflect.Value {
+	return reflect.Indirect(reflect.ValueOf(c.parent)).FieldByName(c.name)
+}
+
+// Replace replaces the current Node with n.
+// The replacement node is not walked by Apply.
+func (c *Cursor) Replace(n ast.Node) {
+	v := c.field()
+	if i := c.Index(); i >= 0 {
+		v = v.Index(i)
+	}
+	v.Set(reflect.ValueOf(n))
+}
+
+// D// application carries all the shared data so we can pass it around cheaply.
+type application struct {
+	pre, post ApplyFunc
+	cursor    Cursor
+	iter      iterator
+}
+
+func (a *application) apply(parent ast.Node, name string, iter *iterator, n ast.Node) {
+	// convert typed nil into untyped nil
+	if v := reflect.ValueOf(n); v.Kind() == reflect.Ptr && v.IsNil() {
+		n = nil
+	}
+
+	// avoid heap-allocating a new cursor for each apply call; reuse a.cursor instead
+	saved := a.cursor
+	a.cursor.parent = parent
+	a.cursor.name = name
+	a.cursor.iter = iter
+	a.cursor.node = n
+
+	if a.pre != nil && !a.pre(&a.cursor) {
+		a.cursor = saved
+		return
+	}
+
+	// walk children
+	// (the order of the cases matches the order of the corresponding node types in go/ast)
+	switch n := n.(type) {
+	case nil:
+		// nothing to do
+
+	case *ast.AlterTableCmd:
+		a.apply(n, "Def", nil, n.Def)
+
+	case *ast.AlterTableSetSchemaStmt:
+		a.apply(n, "Table", nil, n.Table)
+
+	case *ast.AlterTableStmt:
+		a.apply(n, "Table", nil, n.Table)
+		a.apply(n, "Cmds", nil, n.Cmds)
+
+	case *ast.AlterTypeAddValueStmt:
+		a.apply(n, "Type", nil, n.Type)
+
+	case *ast.AlterTypeRenameValueStmt:
+		a.apply(n, "Type", nil, n.Type)
+
+	case *ast.ColumnDef:
+		a.apply(n, "TypeName", nil, n.TypeName)
+
+	case *ast.ColumnRef:
+		// pass
+
+	case *ast.CommentOnColumnStmt:
+		a.apply(n, "Table", nil, n.Table)
+		a.apply(n, "Col", nil, n.Col)
+
+	case *ast.CommentOnSchemaStmt:
+		a.apply(n, "Schema", nil, n.Schema)
+
+	case *ast.CommentOnTableStmt:
+		a.apply(n, "Table", nil, n.Table)
+
+	case *ast.CommentOnTypeStmt:
+		a.apply(n, "Type", nil, n.Type)
+
+	case *ast.CreateEnumStmt:
+		a.apply(n, "TypeName", nil, n.TypeName)
+		a.apply(n, "Vals", nil, n.Vals)
+
+	case *ast.CreateFunctionStmt:
+		a.apply(n, "ReturnType", nil, n.ReturnType)
+		a.apply(n, "Func", nil, n.Func)
+
+	case *ast.CreateSchemaStmt:
+		// pass
+
+	case *ast.CreateTableStmt:
+		a.apply(n, "Name", nil, n.Name)
+
+	case *ast.DropFunctionStmt:
+		// pass
+
+	case *ast.DropSchemaStmt:
+		// pass
+
+	case *ast.DropTableStmt:
+		// pass
+
+	case *ast.DropTypeStmt:
+		// pass
+
+	case *ast.FuncName:
+		// pass
+
+	case *ast.FuncParam:
+		a.apply(n, "Type", nil, n.Type)
+		a.apply(n, "DefExpr", nil, n.DefExpr)
+
+	case *ast.FuncSpec:
+		a.apply(n, "Name", nil, n.Name)
+
+	case *ast.List:
+		// Since item is a slice
+		a.applyList(n, "Items")
+
+	case *ast.RawStmt:
+		a.apply(n, "Stmt", nil, n.Stmt)
+
+	case *ast.RenameColumnStmt:
+		a.apply(n, "Table", nil, n.Table)
+		a.apply(n, "Col", nil, n.Col)
+
+	case *ast.RenameTableStmt:
+		a.apply(n, "Table", nil, n.Table)
+
+	case *ast.ResTarget:
+		a.apply(n, "Val", nil, n.Val)
+
+	case *ast.SelectStmt:
+		a.apply(n, "Fields", nil, n.Fields)
+		a.apply(n, "From", nil, n.From)
+
+	case *ast.Statement:
+		a.apply(n, "Raw", nil, n.Raw)
+
+	case *ast.String:
+		// pass
+
+	case *ast.TODO:
+		// pass
+
+	case *ast.TableName:
+		// pass
+
+	case *ast.TypeName:
+		// pass
+
+	case *pg.A_ArrayExpr:
+		a.apply(n, "Elements", nil, n.Elements)
+
+	case *pg.A_Const:
+		a.apply(n, "Val", nil, n.Val)
+
+	case *pg.A_Expr:
+		a.apply(n, "Name", nil, n.Name)
+		a.apply(n, "Lexpr", nil, n.Lexpr)
+		a.apply(n, "Rexpr", nil, n.Rexpr)
+
+	case *pg.A_Indices:
+		a.apply(n, "Lidx", nil, n.Lidx)
+		a.apply(n, "Uidx", nil, n.Uidx)
+
+	case *pg.A_Indirection:
+		a.apply(n, "Arg", nil, n.Arg)
+		a.apply(n, "Indirection", nil, n.Indirection)
+
+	case *pg.A_Star:
+		// pass
+
+	case *pg.AccessPriv:
+		a.apply(n, "Cols", nil, n.Cols)
+
+	case *pg.Aggref:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Aggargtypes", nil, n.Aggargtypes)
+		a.apply(n, "Aggdirectargs", nil, n.Aggdirectargs)
+		a.apply(n, "Args", nil, n.Args)
+		a.apply(n, "Aggorder", nil, n.Aggorder)
+		a.apply(n, "Aggdistinct", nil, n.Aggdistinct)
+		a.apply(n, "Aggfilter", nil, n.Aggfilter)
+
+	case *pg.Alias:
+		a.apply(n, "Colnames", nil, n.Colnames)
+
+	case *pg.AlterCollationStmt:
+		a.apply(n, "Collname", nil, n.Collname)
+
+	case *pg.AlterDatabaseSetStmt:
+		a.apply(n, "Setstmt", nil, n.Setstmt)
+
+	case *pg.AlterDatabaseStmt:
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.AlterDefaultPrivilegesStmt:
+		a.apply(n, "Options", nil, n.Options)
+		a.apply(n, "Action", nil, n.Action)
+
+	case *pg.AlterDomainStmt:
+		a.apply(n, "TypeName", nil, n.TypeName)
+		a.apply(n, "Def", nil, n.Def)
+
+	case *pg.AlterEnumStmt:
+		a.apply(n, "TypeName", nil, n.TypeName)
+
+	case *pg.AlterEventTrigStmt:
+		// pass
+
+	case *pg.AlterExtensionContentsStmt:
+		a.apply(n, "Object", nil, n.Object)
+
+	case *pg.AlterExtensionStmt:
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.AlterFdwStmt:
+		a.apply(n, "FuncOptions", nil, n.FuncOptions)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.AlterForeignServerStmt:
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.AlterFunctionStmt:
+		a.apply(n, "Func", nil, n.Func)
+		a.apply(n, "Actions", nil, n.Actions)
+
+	case *pg.AlterObjectDependsStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "Object", nil, n.Object)
+		a.apply(n, "Extname", nil, n.Extname)
+
+	case *pg.AlterObjectSchemaStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "Object", nil, n.Object)
+
+	case *pg.AlterOpFamilyStmt:
+		a.apply(n, "Opfamilyname", nil, n.Opfamilyname)
+		a.apply(n, "Items", nil, n.Items)
+
+	case *pg.AlterOperatorStmt:
+		a.apply(n, "Opername", nil, n.Opername)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.AlterOwnerStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "Object", nil, n.Object)
+		a.apply(n, "Newowner", nil, n.Newowner)
+
+	case *pg.AlterPolicyStmt:
+		a.apply(n, "Table", nil, n.Table)
+		a.apply(n, "Roles", nil, n.Roles)
+		a.apply(n, "Qual", nil, n.Qual)
+		a.apply(n, "WithCheck", nil, n.WithCheck)
+
+	case *pg.AlterPublicationStmt:
+		a.apply(n, "Options", nil, n.Options)
+		a.apply(n, "Tables", nil, n.Tables)
+
+	case *pg.AlterRoleSetStmt:
+		a.apply(n, "Role", nil, n.Role)
+		a.apply(n, "Setstmt", nil, n.Setstmt)
+
+	case *pg.AlterRoleStmt:
+		a.apply(n, "Role", nil, n.Role)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.AlterSeqStmt:
+		a.apply(n, "Sequence", nil, n.Sequence)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.AlterSubscriptionStmt:
+		a.apply(n, "Publication", nil, n.Publication)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.AlterSystemStmt:
+		a.apply(n, "Setstmt", nil, n.Setstmt)
+
+	case *pg.AlterTSConfigurationStmt:
+		a.apply(n, "Cfgname", nil, n.Cfgname)
+		a.apply(n, "Tokentype", nil, n.Tokentype)
+		a.apply(n, "Dicts", nil, n.Dicts)
+
+	case *pg.AlterTSDictionaryStmt:
+		a.apply(n, "Dictname", nil, n.Dictname)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.AlterTableCmd:
+		a.apply(n, "Newowner", nil, n.Newowner)
+		a.apply(n, "Def", nil, n.Def)
+
+	case *pg.AlterTableMoveAllStmt:
+		a.apply(n, "Roles", nil, n.Roles)
+
+	case *pg.AlterTableSpaceOptionsStmt:
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.AlterTableStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "Cmds", nil, n.Cmds)
+
+	case *pg.AlterUserMappingStmt:
+		a.apply(n, "User", nil, n.User)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.AlternativeSubPlan:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Subplans", nil, n.Subplans)
+
+	case *pg.ArrayCoerceExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Arg", nil, n.Arg)
+
+	case *pg.ArrayExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Elements", nil, n.Elements)
+
+	case *pg.ArrayRef:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Refupperindexpr", nil, n.Refupperindexpr)
+		a.apply(n, "Reflowerindexpr", nil, n.Reflowerindexpr)
+		a.apply(n, "Refexpr", nil, n.Refexpr)
+		a.apply(n, "Refassgnexpr", nil, n.Refassgnexpr)
+
+	case *pg.BitString:
+		// pass
+
+	case *pg.BlockIdData:
+		// pass
+
+	case *pg.BoolExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Args", nil, n.Args)
+
+	case *pg.BooleanTest:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Arg", nil, n.Arg)
+
+	case *pg.CaseExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Arg", nil, n.Arg)
+		a.apply(n, "Args", nil, n.Args)
+		a.apply(n, "Defresult", nil, n.Defresult)
+
+	case *pg.CaseTestExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+
+	case *pg.CaseWhen:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Expr", nil, n.Expr)
+		a.apply(n, "Result", nil, n.Result)
+
+	case *pg.CheckPointStmt:
+		// pass
+
+	case *pg.ClosePortalStmt:
+		// pass
+
+	case *pg.ClusterStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+
+	case *pg.CoalesceExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Args", nil, n.Args)
+
+	case *pg.CoerceToDomain:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Arg", nil, n.Arg)
+
+	case *pg.CoerceToDomainValue:
+		a.apply(n, "Xpr", nil, n.Xpr)
+
+	case *pg.CoerceViaIO:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Arg", nil, n.Arg)
+
+	case *pg.CollateClause:
+		a.apply(n, "Arg", nil, n.Arg)
+		a.apply(n, "Collname", nil, n.Collname)
+
+	case *pg.CollateExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Arg", nil, n.Arg)
+
+	case *pg.ColumnDef:
+		a.apply(n, "TypeName", nil, n.TypeName)
+		a.apply(n, "RawDefault", nil, n.RawDefault)
+		a.apply(n, "CookedDefault", nil, n.CookedDefault)
+		a.apply(n, "CollClause", nil, n.CollClause)
+		a.apply(n, "Constraints", nil, n.Constraints)
+		a.apply(n, "Fdwoptions", nil, n.Fdwoptions)
+
+	case *pg.ColumnRef:
+		a.apply(n, "Fields", nil, n.Fields)
+
+	case *pg.CommentStmt:
+		a.apply(n, "Object", nil, n.Object)
+
+	case *pg.CommonTableExpr:
+		a.apply(n, "Aliascolnames", nil, n.Aliascolnames)
+		a.apply(n, "Ctequery", nil, n.Ctequery)
+		a.apply(n, "Ctecolnames", nil, n.Ctecolnames)
+		a.apply(n, "Ctecoltypes", nil, n.Ctecoltypes)
+		a.apply(n, "Ctecoltypmods", nil, n.Ctecoltypmods)
+		a.apply(n, "Ctecolcollations", nil, n.Ctecolcollations)
+
+	case *pg.CompositeTypeStmt:
+		a.apply(n, "Typevar", nil, n.Typevar)
+		a.apply(n, "Coldeflist", nil, n.Coldeflist)
+
+	case *pg.Const:
+		a.apply(n, "Xpr", nil, n.Xpr)
+
+	case *pg.Constraint:
+		a.apply(n, "RawExpr", nil, n.RawExpr)
+		a.apply(n, "Keys", nil, n.Keys)
+		a.apply(n, "Exclusions", nil, n.Exclusions)
+		a.apply(n, "Options", nil, n.Options)
+		a.apply(n, "WhereClause", nil, n.WhereClause)
+		a.apply(n, "Pktable", nil, n.Pktable)
+		a.apply(n, "FkAttrs", nil, n.FkAttrs)
+		a.apply(n, "PkAttrs", nil, n.PkAttrs)
+		a.apply(n, "OldConpfeqop", nil, n.OldConpfeqop)
+
+	case *pg.ConstraintsSetStmt:
+		a.apply(n, "Constraints", nil, n.Constraints)
+
+	case *pg.ConvertRowtypeExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Arg", nil, n.Arg)
+
+	case *pg.CopyStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "Query", nil, n.Query)
+		a.apply(n, "Attlist", nil, n.Attlist)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.CreateAmStmt:
+		a.apply(n, "HandlerName", nil, n.HandlerName)
+
+	case *pg.CreateCastStmt:
+		a.apply(n, "Sourcetype", nil, n.Sourcetype)
+		a.apply(n, "Targettype", nil, n.Targettype)
+		a.apply(n, "Func", nil, n.Func)
+
+	case *pg.CreateConversionStmt:
+		a.apply(n, "ConversionName", nil, n.ConversionName)
+		a.apply(n, "FuncName", nil, n.FuncName)
+
+	case *pg.CreateDomainStmt:
+		a.apply(n, "Domainname", nil, n.Domainname)
+		a.apply(n, "TypeName", nil, n.TypeName)
+		a.apply(n, "CollClause", nil, n.CollClause)
+		a.apply(n, "Constraints", nil, n.Constraints)
+
+	case *pg.CreateEnumStmt:
+		a.apply(n, "TypeName", nil, n.TypeName)
+		a.apply(n, "Vals", nil, n.Vals)
+
+	case *pg.CreateEventTrigStmt:
+		a.apply(n, "Whenclause", nil, n.Whenclause)
+		a.apply(n, "Funcname", nil, n.Funcname)
+
+	case *pg.CreateExtensionStmt:
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.CreateFdwStmt:
+		a.apply(n, "FuncOptions", nil, n.FuncOptions)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.CreateForeignServerStmt:
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.CreateForeignTableStmt:
+		a.apply(n, "Base", nil, n.Base)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.CreateFunctionStmt:
+		a.apply(n, "Funcname", nil, n.Funcname)
+		a.apply(n, "Parameters", nil, n.Parameters)
+		a.apply(n, "ReturnType", nil, n.ReturnType)
+		a.apply(n, "Options", nil, n.Options)
+		a.apply(n, "WithClause", nil, n.WithClause)
+
+	case *pg.CreateOpClassItem:
+		a.apply(n, "Name", nil, n.Name)
+		a.apply(n, "OrderFamily", nil, n.OrderFamily)
+		a.apply(n, "ClassArgs", nil, n.ClassArgs)
+		a.apply(n, "Storedtype", nil, n.Storedtype)
+
+	case *pg.CreateOpClassStmt:
+		a.apply(n, "Opclassname", nil, n.Opclassname)
+		a.apply(n, "Opfamilyname", nil, n.Opfamilyname)
+		a.apply(n, "Datatype", nil, n.Datatype)
+		a.apply(n, "Items", nil, n.Items)
+
+	case *pg.CreateOpFamilyStmt:
+		a.apply(n, "Opfamilyname", nil, n.Opfamilyname)
+
+	case *pg.CreatePLangStmt:
+		a.apply(n, "Plhandler", nil, n.Plhandler)
+		a.apply(n, "Plinline", nil, n.Plinline)
+		a.apply(n, "Plvalidator", nil, n.Plvalidator)
+
+	case *pg.CreatePolicyStmt:
+		a.apply(n, "Table", nil, n.Table)
+		a.apply(n, "Roles", nil, n.Roles)
+		a.apply(n, "Qual", nil, n.Qual)
+		a.apply(n, "WithCheck", nil, n.WithCheck)
+
+	case *pg.CreatePublicationStmt:
+		a.apply(n, "Options", nil, n.Options)
+		a.apply(n, "Tables", nil, n.Tables)
+
+	case *pg.CreateRangeStmt:
+		a.apply(n, "TypeName", nil, n.TypeName)
+		a.apply(n, "Params", nil, n.Params)
+
+	case *pg.CreateRoleStmt:
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.CreateSchemaStmt:
+		a.apply(n, "Authrole", nil, n.Authrole)
+		a.apply(n, "SchemaElts", nil, n.SchemaElts)
+
+	case *pg.CreateSeqStmt:
+		a.apply(n, "Sequence", nil, n.Sequence)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.CreateStatsStmt:
+		a.apply(n, "Defnames", nil, n.Defnames)
+		a.apply(n, "StatTypes", nil, n.StatTypes)
+		a.apply(n, "Exprs", nil, n.Exprs)
+		a.apply(n, "Relations", nil, n.Relations)
+
+	case *pg.CreateStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "TableElts", nil, n.TableElts)
+		a.apply(n, "InhRelations", nil, n.InhRelations)
+		a.apply(n, "Partbound", nil, n.Partbound)
+		a.apply(n, "Partspec", nil, n.Partspec)
+		a.apply(n, "OfTypename", nil, n.OfTypename)
+		a.apply(n, "Constraints", nil, n.Constraints)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.CreateSubscriptionStmt:
+		a.apply(n, "Publication", nil, n.Publication)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.CreateTableAsStmt:
+		a.apply(n, "Query", nil, n.Query)
+		a.apply(n, "Into", nil, n.Into)
+
+	case *pg.CreateTableSpaceStmt:
+		a.apply(n, "Owner", nil, n.Owner)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.CreateTransformStmt:
+		a.apply(n, "TypeName", nil, n.TypeName)
+		a.apply(n, "Fromsql", nil, n.Fromsql)
+		a.apply(n, "Tosql", nil, n.Tosql)
+
+	case *pg.CreateTrigStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "Funcname", nil, n.Funcname)
+		a.apply(n, "Args", nil, n.Args)
+		a.apply(n, "Columns", nil, n.Columns)
+		a.apply(n, "WhenClause", nil, n.WhenClause)
+		a.apply(n, "TransitionRels", nil, n.TransitionRels)
+		a.apply(n, "Constrrel", nil, n.Constrrel)
+
+	case *pg.CreateUserMappingStmt:
+		a.apply(n, "User", nil, n.User)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.CreatedbStmt:
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.CurrentOfExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+
+	case *pg.DeallocateStmt:
+		// pass
+
+	case *pg.DeclareCursorStmt:
+		a.apply(n, "Query", nil, n.Query)
+
+	case *pg.DefElem:
+		a.apply(n, "Arg", nil, n.Arg)
+
+	case *pg.DefineStmt:
+		a.apply(n, "Defnames", nil, n.Defnames)
+		a.apply(n, "Args", nil, n.Args)
+		a.apply(n, "Definition", nil, n.Definition)
+
+	case *pg.DeleteStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "UsingClause", nil, n.UsingClause)
+		a.apply(n, "WhereClause", nil, n.WhereClause)
+		a.apply(n, "ReturningList", nil, n.ReturningList)
+		a.apply(n, "WithClause", nil, n.WithClause)
+
+	case *pg.DiscardStmt:
+		// pass
+
+	case *pg.DoStmt:
+		a.apply(n, "Args", nil, n.Args)
+
+	case *pg.DropOwnedStmt:
+		a.apply(n, "Roles", nil, n.Roles)
+
+	case *pg.DropRoleStmt:
+		a.apply(n, "Roles", nil, n.Roles)
+
+	case *pg.DropStmt:
+		a.apply(n, "Objects", nil, n.Objects)
+
+	case *pg.DropSubscriptionStmt:
+		// pass
+
+	case *pg.DropTableSpaceStmt:
+		// pass
+
+	case *pg.DropUserMappingStmt:
+		a.apply(n, "User", nil, n.User)
+
+	case *pg.DropdbStmt:
+		// pass
+
+	case *pg.ExecuteStmt:
+		a.apply(n, "Params", nil, n.Params)
+
+	case *pg.ExplainStmt:
+		a.apply(n, "Query", nil, n.Query)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.Expr:
+		// pass
+
+	case *pg.FetchStmt:
+		// pass
+
+	case *pg.FieldSelect:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Arg", nil, n.Arg)
+
+	case *pg.FieldStore:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Arg", nil, n.Arg)
+		a.apply(n, "Newvals", nil, n.Newvals)
+		a.apply(n, "Fieldnums", nil, n.Fieldnums)
+
+	case *pg.Float:
+		// pass
+
+	case *pg.FromExpr:
+		a.apply(n, "Fromlist", nil, n.Fromlist)
+		a.apply(n, "Quals", nil, n.Quals)
+
+	case *pg.FuncCall:
+		a.apply(n, "Funcname", nil, n.Funcname)
+		a.apply(n, "Args", nil, n.Args)
+		a.apply(n, "AggOrder", nil, n.AggOrder)
+		a.apply(n, "AggFilter", nil, n.AggFilter)
+		a.apply(n, "Over", nil, n.Over)
+
+	case *pg.FuncExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Args", nil, n.Args)
+
+	case *pg.FunctionParameter:
+		a.apply(n, "ArgType", nil, n.ArgType)
+		a.apply(n, "Defexpr", nil, n.Defexpr)
+
+	case *pg.GrantRoleStmt:
+		a.apply(n, "GrantedRoles", nil, n.GrantedRoles)
+		a.apply(n, "GranteeRoles", nil, n.GranteeRoles)
+		a.apply(n, "Grantor", nil, n.Grantor)
+
+	case *pg.GrantStmt:
+		a.apply(n, "Objects", nil, n.Objects)
+		a.apply(n, "Privileges", nil, n.Privileges)
+		a.apply(n, "Grantees", nil, n.Grantees)
+
+	case *pg.GroupingFunc:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Args", nil, n.Args)
+		a.apply(n, "Refs", nil, n.Refs)
+		a.apply(n, "Cols", nil, n.Cols)
+
+	case *pg.GroupingSet:
+		a.apply(n, "Content", nil, n.Content)
+
+	case *pg.ImportForeignSchemaStmt:
+		a.apply(n, "TableList", nil, n.TableList)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.IndexElem:
+		a.apply(n, "Expr", nil, n.Expr)
+		a.apply(n, "Collation", nil, n.Collation)
+		a.apply(n, "Opclass", nil, n.Opclass)
+
+	case *pg.IndexStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "IndexParams", nil, n.IndexParams)
+		a.apply(n, "Options", nil, n.Options)
+		a.apply(n, "WhereClause", nil, n.WhereClause)
+		a.apply(n, "ExcludeOpNames", nil, n.ExcludeOpNames)
+
+	case *pg.InferClause:
+		a.apply(n, "IndexElems", nil, n.IndexElems)
+		a.apply(n, "WhereClause", nil, n.WhereClause)
+
+	case *pg.InferenceElem:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Expr", nil, n.Expr)
+
+	case *pg.InlineCodeBlock:
+		// pass
+
+	case *pg.InsertStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "Cols", nil, n.Cols)
+		a.apply(n, "SelectStmt", nil, n.SelectStmt)
+		a.apply(n, "OnConflictClause", nil, n.OnConflictClause)
+		a.apply(n, "ReturningList", nil, n.ReturningList)
+		a.apply(n, "WithClause", nil, n.WithClause)
+
+	case *pg.Integer:
+		// pass
+
+	case *pg.IntoClause:
+		a.apply(n, "Rel", nil, n.Rel)
+		a.apply(n, "ColNames", nil, n.ColNames)
+		a.apply(n, "Options", nil, n.Options)
+		a.apply(n, "ViewQuery", nil, n.ViewQuery)
+
+	case *pg.JoinExpr:
+		a.apply(n, "Larg", nil, n.Larg)
+		a.apply(n, "Rarg", nil, n.Rarg)
+		a.apply(n, "UsingClause", nil, n.UsingClause)
+		a.apply(n, "Quals", nil, n.Quals)
+		a.apply(n, "Alias", nil, n.Alias)
+
+	case *pg.ListenStmt:
+		// pass
+
+	case *pg.LoadStmt:
+		// pass
+
+	case *pg.LockStmt:
+		a.apply(n, "Relations", nil, n.Relations)
+
+	case *pg.LockingClause:
+		a.apply(n, "LockedRels", nil, n.LockedRels)
+
+	case *pg.MinMaxExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Args", nil, n.Args)
+
+	case *pg.MultiAssignRef:
+		a.apply(n, "Source", nil, n.Source)
+
+	case *pg.NamedArgExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Arg", nil, n.Arg)
+
+	case *pg.NextValueExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+
+	case *pg.NotifyStmt:
+		// pass
+
+	case *pg.Null:
+		// pass
+
+	case *pg.NullTest:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Arg", nil, n.Arg)
+
+	case *pg.ObjectWithArgs:
+		a.apply(n, "Objname", nil, n.Objname)
+		a.apply(n, "Objargs", nil, n.Objargs)
+
+	case *pg.OnConflictClause:
+		a.apply(n, "Infer", nil, n.Infer)
+		a.apply(n, "TargetList", nil, n.TargetList)
+		a.apply(n, "WhereClause", nil, n.WhereClause)
+
+	case *pg.OnConflictExpr:
+		a.apply(n, "ArbiterElems", nil, n.ArbiterElems)
+		a.apply(n, "ArbiterWhere", nil, n.ArbiterWhere)
+		a.apply(n, "OnConflictSet", nil, n.OnConflictSet)
+		a.apply(n, "OnConflictWhere", nil, n.OnConflictWhere)
+		a.apply(n, "ExclRelTlist", nil, n.ExclRelTlist)
+
+	case *pg.OpExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Args", nil, n.Args)
+
+	case *pg.Param:
+		a.apply(n, "Xpr", nil, n.Xpr)
+
+	case *pg.ParamExecData:
+		// pass
+
+	case *pg.ParamExternData:
+		// pass
+
+	case *pg.ParamListInfoData:
+		// pass
+
+	case *pg.ParamRef:
+		// pass
+
+	case *pg.PartitionBoundSpec:
+		a.apply(n, "Listdatums", nil, n.Listdatums)
+		a.apply(n, "Lowerdatums", nil, n.Lowerdatums)
+		a.apply(n, "Upperdatums", nil, n.Upperdatums)
+
+	case *pg.PartitionCmd:
+		a.apply(n, "Name", nil, n.Name)
+		a.apply(n, "Bound", nil, n.Bound)
+
+	case *pg.PartitionElem:
+		a.apply(n, "Expr", nil, n.Expr)
+		a.apply(n, "Collation", nil, n.Collation)
+		a.apply(n, "Opclass", nil, n.Opclass)
+
+	case *pg.PartitionRangeDatum:
+		a.apply(n, "Value", nil, n.Value)
+
+	case *pg.PartitionSpec:
+		a.apply(n, "PartParams", nil, n.PartParams)
+
+	case *pg.PrepareStmt:
+		a.apply(n, "Argtypes", nil, n.Argtypes)
+		a.apply(n, "Query", nil, n.Query)
+
+	case *pg.Query:
+		a.apply(n, "UtilityStmt", nil, n.UtilityStmt)
+		a.apply(n, "CteList", nil, n.CteList)
+		a.apply(n, "Rtable", nil, n.Rtable)
+		a.apply(n, "Jointree", nil, n.Jointree)
+		a.apply(n, "TargetList", nil, n.TargetList)
+		a.apply(n, "OnConflict", nil, n.OnConflict)
+		a.apply(n, "ReturningList", nil, n.ReturningList)
+		a.apply(n, "GroupClause", nil, n.GroupClause)
+		a.apply(n, "GroupingSets", nil, n.GroupingSets)
+		a.apply(n, "HavingQual", nil, n.HavingQual)
+		a.apply(n, "WindowClause", nil, n.WindowClause)
+		a.apply(n, "DistinctClause", nil, n.DistinctClause)
+		a.apply(n, "SortClause", nil, n.SortClause)
+		a.apply(n, "LimitOffset", nil, n.LimitOffset)
+		a.apply(n, "LimitCount", nil, n.LimitCount)
+		a.apply(n, "RowMarks", nil, n.RowMarks)
+		a.apply(n, "SetOperations", nil, n.SetOperations)
+		a.apply(n, "ConstraintDeps", nil, n.ConstraintDeps)
+		a.apply(n, "WithCheckOptions", nil, n.WithCheckOptions)
+
+	case *pg.RangeFunction:
+		a.apply(n, "Functions", nil, n.Functions)
+		a.apply(n, "Alias", nil, n.Alias)
+		a.apply(n, "Coldeflist", nil, n.Coldeflist)
+
+	case *pg.RangeSubselect:
+		a.apply(n, "Subquery", nil, n.Subquery)
+		a.apply(n, "Alias", nil, n.Alias)
+
+	case *pg.RangeTableFunc:
+		a.apply(n, "Docexpr", nil, n.Docexpr)
+		a.apply(n, "Rowexpr", nil, n.Rowexpr)
+		a.apply(n, "Namespaces", nil, n.Namespaces)
+		a.apply(n, "Columns", nil, n.Columns)
+		a.apply(n, "Alias", nil, n.Alias)
+
+	case *pg.RangeTableFuncCol:
+		a.apply(n, "TypeName", nil, n.TypeName)
+		a.apply(n, "Colexpr", nil, n.Colexpr)
+		a.apply(n, "Coldefexpr", nil, n.Coldefexpr)
+
+	case *pg.RangeTableSample:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "Method", nil, n.Method)
+		a.apply(n, "Args", nil, n.Args)
+		a.apply(n, "Repeatable", nil, n.Repeatable)
+
+	case *pg.RangeTblEntry:
+		a.apply(n, "Tablesample", nil, n.Tablesample)
+		a.apply(n, "Subquery", nil, n.Subquery)
+		a.apply(n, "Joinaliasvars", nil, n.Joinaliasvars)
+		a.apply(n, "Functions", nil, n.Functions)
+		a.apply(n, "Tablefunc", nil, n.Tablefunc)
+		a.apply(n, "ValuesLists", nil, n.ValuesLists)
+		a.apply(n, "Coltypes", nil, n.Coltypes)
+		a.apply(n, "Coltypmods", nil, n.Coltypmods)
+		a.apply(n, "Colcollations", nil, n.Colcollations)
+		a.apply(n, "Alias", nil, n.Alias)
+		a.apply(n, "Eref", nil, n.Eref)
+		a.apply(n, "SecurityQuals", nil, n.SecurityQuals)
+
+	case *pg.RangeTblFunction:
+		a.apply(n, "Funcexpr", nil, n.Funcexpr)
+		a.apply(n, "Funccolnames", nil, n.Funccolnames)
+		a.apply(n, "Funccoltypes", nil, n.Funccoltypes)
+		a.apply(n, "Funccoltypmods", nil, n.Funccoltypmods)
+		a.apply(n, "Funccolcollations", nil, n.Funccolcollations)
+
+	case *pg.RangeTblRef:
+		// pass
+
+	case *pg.RangeVar:
+		a.apply(n, "Alias", nil, n.Alias)
+
+	case *pg.RawStmt:
+		a.apply(n, "Stmt", nil, n.Stmt)
+
+	case *pg.ReassignOwnedStmt:
+		a.apply(n, "Roles", nil, n.Roles)
+		a.apply(n, "Newrole", nil, n.Newrole)
+
+	case *pg.RefreshMatViewStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+
+	case *pg.ReindexStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+
+	case *pg.RelabelType:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Arg", nil, n.Arg)
+
+	case *pg.RenameStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "Object", nil, n.Object)
+
+	case *pg.ReplicaIdentityStmt:
+		// pass
+
+	case *pg.ResTarget:
+		a.apply(n, "Indirection", nil, n.Indirection)
+		a.apply(n, "Val", nil, n.Val)
+
+	case *pg.RoleSpec:
+		// pass
+
+	case *pg.RowCompareExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Opnos", nil, n.Opnos)
+		a.apply(n, "Opfamilies", nil, n.Opfamilies)
+		a.apply(n, "Inputcollids", nil, n.Inputcollids)
+		a.apply(n, "Largs", nil, n.Largs)
+		a.apply(n, "Rargs", nil, n.Rargs)
+
+	case *pg.RowExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Args", nil, n.Args)
+		a.apply(n, "Colnames", nil, n.Colnames)
+
+	case *pg.RowMarkClause:
+		// pass
+
+	case *pg.RuleStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "WhereClause", nil, n.WhereClause)
+		a.apply(n, "Actions", nil, n.Actions)
+
+	case *pg.SQLValueFunction:
+		a.apply(n, "Xpr", nil, n.Xpr)
+
+	case *pg.ScalarArrayOpExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Args", nil, n.Args)
+
+	case *pg.SecLabelStmt:
+		a.apply(n, "Object", nil, n.Object)
+
+	case *pg.SelectStmt:
+		a.apply(n, "DistinctClause", nil, n.DistinctClause)
+		a.apply(n, "IntoClause", nil, n.IntoClause)
+		a.apply(n, "TargetList", nil, n.TargetList)
+		a.apply(n, "FromClause", nil, n.FromClause)
+		a.apply(n, "WhereClause", nil, n.WhereClause)
+		a.apply(n, "GroupClause", nil, n.GroupClause)
+		a.apply(n, "HavingClause", nil, n.HavingClause)
+		a.apply(n, "WindowClause", nil, n.WindowClause)
+		a.apply(n, "SortClause", nil, n.SortClause)
+		a.apply(n, "LimitOffset", nil, n.LimitOffset)
+		a.apply(n, "LimitCount", nil, n.LimitCount)
+		a.apply(n, "LockingClause", nil, n.LockingClause)
+		a.apply(n, "WithClause", nil, n.WithClause)
+		a.apply(n, "Larg", nil, n.Larg)
+		a.apply(n, "Rarg", nil, n.Rarg)
+
+	case *pg.SetOperationStmt:
+		a.apply(n, "Larg", nil, n.Larg)
+		a.apply(n, "Rarg", nil, n.Rarg)
+		a.apply(n, "ColTypes", nil, n.ColTypes)
+		a.apply(n, "ColTypmods", nil, n.ColTypmods)
+		a.apply(n, "ColCollations", nil, n.ColCollations)
+		a.apply(n, "GroupClauses", nil, n.GroupClauses)
+
+	case *pg.SetToDefault:
+		a.apply(n, "Xpr", nil, n.Xpr)
+
+	case *pg.SortBy:
+		a.apply(n, "Node", nil, n.Node)
+		a.apply(n, "UseOp", nil, n.UseOp)
+
+	case *pg.SortGroupClause:
+		// pass
+
+	case *pg.String:
+		// pass
+
+	case *pg.SubLink:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Testexpr", nil, n.Testexpr)
+		a.apply(n, "OperName", nil, n.OperName)
+		a.apply(n, "Subselect", nil, n.Subselect)
+
+	case *pg.SubPlan:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Testexpr", nil, n.Testexpr)
+		a.apply(n, "ParamIds", nil, n.ParamIds)
+		a.apply(n, "SetParam", nil, n.SetParam)
+		a.apply(n, "ParParam", nil, n.ParParam)
+		a.apply(n, "Args", nil, n.Args)
+
+	case *pg.TableFunc:
+		a.apply(n, "NsUris", nil, n.NsUris)
+		a.apply(n, "NsNames", nil, n.NsNames)
+		a.apply(n, "Docexpr", nil, n.Docexpr)
+		a.apply(n, "Rowexpr", nil, n.Rowexpr)
+		a.apply(n, "Colnames", nil, n.Colnames)
+		a.apply(n, "Coltypes", nil, n.Coltypes)
+		a.apply(n, "Coltypmods", nil, n.Coltypmods)
+		a.apply(n, "Colcollations", nil, n.Colcollations)
+		a.apply(n, "Colexprs", nil, n.Colexprs)
+		a.apply(n, "Coldefexprs", nil, n.Coldefexprs)
+
+	case *pg.TableLikeClause:
+		a.apply(n, "Relation", nil, n.Relation)
+
+	case *pg.TableSampleClause:
+		a.apply(n, "Args", nil, n.Args)
+		a.apply(n, "Repeatable", nil, n.Repeatable)
+
+	case *pg.TargetEntry:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Expr", nil, n.Expr)
+
+	case *pg.TransactionStmt:
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.TriggerTransition:
+		// pass
+
+	case *pg.TruncateStmt:
+		a.apply(n, "Relations", nil, n.Relations)
+
+	case *pg.TypeCast:
+		a.apply(n, "Arg", nil, n.Arg)
+		a.apply(n, "TypeName", nil, n.TypeName)
+
+	case *pg.TypeName:
+		a.apply(n, "Names", nil, n.Names)
+		a.apply(n, "Typmods", nil, n.Typmods)
+		a.apply(n, "ArrayBounds", nil, n.ArrayBounds)
+
+	case *pg.UnlistenStmt:
+		// pass
+
+	case *pg.UpdateStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "TargetList", nil, n.TargetList)
+		a.apply(n, "WhereClause", nil, n.WhereClause)
+		a.apply(n, "FromClause", nil, n.FromClause)
+		a.apply(n, "ReturningList", nil, n.ReturningList)
+		a.apply(n, "WithClause", nil, n.WithClause)
+
+	case *pg.VacuumStmt:
+		a.apply(n, "Relation", nil, n.Relation)
+		a.apply(n, "VaCols", nil, n.VaCols)
+
+	case *pg.Var:
+		a.apply(n, "Xpr", nil, n.Xpr)
+
+	case *pg.VariableSetStmt:
+		a.apply(n, "Args", nil, n.Args)
+
+	case *pg.VariableShowStmt:
+		// pass
+
+	case *pg.ViewStmt:
+		a.apply(n, "View", nil, n.View)
+		a.apply(n, "Aliases", nil, n.Aliases)
+		a.apply(n, "Query", nil, n.Query)
+		a.apply(n, "Options", nil, n.Options)
+
+	case *pg.WindowClause:
+		a.apply(n, "PartitionClause", nil, n.PartitionClause)
+		a.apply(n, "OrderClause", nil, n.OrderClause)
+		a.apply(n, "StartOffset", nil, n.StartOffset)
+		a.apply(n, "EndOffset", nil, n.EndOffset)
+
+	case *pg.WindowDef:
+		a.apply(n, "PartitionClause", nil, n.PartitionClause)
+		a.apply(n, "OrderClause", nil, n.OrderClause)
+		a.apply(n, "StartOffset", nil, n.StartOffset)
+		a.apply(n, "EndOffset", nil, n.EndOffset)
+
+	case *pg.WindowFunc:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "Args", nil, n.Args)
+		a.apply(n, "Aggfilter", nil, n.Aggfilter)
+
+	case *pg.WithCheckOption:
+		a.apply(n, "Qual", nil, n.Qual)
+
+	case *pg.WithClause:
+		a.apply(n, "Ctes", nil, n.Ctes)
+
+	case *pg.XmlExpr:
+		a.apply(n, "Xpr", nil, n.Xpr)
+		a.apply(n, "NamedArgs", nil, n.NamedArgs)
+		a.apply(n, "ArgNames", nil, n.ArgNames)
+		a.apply(n, "Args", nil, n.Args)
+
+	case *pg.XmlSerialize:
+		a.apply(n, "Expr", nil, n.Expr)
+		a.apply(n, "TypeName", nil, n.TypeName)
+
+	// Comments and fields
+	default:
+		panic(fmt.Sprintf("Apply: unexpected node type %T", n))
+	}
+
+	if a.post != nil && !a.post(&a.cursor) {
+		panic(abort)
+	}
+
+	a.cursor = saved
+}
+
+// An iterator controls iteration over a slice of nodes.
+type iterator struct {
+	index, step int
+}
+
+func (a *application) applyList(parent ast.Node, name string) {
+	// avoid heap-allocating a new iterator for each applyList call; reuse a.iter instead
+	saved := a.iter
+	a.iter.index = 0
+	for {
+		// must reload parent.name each time, since cursor modifications might change it
+		v := reflect.Indirect(reflect.ValueOf(parent)).FieldByName(name)
+		if a.iter.index >= v.Len() {
+			break
+		}
+
+		// element x may be nil in a bad AST - be cautious
+		var x ast.Node
+		if e := v.Index(a.iter.index); e.IsValid() {
+			x = e.Interface().(ast.Node)
+		}
+
+		a.iter.step = 1
+		a.apply(parent, name, &a.iter, x)
+		a.iter.index += a.iter.step
+	}
+	a.iter = saved
+}

--- a/internal/sql/astutils/walk.go
+++ b/internal/sql/astutils/walk.go
@@ -1,0 +1,1126 @@
+package astutils
+
+import (
+	"fmt"
+
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/kyleconroy/sqlc/internal/sql/ast/pg"
+)
+
+type Visitor interface {
+	Visit(ast.Node) Visitor
+}
+
+type VisitorFunc func(ast.Node)
+
+func (vf VisitorFunc) Visit(node ast.Node) Visitor {
+	vf(node)
+	return vf
+}
+
+func walkn(f Visitor, node ast.Node) {
+	if node != nil {
+		Walk(f, node)
+	}
+}
+
+func Walk(f Visitor, node ast.Node) {
+	if f = f.Visit(node); f == nil {
+		return
+	}
+	switch n := node.(type) {
+
+	case *ast.AlterTableCmd:
+		walkn(f, n.Def)
+
+	case *ast.AlterTableSetSchemaStmt:
+		walkn(f, n.Table)
+
+	case *ast.AlterTableStmt:
+		walkn(f, n.Table)
+		walkn(f, n.Cmds)
+
+	case *ast.AlterTypeAddValueStmt:
+		walkn(f, n.Type)
+
+	case *ast.AlterTypeRenameValueStmt:
+		walkn(f, n.Type)
+
+	case *ast.ColumnDef:
+		walkn(f, n.TypeName)
+
+	case *ast.ColumnRef:
+		// pass
+
+	case *ast.CommentOnColumnStmt:
+		walkn(f, n.Table)
+		walkn(f, n.Col)
+
+	case *ast.CommentOnSchemaStmt:
+		walkn(f, n.Schema)
+
+	case *ast.CommentOnTableStmt:
+		walkn(f, n.Table)
+
+	case *ast.CommentOnTypeStmt:
+		walkn(f, n.Type)
+
+	case *ast.CreateEnumStmt:
+		walkn(f, n.TypeName)
+		walkn(f, n.Vals)
+
+	case *ast.CreateFunctionStmt:
+		walkn(f, n.ReturnType)
+		walkn(f, n.Func)
+
+	case *ast.CreateSchemaStmt:
+		// pass
+
+	case *ast.CreateTableStmt:
+		walkn(f, n.Name)
+
+	case *ast.DropFunctionStmt:
+		// pass
+
+	case *ast.DropSchemaStmt:
+		// pass
+
+	case *ast.DropTableStmt:
+		// pass
+
+	case *ast.DropTypeStmt:
+		// pass
+
+	case *ast.FuncName:
+		// pass
+
+	case *ast.FuncParam:
+		walkn(f, n.Type)
+		walkn(f, n.DefExpr)
+
+	case *ast.FuncSpec:
+		walkn(f, n.Name)
+
+	case *ast.List:
+		// pass
+
+	case *ast.RawStmt:
+		walkn(f, n.Stmt)
+
+	case *ast.RenameColumnStmt:
+		walkn(f, n.Table)
+		walkn(f, n.Col)
+
+	case *ast.RenameTableStmt:
+		walkn(f, n.Table)
+
+	case *ast.ResTarget:
+		walkn(f, n.Val)
+
+	case *ast.SelectStmt:
+		walkn(f, n.Fields)
+		walkn(f, n.From)
+
+	case *ast.Statement:
+		walkn(f, n.Raw)
+
+	case *ast.String:
+		// pass
+
+	case *ast.TODO:
+		// pass
+
+	case *ast.TableName:
+		// pass
+
+	case *ast.TypeName:
+		// pass
+
+	case *pg.A_ArrayExpr:
+		walkn(f, n.Elements)
+
+	case *pg.A_Const:
+		walkn(f, n.Val)
+
+	case *pg.A_Expr:
+		walkn(f, n.Name)
+		walkn(f, n.Lexpr)
+		walkn(f, n.Rexpr)
+
+	case *pg.A_Indices:
+		walkn(f, n.Lidx)
+		walkn(f, n.Uidx)
+
+	case *pg.A_Indirection:
+		walkn(f, n.Arg)
+		walkn(f, n.Indirection)
+
+	case *pg.A_Star:
+		// pass
+
+	case *pg.AccessPriv:
+		walkn(f, n.Cols)
+
+	case *pg.Aggref:
+		walkn(f, n.Xpr)
+		walkn(f, n.Aggargtypes)
+		walkn(f, n.Aggdirectargs)
+		walkn(f, n.Args)
+		walkn(f, n.Aggorder)
+		walkn(f, n.Aggdistinct)
+		walkn(f, n.Aggfilter)
+
+	case *pg.Alias:
+		walkn(f, n.Colnames)
+
+	case *pg.AlterCollationStmt:
+		walkn(f, n.Collname)
+
+	case *pg.AlterDatabaseSetStmt:
+		walkn(f, n.Setstmt)
+
+	case *pg.AlterDatabaseStmt:
+		walkn(f, n.Options)
+
+	case *pg.AlterDefaultPrivilegesStmt:
+		walkn(f, n.Options)
+		walkn(f, n.Action)
+
+	case *pg.AlterDomainStmt:
+		walkn(f, n.TypeName)
+		walkn(f, n.Def)
+
+	case *pg.AlterEnumStmt:
+		walkn(f, n.TypeName)
+
+	case *pg.AlterEventTrigStmt:
+		// pass
+
+	case *pg.AlterExtensionContentsStmt:
+		walkn(f, n.Object)
+
+	case *pg.AlterExtensionStmt:
+		walkn(f, n.Options)
+
+	case *pg.AlterFdwStmt:
+		walkn(f, n.FuncOptions)
+		walkn(f, n.Options)
+
+	case *pg.AlterForeignServerStmt:
+		walkn(f, n.Options)
+
+	case *pg.AlterFunctionStmt:
+		walkn(f, n.Func)
+		walkn(f, n.Actions)
+
+	case *pg.AlterObjectDependsStmt:
+		walkn(f, n.Relation)
+		walkn(f, n.Object)
+		walkn(f, n.Extname)
+
+	case *pg.AlterObjectSchemaStmt:
+		walkn(f, n.Relation)
+		walkn(f, n.Object)
+
+	case *pg.AlterOpFamilyStmt:
+		walkn(f, n.Opfamilyname)
+		walkn(f, n.Items)
+
+	case *pg.AlterOperatorStmt:
+		walkn(f, n.Opername)
+		walkn(f, n.Options)
+
+	case *pg.AlterOwnerStmt:
+		walkn(f, n.Relation)
+		walkn(f, n.Object)
+		walkn(f, n.Newowner)
+
+	case *pg.AlterPolicyStmt:
+		walkn(f, n.Table)
+		walkn(f, n.Roles)
+		walkn(f, n.Qual)
+		walkn(f, n.WithCheck)
+
+	case *pg.AlterPublicationStmt:
+		walkn(f, n.Options)
+		walkn(f, n.Tables)
+
+	case *pg.AlterRoleSetStmt:
+		walkn(f, n.Role)
+		walkn(f, n.Setstmt)
+
+	case *pg.AlterRoleStmt:
+		walkn(f, n.Role)
+		walkn(f, n.Options)
+
+	case *pg.AlterSeqStmt:
+		walkn(f, n.Sequence)
+		walkn(f, n.Options)
+
+	case *pg.AlterSubscriptionStmt:
+		walkn(f, n.Publication)
+		walkn(f, n.Options)
+
+	case *pg.AlterSystemStmt:
+		walkn(f, n.Setstmt)
+
+	case *pg.AlterTSConfigurationStmt:
+		walkn(f, n.Cfgname)
+		walkn(f, n.Tokentype)
+		walkn(f, n.Dicts)
+
+	case *pg.AlterTSDictionaryStmt:
+		walkn(f, n.Dictname)
+		walkn(f, n.Options)
+
+	case *pg.AlterTableCmd:
+		walkn(f, n.Newowner)
+		walkn(f, n.Def)
+
+	case *pg.AlterTableMoveAllStmt:
+		walkn(f, n.Roles)
+
+	case *pg.AlterTableSpaceOptionsStmt:
+		walkn(f, n.Options)
+
+	case *pg.AlterTableStmt:
+		walkn(f, n.Relation)
+		walkn(f, n.Cmds)
+
+	case *pg.AlterUserMappingStmt:
+		walkn(f, n.User)
+		walkn(f, n.Options)
+
+	case *pg.AlternativeSubPlan:
+		walkn(f, n.Xpr)
+		walkn(f, n.Subplans)
+
+	case *pg.ArrayCoerceExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.Arg)
+
+	case *pg.ArrayExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.Elements)
+
+	case *pg.ArrayRef:
+		walkn(f, n.Xpr)
+		walkn(f, n.Refupperindexpr)
+		walkn(f, n.Reflowerindexpr)
+		walkn(f, n.Refexpr)
+		walkn(f, n.Refassgnexpr)
+
+	case *pg.BitString:
+		// pass
+
+	case *pg.BlockIdData:
+		// pass
+
+	case *pg.BoolExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.Args)
+
+	case *pg.BooleanTest:
+		walkn(f, n.Xpr)
+		walkn(f, n.Arg)
+
+	case *pg.CaseExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.Arg)
+		walkn(f, n.Args)
+		walkn(f, n.Defresult)
+
+	case *pg.CaseTestExpr:
+		walkn(f, n.Xpr)
+
+	case *pg.CaseWhen:
+		walkn(f, n.Xpr)
+		walkn(f, n.Expr)
+		walkn(f, n.Result)
+
+	case *pg.CheckPointStmt:
+		// pass
+
+	case *pg.ClosePortalStmt:
+		// pass
+
+	case *pg.ClusterStmt:
+		walkn(f, n.Relation)
+
+	case *pg.CoalesceExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.Args)
+
+	case *pg.CoerceToDomain:
+		walkn(f, n.Xpr)
+		walkn(f, n.Arg)
+
+	case *pg.CoerceToDomainValue:
+		walkn(f, n.Xpr)
+
+	case *pg.CoerceViaIO:
+		walkn(f, n.Xpr)
+		walkn(f, n.Arg)
+
+	case *pg.CollateClause:
+		walkn(f, n.Arg)
+		walkn(f, n.Collname)
+
+	case *pg.CollateExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.Arg)
+
+	case *pg.ColumnDef:
+		walkn(f, n.TypeName)
+		walkn(f, n.RawDefault)
+		walkn(f, n.CookedDefault)
+		walkn(f, n.CollClause)
+		walkn(f, n.Constraints)
+		walkn(f, n.Fdwoptions)
+
+	case *pg.ColumnRef:
+		walkn(f, n.Fields)
+
+	case *pg.CommentStmt:
+		walkn(f, n.Object)
+
+	case *pg.CommonTableExpr:
+		walkn(f, n.Aliascolnames)
+		walkn(f, n.Ctequery)
+		walkn(f, n.Ctecolnames)
+		walkn(f, n.Ctecoltypes)
+		walkn(f, n.Ctecoltypmods)
+		walkn(f, n.Ctecolcollations)
+
+	case *pg.CompositeTypeStmt:
+		walkn(f, n.Typevar)
+		walkn(f, n.Coldeflist)
+
+	case *pg.Const:
+		walkn(f, n.Xpr)
+
+	case *pg.Constraint:
+		walkn(f, n.RawExpr)
+		walkn(f, n.Keys)
+		walkn(f, n.Exclusions)
+		walkn(f, n.Options)
+		walkn(f, n.WhereClause)
+		walkn(f, n.Pktable)
+		walkn(f, n.FkAttrs)
+		walkn(f, n.PkAttrs)
+		walkn(f, n.OldConpfeqop)
+
+	case *pg.ConstraintsSetStmt:
+		walkn(f, n.Constraints)
+
+	case *pg.ConvertRowtypeExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.Arg)
+
+	case *pg.CopyStmt:
+		walkn(f, n.Relation)
+		walkn(f, n.Query)
+		walkn(f, n.Attlist)
+		walkn(f, n.Options)
+
+	case *pg.CreateAmStmt:
+		walkn(f, n.HandlerName)
+
+	case *pg.CreateCastStmt:
+		walkn(f, n.Sourcetype)
+		walkn(f, n.Targettype)
+		walkn(f, n.Func)
+
+	case *pg.CreateConversionStmt:
+		walkn(f, n.ConversionName)
+		walkn(f, n.FuncName)
+
+	case *pg.CreateDomainStmt:
+		walkn(f, n.Domainname)
+		walkn(f, n.TypeName)
+		walkn(f, n.CollClause)
+		walkn(f, n.Constraints)
+
+	case *pg.CreateEnumStmt:
+		walkn(f, n.TypeName)
+		walkn(f, n.Vals)
+
+	case *pg.CreateEventTrigStmt:
+		walkn(f, n.Whenclause)
+		walkn(f, n.Funcname)
+
+	case *pg.CreateExtensionStmt:
+		walkn(f, n.Options)
+
+	case *pg.CreateFdwStmt:
+		walkn(f, n.FuncOptions)
+		walkn(f, n.Options)
+
+	case *pg.CreateForeignServerStmt:
+		walkn(f, n.Options)
+
+	case *pg.CreateForeignTableStmt:
+		walkn(f, n.Base)
+		walkn(f, n.Options)
+
+	case *pg.CreateFunctionStmt:
+		walkn(f, n.Funcname)
+		walkn(f, n.Parameters)
+		walkn(f, n.ReturnType)
+		walkn(f, n.Options)
+		walkn(f, n.WithClause)
+
+	case *pg.CreateOpClassItem:
+		walkn(f, n.Name)
+		walkn(f, n.OrderFamily)
+		walkn(f, n.ClassArgs)
+		walkn(f, n.Storedtype)
+
+	case *pg.CreateOpClassStmt:
+		walkn(f, n.Opclassname)
+		walkn(f, n.Opfamilyname)
+		walkn(f, n.Datatype)
+		walkn(f, n.Items)
+
+	case *pg.CreateOpFamilyStmt:
+		walkn(f, n.Opfamilyname)
+
+	case *pg.CreatePLangStmt:
+		walkn(f, n.Plhandler)
+		walkn(f, n.Plinline)
+		walkn(f, n.Plvalidator)
+
+	case *pg.CreatePolicyStmt:
+		walkn(f, n.Table)
+		walkn(f, n.Roles)
+		walkn(f, n.Qual)
+		walkn(f, n.WithCheck)
+
+	case *pg.CreatePublicationStmt:
+		walkn(f, n.Options)
+		walkn(f, n.Tables)
+
+	case *pg.CreateRangeStmt:
+		walkn(f, n.TypeName)
+		walkn(f, n.Params)
+
+	case *pg.CreateRoleStmt:
+		walkn(f, n.Options)
+
+	case *pg.CreateSchemaStmt:
+		walkn(f, n.Authrole)
+		walkn(f, n.SchemaElts)
+
+	case *pg.CreateSeqStmt:
+		walkn(f, n.Sequence)
+		walkn(f, n.Options)
+
+	case *pg.CreateStatsStmt:
+		walkn(f, n.Defnames)
+		walkn(f, n.StatTypes)
+		walkn(f, n.Exprs)
+		walkn(f, n.Relations)
+
+	case *pg.CreateStmt:
+		walkn(f, n.Relation)
+		walkn(f, n.TableElts)
+		walkn(f, n.InhRelations)
+		walkn(f, n.Partbound)
+		walkn(f, n.Partspec)
+		walkn(f, n.OfTypename)
+		walkn(f, n.Constraints)
+		walkn(f, n.Options)
+
+	case *pg.CreateSubscriptionStmt:
+		walkn(f, n.Publication)
+		walkn(f, n.Options)
+
+	case *pg.CreateTableAsStmt:
+		walkn(f, n.Query)
+		walkn(f, n.Into)
+
+	case *pg.CreateTableSpaceStmt:
+		walkn(f, n.Owner)
+		walkn(f, n.Options)
+
+	case *pg.CreateTransformStmt:
+		walkn(f, n.TypeName)
+		walkn(f, n.Fromsql)
+		walkn(f, n.Tosql)
+
+	case *pg.CreateTrigStmt:
+		walkn(f, n.Relation)
+		walkn(f, n.Funcname)
+		walkn(f, n.Args)
+		walkn(f, n.Columns)
+		walkn(f, n.WhenClause)
+		walkn(f, n.TransitionRels)
+		walkn(f, n.Constrrel)
+
+	case *pg.CreateUserMappingStmt:
+		walkn(f, n.User)
+		walkn(f, n.Options)
+
+	case *pg.CreatedbStmt:
+		walkn(f, n.Options)
+
+	case *pg.CurrentOfExpr:
+		walkn(f, n.Xpr)
+
+	case *pg.DeallocateStmt:
+		// pass
+
+	case *pg.DeclareCursorStmt:
+		walkn(f, n.Query)
+
+	case *pg.DefElem:
+		walkn(f, n.Arg)
+
+	case *pg.DefineStmt:
+		walkn(f, n.Defnames)
+		walkn(f, n.Args)
+		walkn(f, n.Definition)
+
+	case *pg.DeleteStmt:
+		walkn(f, n.Relation)
+		walkn(f, n.UsingClause)
+		walkn(f, n.WhereClause)
+		walkn(f, n.ReturningList)
+		walkn(f, n.WithClause)
+
+	case *pg.DiscardStmt:
+		// pass
+
+	case *pg.DoStmt:
+		walkn(f, n.Args)
+
+	case *pg.DropOwnedStmt:
+		walkn(f, n.Roles)
+
+	case *pg.DropRoleStmt:
+		walkn(f, n.Roles)
+
+	case *pg.DropStmt:
+		walkn(f, n.Objects)
+
+	case *pg.DropSubscriptionStmt:
+		// pass
+
+	case *pg.DropTableSpaceStmt:
+		// pass
+
+	case *pg.DropUserMappingStmt:
+		walkn(f, n.User)
+
+	case *pg.DropdbStmt:
+		// pass
+
+	case *pg.ExecuteStmt:
+		walkn(f, n.Params)
+
+	case *pg.ExplainStmt:
+		walkn(f, n.Query)
+		walkn(f, n.Options)
+
+	case *pg.Expr:
+		// pass
+
+	case *pg.FetchStmt:
+		// pass
+
+	case *pg.FieldSelect:
+		walkn(f, n.Xpr)
+		walkn(f, n.Arg)
+
+	case *pg.FieldStore:
+		walkn(f, n.Xpr)
+		walkn(f, n.Arg)
+		walkn(f, n.Newvals)
+		walkn(f, n.Fieldnums)
+
+	case *pg.Float:
+		// pass
+
+	case *pg.FromExpr:
+		walkn(f, n.Fromlist)
+		walkn(f, n.Quals)
+
+	case *pg.FuncCall:
+		walkn(f, n.Funcname)
+		walkn(f, n.Args)
+		walkn(f, n.AggOrder)
+		walkn(f, n.AggFilter)
+		walkn(f, n.Over)
+
+	case *pg.FuncExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.Args)
+
+	case *pg.FunctionParameter:
+		walkn(f, n.ArgType)
+		walkn(f, n.Defexpr)
+
+	case *pg.GrantRoleStmt:
+		walkn(f, n.GrantedRoles)
+		walkn(f, n.GranteeRoles)
+		walkn(f, n.Grantor)
+
+	case *pg.GrantStmt:
+		walkn(f, n.Objects)
+		walkn(f, n.Privileges)
+		walkn(f, n.Grantees)
+
+	case *pg.GroupingFunc:
+		walkn(f, n.Xpr)
+		walkn(f, n.Args)
+		walkn(f, n.Refs)
+		walkn(f, n.Cols)
+
+	case *pg.GroupingSet:
+		walkn(f, n.Content)
+
+	case *pg.ImportForeignSchemaStmt:
+		walkn(f, n.TableList)
+		walkn(f, n.Options)
+
+	case *pg.IndexElem:
+		walkn(f, n.Expr)
+		walkn(f, n.Collation)
+		walkn(f, n.Opclass)
+
+	case *pg.IndexStmt:
+		walkn(f, n.Relation)
+		walkn(f, n.IndexParams)
+		walkn(f, n.Options)
+		walkn(f, n.WhereClause)
+		walkn(f, n.ExcludeOpNames)
+
+	case *pg.InferClause:
+		walkn(f, n.IndexElems)
+		walkn(f, n.WhereClause)
+
+	case *pg.InferenceElem:
+		walkn(f, n.Xpr)
+		walkn(f, n.Expr)
+
+	case *pg.InlineCodeBlock:
+		// pass
+
+	case *pg.InsertStmt:
+		walkn(f, n.Relation)
+		walkn(f, n.Cols)
+		walkn(f, n.SelectStmt)
+		walkn(f, n.OnConflictClause)
+		walkn(f, n.ReturningList)
+		walkn(f, n.WithClause)
+
+	case *pg.Integer:
+		// pass
+
+	case *pg.IntoClause:
+		walkn(f, n.Rel)
+		walkn(f, n.ColNames)
+		walkn(f, n.Options)
+		walkn(f, n.ViewQuery)
+
+	case *pg.JoinExpr:
+		walkn(f, n.Larg)
+		walkn(f, n.Rarg)
+		walkn(f, n.UsingClause)
+		walkn(f, n.Quals)
+		walkn(f, n.Alias)
+
+	case *pg.ListenStmt:
+		// pass
+
+	case *pg.LoadStmt:
+		// pass
+
+	case *pg.LockStmt:
+		walkn(f, n.Relations)
+
+	case *pg.LockingClause:
+		walkn(f, n.LockedRels)
+
+	case *pg.MinMaxExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.Args)
+
+	case *pg.MultiAssignRef:
+		walkn(f, n.Source)
+
+	case *pg.NamedArgExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.Arg)
+
+	case *pg.NextValueExpr:
+		walkn(f, n.Xpr)
+
+	case *pg.NotifyStmt:
+		// pass
+
+	case *pg.Null:
+		// pass
+
+	case *pg.NullTest:
+		walkn(f, n.Xpr)
+		walkn(f, n.Arg)
+
+	case *pg.ObjectWithArgs:
+		walkn(f, n.Objname)
+		walkn(f, n.Objargs)
+
+	case *pg.OnConflictClause:
+		walkn(f, n.Infer)
+		walkn(f, n.TargetList)
+		walkn(f, n.WhereClause)
+
+	case *pg.OnConflictExpr:
+		walkn(f, n.ArbiterElems)
+		walkn(f, n.ArbiterWhere)
+		walkn(f, n.OnConflictSet)
+		walkn(f, n.OnConflictWhere)
+		walkn(f, n.ExclRelTlist)
+
+	case *pg.OpExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.Args)
+
+	case *pg.Param:
+		walkn(f, n.Xpr)
+
+	case *pg.ParamExecData:
+		// pass
+
+	case *pg.ParamExternData:
+		// pass
+
+	case *pg.ParamListInfoData:
+		// pass
+
+	case *pg.ParamRef:
+		// pass
+
+	case *pg.PartitionBoundSpec:
+		walkn(f, n.Listdatums)
+		walkn(f, n.Lowerdatums)
+		walkn(f, n.Upperdatums)
+
+	case *pg.PartitionCmd:
+		walkn(f, n.Name)
+		walkn(f, n.Bound)
+
+	case *pg.PartitionElem:
+		walkn(f, n.Expr)
+		walkn(f, n.Collation)
+		walkn(f, n.Opclass)
+
+	case *pg.PartitionRangeDatum:
+		walkn(f, n.Value)
+
+	case *pg.PartitionSpec:
+		walkn(f, n.PartParams)
+
+	case *pg.PrepareStmt:
+		walkn(f, n.Argtypes)
+		walkn(f, n.Query)
+
+	case *pg.Query:
+		walkn(f, n.UtilityStmt)
+		walkn(f, n.CteList)
+		walkn(f, n.Rtable)
+		walkn(f, n.Jointree)
+		walkn(f, n.TargetList)
+		walkn(f, n.OnConflict)
+		walkn(f, n.ReturningList)
+		walkn(f, n.GroupClause)
+		walkn(f, n.GroupingSets)
+		walkn(f, n.HavingQual)
+		walkn(f, n.WindowClause)
+		walkn(f, n.DistinctClause)
+		walkn(f, n.SortClause)
+		walkn(f, n.LimitOffset)
+		walkn(f, n.LimitCount)
+		walkn(f, n.RowMarks)
+		walkn(f, n.SetOperations)
+		walkn(f, n.ConstraintDeps)
+		walkn(f, n.WithCheckOptions)
+
+	case *pg.RangeFunction:
+		walkn(f, n.Functions)
+		walkn(f, n.Alias)
+		walkn(f, n.Coldeflist)
+
+	case *pg.RangeSubselect:
+		walkn(f, n.Subquery)
+		walkn(f, n.Alias)
+
+	case *pg.RangeTableFunc:
+		walkn(f, n.Docexpr)
+		walkn(f, n.Rowexpr)
+		walkn(f, n.Namespaces)
+		walkn(f, n.Columns)
+		walkn(f, n.Alias)
+
+	case *pg.RangeTableFuncCol:
+		walkn(f, n.TypeName)
+		walkn(f, n.Colexpr)
+		walkn(f, n.Coldefexpr)
+
+	case *pg.RangeTableSample:
+		walkn(f, n.Relation)
+		walkn(f, n.Method)
+		walkn(f, n.Args)
+		walkn(f, n.Repeatable)
+
+	case *pg.RangeTblEntry:
+		walkn(f, n.Tablesample)
+		walkn(f, n.Subquery)
+		walkn(f, n.Joinaliasvars)
+		walkn(f, n.Functions)
+		walkn(f, n.Tablefunc)
+		walkn(f, n.ValuesLists)
+		walkn(f, n.Coltypes)
+		walkn(f, n.Coltypmods)
+		walkn(f, n.Colcollations)
+		walkn(f, n.Alias)
+		walkn(f, n.Eref)
+		walkn(f, n.SecurityQuals)
+
+	case *pg.RangeTblFunction:
+		walkn(f, n.Funcexpr)
+		walkn(f, n.Funccolnames)
+		walkn(f, n.Funccoltypes)
+		walkn(f, n.Funccoltypmods)
+		walkn(f, n.Funccolcollations)
+
+	case *pg.RangeTblRef:
+		// pass
+
+	case *pg.RangeVar:
+		walkn(f, n.Alias)
+
+	case *pg.RawStmt:
+		walkn(f, n.Stmt)
+
+	case *pg.ReassignOwnedStmt:
+		walkn(f, n.Roles)
+		walkn(f, n.Newrole)
+
+	case *pg.RefreshMatViewStmt:
+		walkn(f, n.Relation)
+
+	case *pg.ReindexStmt:
+		walkn(f, n.Relation)
+
+	case *pg.RelabelType:
+		walkn(f, n.Xpr)
+		walkn(f, n.Arg)
+
+	case *pg.RenameStmt:
+		walkn(f, n.Relation)
+		walkn(f, n.Object)
+
+	case *pg.ReplicaIdentityStmt:
+		// pass
+
+	case *pg.ResTarget:
+		walkn(f, n.Indirection)
+		walkn(f, n.Val)
+
+	case *pg.RoleSpec:
+		// pass
+
+	case *pg.RowCompareExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.Opnos)
+		walkn(f, n.Opfamilies)
+		walkn(f, n.Inputcollids)
+		walkn(f, n.Largs)
+		walkn(f, n.Rargs)
+
+	case *pg.RowExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.Args)
+		walkn(f, n.Colnames)
+
+	case *pg.RowMarkClause:
+		// pass
+
+	case *pg.RuleStmt:
+		walkn(f, n.Relation)
+		walkn(f, n.WhereClause)
+		walkn(f, n.Actions)
+
+	case *pg.SQLValueFunction:
+		walkn(f, n.Xpr)
+
+	case *pg.ScalarArrayOpExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.Args)
+
+	case *pg.SecLabelStmt:
+		walkn(f, n.Object)
+
+	case *pg.SelectStmt:
+		walkn(f, n.DistinctClause)
+		walkn(f, n.IntoClause)
+		walkn(f, n.TargetList)
+		walkn(f, n.FromClause)
+		walkn(f, n.WhereClause)
+		walkn(f, n.GroupClause)
+		walkn(f, n.HavingClause)
+		walkn(f, n.WindowClause)
+		walkn(f, n.SortClause)
+		walkn(f, n.LimitOffset)
+		walkn(f, n.LimitCount)
+		walkn(f, n.LockingClause)
+		walkn(f, n.WithClause)
+		walkn(f, n.Larg)
+		walkn(f, n.Rarg)
+
+	case *pg.SetOperationStmt:
+		walkn(f, n.Larg)
+		walkn(f, n.Rarg)
+		walkn(f, n.ColTypes)
+		walkn(f, n.ColTypmods)
+		walkn(f, n.ColCollations)
+		walkn(f, n.GroupClauses)
+
+	case *pg.SetToDefault:
+		walkn(f, n.Xpr)
+
+	case *pg.SortBy:
+		walkn(f, n.Node)
+		walkn(f, n.UseOp)
+
+	case *pg.SortGroupClause:
+		// pass
+
+	case *pg.String:
+		// pass
+
+	case *pg.SubLink:
+		walkn(f, n.Xpr)
+		walkn(f, n.Testexpr)
+		walkn(f, n.OperName)
+		walkn(f, n.Subselect)
+
+	case *pg.SubPlan:
+		walkn(f, n.Xpr)
+		walkn(f, n.Testexpr)
+		walkn(f, n.ParamIds)
+		walkn(f, n.SetParam)
+		walkn(f, n.ParParam)
+		walkn(f, n.Args)
+
+	case *pg.TableFunc:
+		walkn(f, n.NsUris)
+		walkn(f, n.NsNames)
+		walkn(f, n.Docexpr)
+		walkn(f, n.Rowexpr)
+		walkn(f, n.Colnames)
+		walkn(f, n.Coltypes)
+		walkn(f, n.Coltypmods)
+		walkn(f, n.Colcollations)
+		walkn(f, n.Colexprs)
+		walkn(f, n.Coldefexprs)
+
+	case *pg.TableLikeClause:
+		walkn(f, n.Relation)
+
+	case *pg.TableSampleClause:
+		walkn(f, n.Args)
+		walkn(f, n.Repeatable)
+
+	case *pg.TargetEntry:
+		walkn(f, n.Xpr)
+		walkn(f, n.Expr)
+
+	case *pg.TransactionStmt:
+		walkn(f, n.Options)
+
+	case *pg.TriggerTransition:
+		// pass
+
+	case *pg.TruncateStmt:
+		walkn(f, n.Relations)
+
+	case *pg.TypeCast:
+		walkn(f, n.Arg)
+		walkn(f, n.TypeName)
+
+	case *pg.TypeName:
+		walkn(f, n.Names)
+		walkn(f, n.Typmods)
+		walkn(f, n.ArrayBounds)
+
+	case *pg.UnlistenStmt:
+		// pass
+
+	case *pg.UpdateStmt:
+		walkn(f, n.Relation)
+		walkn(f, n.TargetList)
+		walkn(f, n.WhereClause)
+		walkn(f, n.FromClause)
+		walkn(f, n.ReturningList)
+		walkn(f, n.WithClause)
+
+	case *pg.VacuumStmt:
+		walkn(f, n.Relation)
+		walkn(f, n.VaCols)
+
+	case *pg.Var:
+		walkn(f, n.Xpr)
+
+	case *pg.VariableSetStmt:
+		walkn(f, n.Args)
+
+	case *pg.VariableShowStmt:
+		// pass
+
+	case *pg.ViewStmt:
+		walkn(f, n.View)
+		walkn(f, n.Aliases)
+		walkn(f, n.Query)
+		walkn(f, n.Options)
+
+	case *pg.WindowClause:
+		walkn(f, n.PartitionClause)
+		walkn(f, n.OrderClause)
+		walkn(f, n.StartOffset)
+		walkn(f, n.EndOffset)
+
+	case *pg.WindowDef:
+		walkn(f, n.PartitionClause)
+		walkn(f, n.OrderClause)
+		walkn(f, n.StartOffset)
+		walkn(f, n.EndOffset)
+
+	case *pg.WindowFunc:
+		walkn(f, n.Xpr)
+		walkn(f, n.Args)
+		walkn(f, n.Aggfilter)
+
+	case *pg.WithCheckOption:
+		walkn(f, n.Qual)
+
+	case *pg.WithClause:
+		walkn(f, n.Ctes)
+
+	case *pg.XmlExpr:
+		walkn(f, n.Xpr)
+		walkn(f, n.NamedArgs)
+		walkn(f, n.ArgNames)
+		walkn(f, n.Args)
+
+	case *pg.XmlSerialize:
+		walkn(f, n.Expr)
+		walkn(f, n.TypeName)
+
+	default:
+		panic(fmt.Sprintf("walk: unexpected node type %T", n))
+	}
+
+	f.Visit(nil)
+}


### PR DESCRIPTION
For now, our internal representation will be based on the pg_query_go to aid porting.

The `cmd/sqlc-*` commands will be removed before merging.