### PR TITLE
docker: Build sqlc using Go 1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # STEP 1: Build sqlc
-FROM golang:1.13 AS builder
+FROM golang:1.14 AS builder
 
 COPY . /workspace
 WORKDIR /workspace


### PR DESCRIPTION
This only affects the sqlc Docker container