### PR TITLE
📝  fix readme supported types file link

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ overrides:
 
 Each override document has the following keys:
 - `db_type`:
-  - The PostgreSQL type to override. Find the full list of supported types in [gen.go](https://github.com/kyleconroy/sqlc/blob/master/internal/dinosql/gen.go#L438).
+  - The PostgreSQL type to override. Find the full list of supported types in [postgresql_type.go](https://github.com/kyleconroy/sqlc/blob/master/internal/codegen/golang/postgresql_type.go#L12).
 - `go_type`:
   - A fully qualified name to a Go type to use in the generated code.
 - `nullable`:


### PR DESCRIPTION
`internal/dinosql/gen.go` was already missing and the link led to a 404 page, so I fixed it. to `internal/codegen/golang/postgresql_type.go`

#751 