### PR TITLE
Generate valid code for MySQL named parameters

### DIFF
--- a/internal/endtoend/testdata/params_duplicate/mysql/go/models.go
+++ b/internal/endtoend/testdata/params_duplicate/mysql/go/models.go
@@ -8,6 +8,6 @@ import (
 
 type User struct {
 	ID        int32
-	FirstName string
+	FirstName sql.NullString
 	LastName  sql.NullString
 }

--- a/internal/endtoend/testdata/params_duplicate/mysql/query.sql
+++ b/internal/endtoend/testdata/params_duplicate/mysql/query.sql
@@ -1,6 +1,12 @@
-/* name: SelectUserArg :many */
+/* name: SelectUserByID :many */
 SELECT first_name from
 users where (sqlc.arg(id) = id OR sqlc.arg(id) = 0);
+
+/* name: SelectUserByName :many */
+SELECT first_name
+FROM users
+WHERE first_name = sqlc.arg(name)
+   OR last_name = sqlc.arg(name);
 
 /* name: SelectUserQuestion :many */
 SELECT first_name from

--- a/internal/endtoend/testdata/params_duplicate/mysql/schema.sql
+++ b/internal/endtoend/testdata/params_duplicate/mysql/schema.sql
@@ -1,5 +1,5 @@
 CREATE TABLE users (
     id integer NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    first_name varchar(255) NOT NULL,
+    first_name varchar(255),
     last_name varchar(255)
 ) ENGINE=InnoDB;

--- a/internal/sql/rewrite/parameters.go
+++ b/internal/sql/rewrite/parameters.go
@@ -48,6 +48,8 @@ func NamedParameters(engine config.Engine, raw *ast.RawStmt) (*ast.RawStmt, map[
 		return raw, map[int]string{}, nil
 	}
 
+	hasNamedParameterSupport := engine != config.EngineMySQL
+
 	args := map[string]int{}
 	argn := 0
 	var edits []source.Edit
@@ -58,7 +60,7 @@ func NamedParameters(engine config.Engine, raw *ast.RawStmt) (*ast.RawStmt, map[
 		case named.IsParamFunc(node):
 			fun := node.(*ast.FuncCall)
 			param, isConst := flatten(fun.Args)
-			if num, ok := args[param]; ok {
+			if num, ok := args[param]; ok && hasNamedParameterSupport {
 				cr.Replace(&ast.ParamRef{
 					Number:   num,
 					Location: fun.Location,


### PR DESCRIPTION
While this technically is a solution for #777, I'm not happy with it. I'd like to get real support for named parameters before I release 1.6.0.