### PR TITLE
Override globs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/antlr/antlr4 v0.0.0-20200209180723-1177c0b58d07
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-sql-driver/mysql v1.6.0
+	github.com/gobwas/glob v0.2.3
 	github.com/google/go-cmp v0.5.5
 	github.com/jackc/pgx/v4 v4.11.0
 	github.com/jinzhu/inflection v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=

--- a/internal/codegen/golang/compat.go
+++ b/internal/codegen/golang/compat.go
@@ -13,5 +13,5 @@ func sameTableName(n *ast.TableName, f core.FQN, defaultSchema string) bool {
 	if n.Schema == "" {
 		schema = defaultSchema
 	}
-	return n.Catalog == f.Catalog && schema == f.Schema && n.Name == f.Rel
+	return n.Catalog == f.Catalog && ((f.Schema != nil && f.Schema.Match(schema)) || schema == "") && ((f.Rel != nil && f.Rel.Match(n.Name)) || n.Name == "")
 }

--- a/internal/codegen/golang/go_type.go
+++ b/internal/codegen/golang/go_type.go
@@ -12,7 +12,7 @@ func goType(r *compiler.Result, col *compiler.Column, settings config.CombinedSe
 			continue
 		}
 		sameTable := sameTableName(col.Table, oride.Table, r.Catalog.DefaultSchema)
-		if oride.Column != "" && oride.ColumnName == col.Name && sameTable {
+		if oride.Column != "" && oride.ColumnName.Match(col.Name) && sameTable {
 			return oride.GoTypeName
 		}
 	}

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gobwas/glob"
+
 	"github.com/kyleconroy/sqlc/internal/codegen"
 	"github.com/kyleconroy/sqlc/internal/compiler"
 	"github.com/kyleconroy/sqlc/internal/config"
@@ -74,7 +76,7 @@ func buildStructs(r *compiler.Result, settings config.CombinedSettings) []Struct
 				structName = inflection.Singular(structName)
 			}
 			s := Struct{
-				Table:   core.FQN{Schema: schema.Name, Rel: table.Rel.Name},
+				Table:   core.FQN{Schema: glob.MustCompile(schema.Name), Rel: glob.MustCompile(table.Rel.Name)},
 				Name:    StructName(structName, settings),
 				Comment: table.Comment,
 			}

--- a/internal/codegen/kotlin/gen.go
+++ b/internal/codegen/kotlin/gen.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/gobwas/glob"
+
 	"github.com/kyleconroy/sqlc/internal/codegen"
 	"github.com/kyleconroy/sqlc/internal/compiler"
 	"github.com/kyleconroy/sqlc/internal/config"
@@ -26,7 +28,7 @@ func sameTableName(n *ast.TableName, f core.FQN) bool {
 	if n.Schema == "" {
 		schema = "public"
 	}
-	return n.Catalog == n.Catalog && schema == f.Schema && n.Name == f.Rel
+	return n.Catalog == f.Catalog && ((f.Schema != nil && f.Schema.Match(schema)) || schema == "") && ((f.Rel != nil && f.Rel.Match(n.Name)) || n.Name == "")
 }
 
 var ktIdentPattern = regexp.MustCompile("[^a-zA-Z0-9_]+")
@@ -286,7 +288,7 @@ func buildDataClasses(r *compiler.Result, settings config.CombinedSettings) []St
 				structName = inflection.Singular(structName)
 			}
 			s := Struct{
-				Table:   core.FQN{Schema: schema.Name, Rel: table.Rel.Name},
+				Table:   core.FQN{Schema: glob.MustCompile(schema.Name), Rel: glob.MustCompile(table.Rel.Name)},
 				Name:    structName,
 				Comment: table.Comment,
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 
 	yaml "gopkg.in/yaml.v3"
 
+	"github.com/gobwas/glob"
+
 	"github.com/kyleconroy/sqlc/internal/core"
 )
 
@@ -160,7 +162,7 @@ type Override struct {
 	// fully qualified name of the column, e.g. `accounts.id`
 	Column string `json:"column" yaml:"column"`
 
-	ColumnName   string
+	ColumnName   glob.Glob
 	Table        core.FQN
 	GoImportPath string
 	GoPackage    string
@@ -198,16 +200,16 @@ func (o *Override) Parse() error {
 		colParts := strings.Split(o.Column, ".")
 		switch len(colParts) {
 		case 2:
-			o.ColumnName = colParts[1]
-			o.Table = core.FQN{Schema: "public", Rel: colParts[0]}
+			o.ColumnName = glob.MustCompile(colParts[1])
+			o.Table = core.FQN{Schema: glob.MustCompile("public"), Rel: glob.MustCompile(colParts[0])}
 		case 3:
-			o.ColumnName = colParts[2]
-			o.Table = core.FQN{Schema: colParts[0], Rel: colParts[1]}
+			o.ColumnName = glob.MustCompile(colParts[2])
+			o.Table = core.FQN{Schema: glob.MustCompile(colParts[0]), Rel: glob.MustCompile(colParts[1])}
 		case 4:
-			o.ColumnName = colParts[3]
-			o.Table = core.FQN{Catalog: colParts[0], Schema: colParts[1], Rel: colParts[2]}
+			o.ColumnName = glob.MustCompile(colParts[3])
+			o.Table = core.FQN{Catalog: colParts[0], Schema: glob.MustCompile(colParts[1]), Rel: glob.MustCompile(colParts[2])}
 		default:
-			return fmt.Errorf("Override `column` specifier %q is not the proper format, expected '[catalog.][schema.]colname.tablename'", o.Column)
+			return fmt.Errorf("Override `column` specifier %q is not the proper format, expected '[catalog.][schema.]tablename.colname'", o.Column)
 		}
 	}
 

--- a/internal/core/fqn.go
+++ b/internal/core/fqn.go
@@ -9,14 +9,3 @@ type FQN struct {
 	Schema  glob.Glob
 	Rel     glob.Glob
 }
-
-func (f FQN) String() string {
-	s := f.Rel
-	if f.Schema != "" {
-		s = f.Schema + "." + s
-	}
-	if f.Catalog != "" {
-		s = f.Catalog + "." + s
-	}
-	return s
-}

--- a/internal/core/fqn.go
+++ b/internal/core/fqn.go
@@ -1,11 +1,13 @@
 package core
 
+import "github.com/gobwas/glob"
+
 // TODO: This is the last struct left over from the old architecture. Figure
 // out how to remove it at some point
 type FQN struct {
 	Catalog string
-	Schema  string
-	Rel     string
+	Schema  glob.Glob
+	Rel     glob.Glob
 }
 
 func (f FQN) String() string {


### PR DESCRIPTION
So, I'm going to start with the use case.

Our MariaDB database has a lot of KSUIDs, enough that I would be better off writing a tool to automate building the override statements than doing it by hand.

It would be nice if we could just override on type, replace 'binary(20)' with 'github.com/segmentio/ksuid.KSUID' and call it a day.

Sadly, at least the mysql parser turns 'binary(20)' into 'char' well before the override code gets it.  In fact, it does this well before any of the sqlc code gets it.

That leaves doing it by column name, but as mentioned above...  There are quite a lot of them.

On the other hand, our naming convention is at least vaguely straight forward.  The columns all end with _ksuid, so we can automatically detect them.

But why write rules to do this, and have a huge override table, when we can just add globbing support to sqlc?

And so I did that instead. :)

This passes all of the tests, and is reasonably straight forward.