### PR TITLE
Add a flag to allow the config file path to be specified

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -17,6 +17,7 @@ import (
 // Do runs the command logic.
 func Do(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
 	rootCmd := &cobra.Command{Use: "sqlc", SilenceUsage: true}
+	rootCmd.PersistentFlags().String("config", "", "Path to config file to use (e.g. sqlc.yaml or sqlc.json)")
 	rootCmd.AddCommand(checkCmd)
 	rootCmd.AddCommand(genCmd)
 	rootCmd.AddCommand(initCmd)
@@ -86,7 +87,12 @@ var genCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		output, err := Generate(ParseEnv(), dir, stderr)
+		configFlag, err := cmd.Flags().GetString("config")
+		if err != nil {
+			configFlag = ""
+		}
+
+		output, err := Generate(ParseEnv(), dir, configFlag, stderr)
 		if err != nil {
 			os.Exit(1)
 		}
@@ -111,7 +117,12 @@ var checkCmd = &cobra.Command{
 			fmt.Fprintln(stderr, "error parsing sqlc.json: file does not exist")
 			os.Exit(1)
 		}
-		if _, err := Generate(Env{}, dir, stderr); err != nil {
+		configFlag, err := cmd.Flags().GetString("config")
+		if err != nil {
+			configFlag = ""
+		}
+
+		if _, err := Generate(Env{}, dir, configFlag, stderr); err != nil {
 			os.Exit(1)
 		}
 		return nil

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -44,10 +44,21 @@ type outPair struct {
 	config.SQL
 }
 
-func Generate(e Env, dir string, stderr io.Writer) (map[string]string, error) {
+func Generate(e Env, dir string, configFlag string, stderr io.Writer) (map[string]string, error) {
 	var yamlMissing, jsonMissing bool
-	yamlPath := filepath.Join(dir, "sqlc.yaml")
-	jsonPath := filepath.Join(dir, "sqlc.json")
+	var yamlPath, jsonPath string
+	if strings.HasSuffix(configFlag, ".yaml") {
+		yamlPath = configFlag
+		jsonPath = ""
+		dir = filepath.Dir(configFlag)
+	} else if strings.HasSuffix(configFlag, ".json") {
+		yamlPath = ""
+		jsonPath = configFlag
+		dir = filepath.Dir(configFlag)
+	} else {
+		yamlPath = filepath.Join(dir, "sqlc.yaml")
+		jsonPath = filepath.Join(dir, "sqlc.json")
+	}
 
 	if _, err := os.Stat(yamlPath); os.IsNotExist(err) {
 		yamlMissing = true

--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -35,7 +35,7 @@ func TestExamples(t *testing.T) {
 			t.Parallel()
 			path := filepath.Join(examples, tc)
 			var stderr bytes.Buffer
-			output, err := cmd.Generate(cmd.Env{}, path, &stderr)
+			output, err := cmd.Generate(cmd.Env{}, path, "", &stderr)
 			if err != nil {
 				t.Fatalf("sqlc generate failed: %s", stderr.String())
 			}
@@ -62,7 +62,7 @@ func BenchmarkExamples(b *testing.B) {
 			path := filepath.Join(examples, tc)
 			for i := 0; i < b.N; i++ {
 				var stderr bytes.Buffer
-				cmd.Generate(cmd.Env{}, path, &stderr)
+				cmd.Generate(cmd.Env{}, path, "", &stderr)
 			}
 		})
 	}
@@ -91,7 +91,7 @@ func TestReplay(t *testing.T) {
 			path, _ := filepath.Abs(tc)
 			var stderr bytes.Buffer
 			expected := expectedStderr(t, path)
-			output, err := cmd.Generate(cmd.Env{}, path, &stderr)
+			output, err := cmd.Generate(cmd.Env{}, path, "", &stderr)
 			if len(expected) == 0 && err != nil {
 				t.Fatalf("sqlc generate failed: %s", stderr.String())
 			}
@@ -184,7 +184,7 @@ func BenchmarkReplay(b *testing.B) {
 			path, _ := filepath.Abs(tc)
 			for i := 0; i < b.N; i++ {
 				var stderr bytes.Buffer
-				cmd.Generate(cmd.Env{}, path, &stderr)
+				cmd.Generate(cmd.Env{}, path, "", &stderr)
 			}
 		})
 	}


### PR DESCRIPTION
This diff allows us to pass the location of the config file on the command line, allowing us to call sqlc from another directory than the one where the config file is located.

This is useful in build systems where there are restrictions on the execution environment.