### PR TITLE
dolphin: Represent tinyint as int32

### DIFF
--- a/internal/codegen/golang/mysql_type.go
+++ b/internal/codegen/golang/mysql_type.go
@@ -21,7 +21,7 @@ func mysqlType(r *compiler.Result, col *compiler.Column, settings config.Combine
 		}
 		return "sql.NullString"
 
-	case "int", "integer", "smallint", "mediumint", "year":
+	case "int", "integer", "tinyint", "smallint", "mediumint", "year":
 		if notNull {
 			return "int32"
 		}
@@ -58,7 +58,7 @@ func mysqlType(r *compiler.Result, col *compiler.Column, settings config.Combine
 		}
 		return "sql.NullTime"
 
-	case "boolean", "bool", "tinyint":
+	case "boolean", "bool":
 		if notNull {
 			return "bool"
 		}

--- a/internal/endtoend/testdata/insert_select/mysql/go/models.go
+++ b/internal/endtoend/testdata/insert_select/mysql/go/models.go
@@ -6,7 +6,7 @@ import ()
 
 type Bar struct {
 	Name  string
-	Ready bool
+	Ready int32
 }
 
 type Foo struct {

--- a/internal/endtoend/testdata/insert_select/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/insert_select/mysql/go/query.sql.go
@@ -15,7 +15,7 @@ FROM bar WHERE ready = ?
 
 type InsertSelectParams struct {
 	Meta  string
-	Ready bool
+	Ready int32
 }
 
 func (q *Queries) InsertSelect(ctx context.Context, arg InsertSelectParams) error {


### PR DESCRIPTION
Fixes #666 

Please see the discussion on https://github.com/go-sql-driver/mysql/issues/440 as to why we can't default to using tinyint as a bool value.