### PR TITLE
Dolphin: Skip processing view drops

### DIFF
--- a/internal/engine/dolphin/convert.go
+++ b/internal/engine/dolphin/convert.go
@@ -170,6 +170,10 @@ func (c *cc) convertDeleteStmt(n *pcast.DeleteStmt) *pg.DeleteStmt {
 }
 
 func (c *cc) convertDropTableStmt(n *pcast.DropTableStmt) ast.Node {
+	// TODO: Remove once views are supported.
+	if n.IsView {
+		return &ast.TODO{}
+	}
 	drop := &ast.DropTableStmt{IfExists: n.IfExists}
 	for _, name := range n.Tables {
 		drop.Tables = append(drop.Tables, parseTableName(name))


### PR DESCRIPTION
We don't currently process create view statements, but drop view statements get
parsed as regular drop statements, so we need to skip processing drops when
they're for views.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kyleconroy/sqlc/653)
<!-- Reviewable:end -->
