### PR TITLE
MySQL: Prevent Panic when WHERE clause contains parenthesis. 

### DIFF
--- a/internal/endtoend/testdata/mysql_param/query.sql
+++ b/internal/endtoend/testdata/mysql_param/query.sql
@@ -26,9 +26,8 @@ select first_name, id FROM users LIMIT sqlc.arg(UsersLimit);
 /* name: InsertNewUser :exec */
 INSERT INTO users (first_name, last_name) VALUES (?, sqlc.arg(user_last_name));
 
-
 /* name: ListUserParenExpr :many */
 SELECT * FROM users WHERE (job_status = 'APPLIED' OR job_status = 'PENDING')
 AND id > :lastID
+ORDER BY id
 LIMIT :usersLimit;
-

--- a/internal/endtoend/testdata/mysql_param/query.sql
+++ b/internal/endtoend/testdata/mysql_param/query.sql
@@ -25,3 +25,10 @@ select first_name, id FROM users LIMIT sqlc.arg(UsersLimit);
 
 /* name: InsertNewUser :exec */
 INSERT INTO users (first_name, last_name) VALUES (?, sqlc.arg(user_last_name));
+
+
+/* name: ListUserParenExpr :many */
+SELECT * FROM users WHERE (job_status = 'APPLIED' OR job_status = 'PENDING')
+AND id > :lastID
+LIMIT :usersLimit;
+

--- a/internal/mysql/param.go
+++ b/internal/mysql/param.go
@@ -110,6 +110,12 @@ func (pGen PackageGenerator) paramsInWhereExpr(e sqlparser.SQLNode, tableAliasMa
 	case *sqlparser.IsExpr:
 		// TODO: see if there is a use case for params in IS expressions
 		return []*Param{}, nil
+	case *sqlparser.ParenExpr:
+		expr, err := pGen.paramsInWhereExpr(v.Expr, tableAliasMap, defaultTable)
+		if err != nil {
+			return nil, err
+		}
+		params = append(params, expr...)
 	default:
 		panic(fmt.Sprintf("Failed to handle %T in where", v))
 	}


### PR DESCRIPTION
The sqlc MySQL parser didn't have the logic to handle a where clause with parenthesis in it and would panic. This seems to fix it, but there might be some edge cases I didn't account for. (Sorry for the semi-contrived test case, its similar to what I needed but its also kinda silly)
