### PR TITLE
internal/dinosql: Check parameter style before ref

### DIFF
--- a/internal/dinosql/parser.go
+++ b/internal/dinosql/parser.go
@@ -398,10 +398,10 @@ func validateCmd(n nodes.Node, name, cmd string) error {
 var errUnsupportedStatementType = errors.New("parseQuery: unsupported statement type")
 
 func parseQuery(c core.Catalog, stmt nodes.Node, source string, rewriteParameters bool) (*Query, error) {
-	if err := validateParamRef(stmt); err != nil {
+	if err := validateParamStyle(stmt); err != nil {
 		return nil, err
 	}
-	if err := validateParamStyle(stmt); err != nil {
+	if err := validateParamRef(stmt); err != nil {
 		return nil, err
 	}
 	raw, ok := stmt.(nodes.RawStmt)

--- a/internal/endtoend/testdata/invalid_params/query.sql
+++ b/internal/endtoend/testdata/invalid_params/query.sql
@@ -10,7 +10,7 @@ SELECT foo FROM bar WHERE baz = $1 AND baz = $3;
 SELECT foo FROM bar;
 
 -- name: Named :many
-SELECT id FROM bar WHERE id = $1 AND sqlc.arg(named) = true;
+SELECT id FROM bar WHERE id = $1 AND sqlc.arg(named) = true AND id = $5;
 
 -- stderr
 -- # package querytest


### PR DESCRIPTION
A invalid query with mixed parameter styles ($1, sqlc.arg, @) and
missing parameter refs ($1, $3, but no $2) should error with a mixed
parameter style error.

Before this change, this query fail to compile with an ambiguous `could not determine data type of parameter $2` message.

Thanks to @kevinburkemeter for the bug report.