### PR TITLE
compiler: Enable experimental parser by default

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -74,7 +74,7 @@ type Env struct {
 
 func ParseEnv() Env {
 	return Env{
-		ExperimentalParser: os.Getenv("SQLC_EXPERIMENTAL_PARSER") == "on",
+		ExperimentalParser: os.Getenv("SQLC_EXPERIMENTAL_PARSER") != "off",
 	}
 }
 

--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -61,7 +61,7 @@ func TestReplay(t *testing.T) {
 			path, _ := filepath.Abs(filepath.Join("testdata", tc))
 			var stderr bytes.Buffer
 			expected := expectedStderr(t, path)
-			output, err := cmd.Generate(cmd.Env{}, path, &stderr)
+			output, err := cmd.Generate(cmd.Env{ExperimentalParser: true}, path, &stderr)
 			if len(expected) == 0 && err != nil {
 				t.Fatalf("sqlc generate failed: %s", stderr.String())
 			}
@@ -70,12 +70,12 @@ func TestReplay(t *testing.T) {
 				t.Errorf("stderr differed (-want +got):\n%s", diff)
 			}
 		})
-		t.Run(tc+"/experimental", func(t *testing.T) {
+		t.Run(tc+"/deprecated-parser", func(t *testing.T) {
 			t.Parallel()
 			path, _ := filepath.Abs(filepath.Join("testdata", tc))
 			var stderr bytes.Buffer
 			expected := expectedStderr(t, path)
-			output, err := cmd.Generate(cmd.Env{ExperimentalParser: true}, path, &stderr)
+			output, err := cmd.Generate(cmd.Env{ExperimentalParser: false}, path, &stderr)
 			if len(expected) == 0 && err != nil {
 				t.Fatalf("sqlc generate failed: %s", stderr.String())
 			}


### PR DESCRIPTION
The parser seems to be in a good enough state to turn on my default. Setting `SQLC_EXPERIMENTAL_PARSER=off` will revert to previous behavior. The plan is to remove the old code path in the v1.5.0 release.