### PR TITLE
Support table returns for postgres go

### DIFF
--- a/internal/codegen/golang/postgresql_type.go
+++ b/internal/codegen/golang/postgresql_type.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kyleconroy/sqlc/internal/compiler"
 	"github.com/kyleconroy/sqlc/internal/config"
 	"github.com/kyleconroy/sqlc/internal/debug"
+	"github.com/kyleconroy/sqlc/internal/inflection"
 	"github.com/kyleconroy/sqlc/internal/sql/catalog"
 )
 
@@ -148,6 +149,18 @@ func postgresType(r *compiler.Result, col *compiler.Column, settings config.Comb
 		for _, schema := range r.Catalog.Schemas {
 			if schema.Name == "pg_catalog" {
 				continue
+			}
+			for _, tb := range schema.Tables {
+				if rel.Name == tb.Rel.Name && rel.Schema == schema.Name {
+					name := rel.Name
+					if !settings.Go.EmitExactTableNames {
+						name = inflection.Singular(name)
+					}
+					if rel.Schema == r.Catalog.DefaultSchema {
+						return StructName(name, settings)
+					}
+					return StructName(schema.Name+"_"+name, settings)
+				}
 			}
 			for _, typ := range schema.Types {
 				switch t := typ.(type) {

--- a/internal/compiler/output_columns.go
+++ b/internal/compiler/output_columns.go
@@ -222,7 +222,7 @@ func sourceTables(qc *QueryCatalog, node ast.Node) ([]*Table, error) {
 	case *ast.SelectStmt:
 		list = astutils.Search(n.FromClause, func(node ast.Node) bool {
 			switch node.(type) {
-			case *ast.RangeVar, *ast.RangeSubselect:
+			case *ast.RangeVar, *ast.RangeSubselect, *ast.FuncName:
 				return true
 			default:
 				return false
@@ -244,6 +244,20 @@ func sourceTables(qc *QueryCatalog, node ast.Node) ([]*Table, error) {
 	var tables []*Table
 	for _, item := range list.Items {
 		switch n := item.(type) {
+		case *ast.FuncName:
+			fn, err := qc.GetFunc(n)
+			if err != nil {
+				return nil, err
+			}
+			table, err := qc.GetTable(&ast.TableName{
+				Catalog: fn.ReturnType.Catalog,
+				Schema:  fn.ReturnType.Schema,
+				Name:    fn.ReturnType.Name,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("sourceTables: selecting on a function with an unsupported return type: %T", fn.ReturnType)
+			}
+			tables = append(tables, table)
 		case *ast.RangeSubselect:
 			cols, err := outputColumns(qc, n.Subquery)
 			if err != nil {

--- a/internal/compiler/query.go
+++ b/internal/compiler/query.go
@@ -7,6 +7,11 @@ type Table struct {
 	Columns []*Column
 }
 
+type Function struct {
+	Rel        *ast.FuncName
+	ReturnType *ast.TypeName
+}
+
 type Column struct {
 	Name     string
 	DataType string

--- a/internal/compiler/query_catalog.go
+++ b/internal/compiler/query_catalog.go
@@ -70,3 +70,14 @@ func (qc QueryCatalog) GetTable(rel *ast.TableName) (*Table, error) {
 	}
 	return &Table{Rel: rel, Columns: cols}, nil
 }
+
+func (qc QueryCatalog) GetFunc(rel *ast.FuncName) (*Function, error) {
+	src, err := qc.catalog.GetFunc(rel)
+	if err != nil {
+		return nil, err
+	}
+	return &Function{
+		Rel:        rel,
+		ReturnType: src.ReturnType,
+	}, nil
+}

--- a/internal/sql/catalog/public.go
+++ b/internal/sql/catalog/public.go
@@ -131,3 +131,20 @@ func (c *Catalog) GetTable(rel *ast.TableName) (Table, error) {
 		return *table, err
 	}
 }
+
+func (c *Catalog) GetFunc(rel *ast.FuncName) (Function, error) {
+	ns := rel.Schema
+	if ns == "" {
+		ns = c.DefaultSchema
+	}
+	schema, err := c.getSchema(ns)
+	if err != nil {
+		return Function{}, err
+	}
+	fn, _, err := schema.getFuncByName(rel)
+	if fn == nil {
+		return Function{}, err
+	} else {
+		return *fn, err
+	}
+}


### PR DESCRIPTION
I'm not sure if this is the correct/best way of doing this, but it seems to get the job done! It enables table types for postgres go, which is particularly useful in functions which can return a table type so we get the benefit of our existing structs rather than a string.