### PR TITLE
Add option to return empty slices in generated :many query, to improve usability with JSON

### DIFF
--- a/internal/codegen/golang/gen.go
+++ b/internal/codegen/golang/gen.go
@@ -652,7 +652,11 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ([]{{.Ret.
 		return nil, err
 	}
 	defer rows.Close()
+	{{- if $.EmitEmptySlices}}
+	items := []{{.Ret.Type}}{}
+	{{else}}
 	var items []{{.Ret.Type}}
+	{{end -}}
 	for rows.Next() {
 		var {{.Ret.Name}} {{.Ret.Type}}
 		if err := rows.Scan({{.Ret.Scan}}); err != nil {
@@ -729,6 +733,7 @@ type tmplCtx struct {
 	EmitJSONTags        bool
 	EmitPreparedQueries bool
 	EmitInterface       bool
+	EmitEmptySlices     bool
 }
 
 func (t *tmplCtx) OutputQuery(sourceName string) bool {
@@ -750,6 +755,7 @@ func Generate(r Generateable, settings config.CombinedSettings) (map[string]stri
 		EmitInterface:       golang.EmitInterface,
 		EmitJSONTags:        golang.EmitJSONTags,
 		EmitPreparedQueries: golang.EmitPreparedQueries,
+		EmitEmptySlices:     golang.EmitEmptySlices,
 		Q:                   "`",
 		Package:             golang.Package,
 		GoQueries:           r.GoQueries(settings),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,6 +115,7 @@ type SQLGo struct {
 	EmitJSONTags        bool              `json:"emit_json_tags" yaml:"emit_json_tags"`
 	EmitPreparedQueries bool              `json:"emit_prepared_queries" yaml:"emit_prepared_queries"`
 	EmitExactTableNames bool              `json:"emit_exact_table_names,omitempty" yaml:"emit_exact_table_names"`
+	EmitEmptySlices     bool              `json:"emit_empty_slices,omitempty" yaml:"emit_empty_slices"`
 	Package             string            `json:"package" yaml:"package"`
 	Out                 string            `json:"out" yaml:"out"`
 	Overrides           []Override        `json:"overrides,omitempty" yaml:"overrides"`


### PR DESCRIPTION
## Description

sqlc is very useful when creating REST APIs. However when querying for a collection of models using the `:many` query, while the corresponding database table is empty, the result in JSON is marshalled into `null`. To improve the usability with APIs returning JSON and preferabily `[]` instead of `null`, I propose to add an option to change the returned slice of generated `:many` queries. See examples below.


## Current behavior

Let's take a look at the example in `sqlc/examples/authors/`:

The following query in `query.sql`:
```sql
-- name: ListAuthors :many
SELECT * FROM authors
ORDER BY name;
```

Generates the following Go code:
```go
func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
	// snip ...
	var items []Author
	// snip ...
	return items, nil
}
```

When the database table `authors` is empty, the returned results of this function is `[]pkg.Authors(nil), <nil>`.
Therefore when marshalling the result as JSON, the output is therefore `null` aswell. 

Example code:
```go
// Create response struct
resp := struct {
	Authors []Author `json:"authors"`
}{}

// Fill in authors
resp.Authors, _ = db.ListAuthors(context.Background())

// Marshall to JSON
data, _ := json.MarshalIndent(resp, "", "\t")

// Print it
fmt.Println(string(data))
```
Output:
```json
{
	"authors": null
}
```

In usecases like JavaScript applications or other API consumers it is easier to deal with an empty array `[]` instead of `null` because `null` has to be treated specifically.

---

## Proposed behavior
With this pull request I've added an additional configuration option (opt in) which changes this behavior, so the marshalled JSON turnes into an empty array `[]` instead of `null`. The added configuration option is called `emit_empty_slices` (but could be changed if someone suggests a more precise keyword).

In the sqlc.json this option goes right where the other options go:
```javascript
{
  "version": "2",
  "sql": [
    {
      "schema": "schema.sql",
      "queries": "query.sql",
      "engine": "postgresql",
      "gen": {
        "go": {
          "package": "authors",
          "out": ".",
          "emit_json_tags": true,
          "emit_empty_slices": true // <----- new addition
        }
      }
    }
  ]
}
```

With this option enabled, the generated Go code for the same function will have just a very suble difference in the initialization of the returned slice. `var items []Author` becomes `items := []Author{}`:

```go
func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
	// snip ...
	items := []Author{}
	// snip ...
	return items, nil
}
```

Executing the Go code in the example above on an empty authors table will now result in this JSON output:
```json
{
	"authors": []
}
```

## Conclusion
This makes direct use of sqlc results in a JSON encoded REST API much more comfortable for e.g. JavaScript clients.