### PR TITLE
Check if the flag was changed

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -83,7 +83,7 @@ func ParseEnv() Env {
 }
 
 func getConfigPath(stderr io.Writer, f *pflag.Flag) (string, string) {
-	if f != nil {
+	if f != nil && f.Changed {
 		file := f.Value.String()
 		if file == "" {
 			fmt.Fprintln(stderr, "error parsing config: file argument is empty")


### PR DESCRIPTION
Only use the flag value if it was changed by the user. Ignore the default value of empty string

Fixes #864