### PR TITLE
cmd: Add debugging support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/antlr/antlr4 v0.0.0-20200209180723-1177c0b58d07
+	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-cmp v0.4.0
 	github.com/jinzhu/inflection v1.0.0
 	github.com/lfittl/pg_query_go v1.0.0

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -91,6 +91,12 @@ func Generate(e Env, dir string, stderr io.Writer) (map[string]string, error) {
 		return nil, err
 	}
 
+	debug, err := opts.DebugFromEnv()
+	if err != nil {
+		fmt.Fprintf(stderr, "error parsing SQLCDEBUG: %s\n", err)
+		return nil, err
+	}
+
 	output := map[string]string{}
 	errored := false
 
@@ -127,7 +133,9 @@ func Generate(e Env, dir string, stderr io.Writer) (map[string]string, error) {
 		sql.Queries = joined
 
 		var name string
-		parseOpts := opts.Parser{}
+		parseOpts := opts.Parser{
+			Debug: debug,
+		}
 		if sql.Gen.Go != nil {
 			name = combo.Go.Package
 		} else if sql.Gen.Kotlin != nil {

--- a/internal/compiler/compile.go
+++ b/internal/compiler/compile.go
@@ -104,7 +104,7 @@ func parseQueries(p Parser, c *catalog.Catalog, queries []string, o opts.Parser)
 			continue
 		}
 		for _, stmt := range stmts {
-			query, err := parseQuery(p, c, stmt.Raw, src, o.UsePositionalParameters)
+			query, err := parseQuery(p, c, stmt.Raw, src, o)
 			if err == ErrUnsupportedStatementType {
 				continue
 			}

--- a/internal/debug/dump.go
+++ b/internal/debug/dump.go
@@ -1,0 +1,9 @@
+package debug
+
+import (
+	"github.com/davecgh/go-spew/spew"
+)
+
+func Dump(n interface{}) {
+	spew.Dump(n)
+}

--- a/internal/opts/debug.go
+++ b/internal/opts/debug.go
@@ -1,0 +1,29 @@
+package opts
+
+import (
+	"os"
+	"strings"
+)
+
+// The SQLCDEBUG variable controls debugging variables within the runtime. It
+// is a comma-separated list of name=val pairs setting these named variables:
+//
+//     dumpast: setting dumpast=1 will print the AST of every SQL statement
+
+type Debug struct {
+	DumpAST bool
+}
+
+func DebugFromEnv() (Debug, error) {
+	d := Debug{}
+	val := os.Getenv("SQLCDEBUG")
+	if val == "" {
+		return d, nil
+	}
+	for _, pair := range strings.Split(val, ",") {
+		if pair == "dumpast=1" {
+			d.DumpAST = true
+		}
+	}
+	return d, nil
+}

--- a/internal/opts/parser.go
+++ b/internal/opts/parser.go
@@ -2,4 +2,5 @@ package opts
 
 type Parser struct {
 	UsePositionalParameters bool
+	Debug                   Debug
 }


### PR DESCRIPTION
The SQLCDEBUG environment variable can be used to control dumping AST
nodes to stdout.