### PR TITLE
golang: Generate correct types for int2 and int8

### DIFF
--- a/internal/codegen/golang/postgresql_type.go
+++ b/internal/codegen/golang/postgresql_type.go
@@ -34,13 +34,13 @@ func postgresType(r *compiler.Result, col *compiler.Column, settings config.Comb
 		}
 		return "sql.NullInt32"
 
-	case "bigint", "pg_catalog.int8":
+	case "bigint", "int8", "pg_catalog.int8":
 		if notNull {
 			return "int64"
 		}
 		return "sql.NullInt64"
 
-	case "smallint", "pg_catalog.int2":
+	case "smallint", "int2", "pg_catalog.int2":
 		return "int16"
 
 	case "float", "double precision", "pg_catalog.float8":

--- a/internal/endtoend/testdata/datatype/go/models.go
+++ b/internal/endtoend/testdata/datatype/go/models.go
@@ -56,6 +56,9 @@ type DtNumeric struct {
 	H int16
 	I sql.NullInt32
 	J sql.NullInt64
+	K int16
+	L sql.NullInt32
+	M sql.NullInt64
 }
 
 type DtNumericNotNull struct {
@@ -69,4 +72,7 @@ type DtNumericNotNull struct {
 	H int16
 	I int32
 	J int64
+	K int16
+	L int32
+	M int64
 }

--- a/internal/endtoend/testdata/datatype/sql/numeric.sql
+++ b/internal/endtoend/testdata/datatype/sql/numeric.sql
@@ -12,7 +12,11 @@ CREATE TABLE dt_numeric (
     -- TODO: this maps incorrectly to int16, not NullInt16
     h smallserial,
     i serial,
-    j bigserial
+    j bigserial,
+    -- TODO: this maps incorrectly to int16, not NullInt16
+    k int2,
+    l int4,
+    m int8
 );
 
 CREATE TABLE dt_numeric_not_null (
@@ -25,5 +29,8 @@ CREATE TABLE dt_numeric_not_null (
     g double precision NOT NULL,
     h smallserial NOT NULL,
     i serial NOT NULL,
-    j bigserial NOT NULL
+    j bigserial NOT NULL,
+    k int2 NOT NULL,
+    l int4 NOT NULL,
+    m int8 NOT NULL
 );


### PR DESCRIPTION
Fixes #578 