### PR TITLE
Add LeavePlural config option

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,7 +114,8 @@ type SQLGen struct {
 type SQLGo struct {
 	EmitInterface       bool              `json:"emit_interface" yaml:"emit_interface"`
 	EmitJSONTags        bool              `json:"emit_json_tags" yaml:"emit_json_tags"`
-	EmitPreparedQueries bool              `json:"emit_prepared_queries" yaml:"emit_prepared_queries":`
+	EmitPreparedQueries bool              `json:"emit_prepared_queries" yaml:"emit_prepared_queries"`
+	EmitExactTableNames bool              `json:"emit_exact_table_names,omitempty" yaml:"emit_exact_table_names"`
 	Package             string            `json:"package" yaml:"package"`
 	Out                 string            `json:"out" yaml:"out"`
 	Overrides           []Override        `json:"overrides,omitempty" yaml:"overrides"`
@@ -122,8 +123,9 @@ type SQLGo struct {
 }
 
 type SQLKotlin struct {
-	Package string `json:"package" yaml:"package"`
-	Out     string `json:"out" yaml:"out"`
+	EmitExactTableNames bool   `json:"emit_exact_table_names,omitempty" yaml:"emit_exact_table_names"`
+	Package             string `json:"package" yaml:"package"`
+	Out                 string `json:"out" yaml:"out"`
 }
 
 type Override struct {

--- a/internal/config/v_one.go
+++ b/internal/config/v_one.go
@@ -24,6 +24,7 @@ type v1PackageSettings struct {
 	EmitInterface       bool       `json:"emit_interface" yaml:"emit_interface"`
 	EmitJSONTags        bool       `json:"emit_json_tags" yaml:"emit_json_tags"`
 	EmitPreparedQueries bool       `json:"emit_prepared_queries" yaml:"emit_prepared_queries"`
+	EmitExactTableNames bool       `json:"emit_exact_table_names,omitempty" yaml:"emit_exact_table_names"`
 	Overrides           []Override `json:"overrides" yaml:"overrides"`
 }
 
@@ -103,6 +104,7 @@ func (c *V1GenerateSettings) Translate() Config {
 					EmitInterface:       pkg.EmitInterface,
 					EmitJSONTags:        pkg.EmitJSONTags,
 					EmitPreparedQueries: pkg.EmitPreparedQueries,
+					EmitExactTableNames: pkg.EmitExactTableNames,
 					Package:             pkg.Name,
 					Out:                 pkg.Path,
 					Overrides:           pkg.Overrides,

--- a/internal/dinosql/gen.go
+++ b/internal/dinosql/gen.go
@@ -595,9 +595,13 @@ func (r Result) Structs(settings config.CombinedSettings) []GoStruct {
 			} else {
 				tableName = name + "_" + table.Name
 			}
+			structName := tableName
+			if !settings.Go.EmitExactTableNames {
+				structName = inflection.Singular(structName)
+			}
 			s := GoStruct{
 				Table:   core.FQN{Schema: name, Rel: table.Name},
-				Name:    StructName(inflection.Singular(tableName), settings),
+				Name:    StructName(structName, settings),
 				Comment: table.Comment,
 			}
 			for _, column := range table.Columns {

--- a/internal/dinosql/kotlin/gen.go
+++ b/internal/dinosql/kotlin/gen.go
@@ -446,9 +446,13 @@ func (r Result) KtDataClasses(settings config.CombinedSettings) []KtStruct {
 			} else {
 				tableName = name + "_" + table.Name
 			}
+			structName := KtDataClassName(tableName, settings)
+			if !settings.Go.EmitExactTableNames {
+				structName = inflection.Singular(structName)
+			}
 			s := KtStruct{
 				Table:   core.FQN{Schema: name, Rel: table.Name},
-				Name:    inflection.Singular(KtDataClassName(tableName, settings)),
+				Name:    structName,
 				Comment: table.Comment,
 			}
 			for _, column := range table.Columns {

--- a/internal/mysql/gen.go
+++ b/internal/mysql/gen.go
@@ -68,7 +68,7 @@ func (r *Result) Structs(settings config.CombinedSettings) []dinosql.GoStruct {
 	var structs []dinosql.GoStruct
 	for tableName, cols := range r.Schema.tables {
 		structName := dinosql.StructName(tableName, settings)
-		if !settings.Pkg.EmitExactTableNames {
+		if !(settings.Go.EmitExactTableNames || settings.Kotlin.EmitExactTableNames) {
 			structName = inflection.Singular(structName)
 		}
 		s := dinosql.GoStruct{

--- a/internal/mysql/gen.go
+++ b/internal/mysql/gen.go
@@ -67,8 +67,12 @@ func (pGen PackageGenerator) enumNameFromColDef(col *sqlparser.ColumnDefinition)
 func (r *Result) Structs(settings config.CombinedSettings) []dinosql.GoStruct {
 	var structs []dinosql.GoStruct
 	for tableName, cols := range r.Schema.tables {
+		structName := dinosql.StructName(tableName, settings)
+		if !settings.Pkg.EmitExactTableNames {
+			structName = inflection.Singular(structName)
+		}
 		s := dinosql.GoStruct{
-			Name:  inflection.Singular(dinosql.StructName(tableName, settings)),
+			Name:  structName,
 			Table: core.FQN{tableName, "", ""}, // TODO: Complete hack. Only need for equality check to see if struct can be reused between queries
 		}
 


### PR DESCRIPTION
If set to true, the struct names are not singularized.

My table names are not English, stripping the "s" from the end
is quite annoying.