### PR TITLE
Fixed typo in settings example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ packages:
     emit_prepared_queries: true
     emit_interface: false
     emit_exact_table_names: false
-    emit_emptly_slices: false
+    emit_empty_slices: false
 ```
 
 Each package document has the following keys:


### PR DESCRIPTION
Fixed misspelling of `emit_empty_slices` as `emit_emptly_slices`.