### PR TITLE
cmd: Allow config file location to be specified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/lib/pq v1.9.0
 	github.com/pingcap/parser v0.0.0-20201024025010-3b2fb4b41d73
 	github.com/spf13/cobra v1.1.1
+	github.com/spf13/pflag v1.0.5
 	golang.org/x/tools v0.0.0-20191219041853-979b82bfef62 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -18,7 +18,7 @@ import (
 // Do runs the command logic.
 func Do(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
 	rootCmd := &cobra.Command{Use: "sqlc", SilenceUsage: true}
-	rootCmd.PersistentFlags().StringP("file", "f", "", "specify an alternate config file (default: sqlc.yml)")
+	rootCmd.PersistentFlags().StringP("file", "f", "", "specify an alternate config file (default: sqlc.yaml)")
 
 	rootCmd.AddCommand(checkCmd)
 	rootCmd.AddCommand(genCmd)

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	yaml "gopkg.in/yaml.v3"
 
 	"github.com/kyleconroy/sqlc/internal/config"
@@ -17,6 +18,8 @@ import (
 // Do runs the command logic.
 func Do(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
 	rootCmd := &cobra.Command{Use: "sqlc", SilenceUsage: true}
+	rootCmd.PersistentFlags().StringP("file", "f", "", "specify an alternate config file (default: sqlc.yml)")
+
 	rootCmd.AddCommand(checkCmd)
 	rootCmd.AddCommand(genCmd)
 	rootCmd.AddCommand(initCmd)
@@ -57,14 +60,18 @@ var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Create an empty sqlc.yaml settings file",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if _, err := os.Stat("sqlc.yaml"); !os.IsNotExist(err) {
+		file := "sqlc.yaml"
+		if f := cmd.Flag("file"); f != nil {
+			file = f.Value.String()
+		}
+		if _, err := os.Stat(file); !os.IsNotExist(err) {
 			return nil
 		}
 		blob, err := yaml.Marshal(config.V1GenerateSettings{Version: "1"})
 		if err != nil {
 			return err
 		}
-		return ioutil.WriteFile("sqlc.yaml", blob, 0644)
+		return ioutil.WriteFile(file, blob, 0644)
 	},
 }
 
@@ -75,22 +82,39 @@ func ParseEnv() Env {
 	return Env{}
 }
 
+func getConfigPath(stderr io.Writer, f *pflag.Flag) (string, string) {
+	if f != nil {
+		file := f.Value.String()
+		if file == "" {
+			fmt.Fprintln(stderr, "error parsing config: file argument is empty")
+			os.Exit(1)
+		}
+		abspath, err := filepath.Abs(file)
+		if err != nil {
+			fmt.Fprintf(stderr, "error parsing config: absolute file path lookup failed: %s\n", err)
+			os.Exit(1)
+		}
+		return filepath.Dir(abspath), filepath.Base(abspath)
+	} else {
+		wd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintln(stderr, "error parsing sqlc.json: file does not exist")
+			os.Exit(1)
+		}
+		return wd, ""
+	}
+}
+
 var genCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "Generate Go code from SQL",
 	Run: func(cmd *cobra.Command, args []string) {
 		stderr := cmd.ErrOrStderr()
-		dir, err := os.Getwd()
-		if err != nil {
-			fmt.Fprintln(stderr, "error parsing sqlc.json: file does not exist")
-			os.Exit(1)
-		}
-
-		output, err := Generate(ParseEnv(), dir, stderr)
+		dir, name := getConfigPath(stderr, cmd.Flag("file"))
+		output, err := Generate(ParseEnv(), dir, name, stderr)
 		if err != nil {
 			os.Exit(1)
 		}
-
 		for filename, source := range output {
 			os.MkdirAll(filepath.Dir(filename), 0755)
 			if err := ioutil.WriteFile(filename, []byte(source), 0644); err != nil {
@@ -106,12 +130,8 @@ var checkCmd = &cobra.Command{
 	Short: "Statically check SQL for syntax and type errors",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		stderr := cmd.ErrOrStderr()
-		dir, err := os.Getwd()
-		if err != nil {
-			fmt.Fprintln(stderr, "error parsing sqlc.json: file does not exist")
-			os.Exit(1)
-		}
-		if _, err := Generate(Env{}, dir, stderr); err != nil {
+		dir, name := getConfigPath(stderr, cmd.Flag("file"))
+		if _, err := Generate(Env{}, dir, name, stderr); err != nil {
 			os.Exit(1)
 		}
 		return nil

--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -35,7 +35,7 @@ func TestExamples(t *testing.T) {
 			t.Parallel()
 			path := filepath.Join(examples, tc)
 			var stderr bytes.Buffer
-			output, err := cmd.Generate(cmd.Env{}, path, &stderr)
+			output, err := cmd.Generate(cmd.Env{}, path, "", &stderr)
 			if err != nil {
 				t.Fatalf("sqlc generate failed: %s", stderr.String())
 			}
@@ -62,7 +62,7 @@ func BenchmarkExamples(b *testing.B) {
 			path := filepath.Join(examples, tc)
 			for i := 0; i < b.N; i++ {
 				var stderr bytes.Buffer
-				cmd.Generate(cmd.Env{}, path, &stderr)
+				cmd.Generate(cmd.Env{}, path, "", &stderr)
 			}
 		})
 	}
@@ -91,7 +91,7 @@ func TestReplay(t *testing.T) {
 			path, _ := filepath.Abs(tc)
 			var stderr bytes.Buffer
 			expected := expectedStderr(t, path)
-			output, err := cmd.Generate(cmd.Env{}, path, &stderr)
+			output, err := cmd.Generate(cmd.Env{}, path, "", &stderr)
 			if len(expected) == 0 && err != nil {
 				t.Fatalf("sqlc generate failed: %s", stderr.String())
 			}
@@ -184,7 +184,7 @@ func BenchmarkReplay(b *testing.B) {
 			path, _ := filepath.Abs(tc)
 			for i := 0; i < b.N; i++ {
 				var stderr bytes.Buffer
-				cmd.Generate(cmd.Env{}, path, &stderr)
+				cmd.Generate(cmd.Env{}, path, "", &stderr)
 			}
 		})
 	}


### PR DESCRIPTION
You can now pass the `--file` flag (`-f` for short) to the `init`, `generate` and `compile` commands.

The paths inside the configuration file are relative to the directory that file is in.

Fixes #825 

