### PR TITLE
mysql tinyint(1) as bool

### DIFF
--- a/internal/endtoend/testdata/insert_select/mysql/go/models.go
+++ b/internal/endtoend/testdata/insert_select/mysql/go/models.go
@@ -6,7 +6,7 @@ import ()
 
 type Bar struct {
 	Name  string
-	Ready int32
+	Ready bool
 }
 
 type Foo struct {

--- a/internal/endtoend/testdata/insert_select/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/insert_select/mysql/go/query.sql.go
@@ -15,7 +15,7 @@ FROM bar WHERE ready = ?
 
 type InsertSelectParams struct {
 	Meta  string
-	Ready int32
+	Ready bool
 }
 
 func (q *Queries) InsertSelect(ctx context.Context, arg InsertSelectParams) error {

--- a/internal/engine/dolphin/convert.go
+++ b/internal/engine/dolphin/convert.go
@@ -8,7 +8,6 @@ import (
 	pcast "github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/opcode"
 	driver "github.com/pingcap/parser/test_driver"
-	"github.com/pingcap/parser/types"
 
 	"github.com/kyleconroy/sqlc/internal/debug"
 	"github.com/kyleconroy/sqlc/internal/sql/ast"
@@ -40,7 +39,7 @@ func (c *cc) convertAlterTableStmt(n *pcast.AlterTableStmt) ast.Node {
 					Subtype: ast.AT_AddColumn,
 					Def: &ast.ColumnDef{
 						Colname:   def.Name.String(),
-						TypeName:  &ast.TypeName{Name: types.TypeStr(def.Tp.Tp)},
+						TypeName:  parseTypeName(def),
 						IsNotNull: isNotNull(def),
 					},
 				})
@@ -69,7 +68,7 @@ func (c *cc) convertAlterTableStmt(n *pcast.AlterTableStmt) ast.Node {
 					Subtype: ast.AT_AddColumn,
 					Def: &ast.ColumnDef{
 						Colname:   def.Name.String(),
-						TypeName:  &ast.TypeName{Name: types.TypeStr(def.Tp.Tp)},
+						TypeName:  parseTypeName(def),
 						IsNotNull: isNotNull(def),
 					},
 				})
@@ -226,7 +225,7 @@ func (c *cc) convertCreateTableStmt(n *pcast.CreateTableStmt) ast.Node {
 		}
 		create.Cols = append(create.Cols, &ast.ColumnDef{
 			Colname:   def.Name.String(),
-			TypeName:  &ast.TypeName{Name: types.TypeStr(def.Tp.Tp)},
+			TypeName:  parseTypeName(def),
 			IsNotNull: isNotNull(def),
 			Comment:   comment,
 			Vals:      vals,

--- a/internal/engine/dolphin/utils.go
+++ b/internal/engine/dolphin/utils.go
@@ -2,6 +2,7 @@ package dolphin
 
 import (
 	pcast "github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/types"
 
 	"github.com/kyleconroy/sqlc/internal/sql/ast"
 )
@@ -69,6 +70,14 @@ func parseTableName(n *pcast.TableName) *ast.TableName {
 		Schema: n.Schema.String(),
 		Name:   n.Name.String(),
 	}
+}
+
+func parseTypeName(def *pcast.ColumnDef) *ast.TypeName {
+	name := types.TypeStr(def.Tp.Tp)
+	if name == "tinyint" && def.Tp.Flen == 1 {
+		name = "bool"
+	}
+	return &ast.TypeName{Name: name}
 }
 
 func toList(node pcast.Node) *ast.List {


### PR DESCRIPTION
The current sqlc generate mysql `bool` column type as go `int32`.
pingcap/parser seems to interpret mysql `bool` column type as a `tinyint` type.
Probably because `bool` is an alias for  `tinyint(1)` in mysql.
This PR makes the mysql `bool` column to be output to the go `bool` and the mysql `tinyint(1)` to be output to the go `bool` as well.