### PR TITLE
brew install sqlc

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ rename:
 ### macOS
 
 ```
-brew install kyleconroy/sqlc/sqlc
+brew install sqlc
 ```
 
 ### Ubuntu


### PR DESCRIPTION
sqlc can now be installed on MacOS via brew without a tap!