### PR TITLE
internal/postgresql: Fix NamedArgExpr rewrite

### DIFF
--- a/internal/postgresql/ast/astutil.go
+++ b/internal/postgresql/ast/astutil.go
@@ -1020,7 +1020,7 @@ func (a *application) apply(parent nodes.Node, name string, iter *iterator, node
 
 	case nodes.NamedArgExpr:
 		a.apply(&n, "Xpr", nil, n.Xpr)
-		a.apply(&n, "Args", nil, n.Arg)
+		a.apply(&n, "Arg", nil, n.Arg)
 		a.cursor.set(n, &n)
 
 	case nodes.NextValueExpr:


### PR DESCRIPTION
The Arg field was incorrectly named "Args" in the call to apply.

Credit to @kevinburkemeter for the initial bug report