### PR TITLE
Set default config filepath

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -18,7 +18,7 @@ import (
 // Do runs the command logic.
 func Do(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
 	rootCmd := &cobra.Command{Use: "sqlc", SilenceUsage: true}
-	rootCmd.PersistentFlags().StringP("file", "f", "", "specify an alternate config file (default: sqlc.yaml)")
+	rootCmd.PersistentFlags().StringP("file", "f", "sqlc.yaml", "specify an alternate config file (default: sqlc.yaml)")
 
 	rootCmd.AddCommand(checkCmd)
 	rootCmd.AddCommand(genCmd)


### PR DESCRIPTION
Fixes an issue where the default config path is not used (`sqlc.yaml`)