### PR TITLE
Exit with non-zero error code when parsing fails

### DIFF
--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -151,8 +151,9 @@ func Generate(e Env, dir, filename string, stderr io.Writer) (map[string]string,
 			name = combo.Kotlin.Package
 		}
 
-		result, errored := parse(e, name, dir, sql.SQL, combo, parseOpts, stderr)
-		if errored {
+		result, failed := parse(e, name, dir, sql.SQL, combo, parseOpts, stderr)
+		if failed {
+			errored = true
 			break
 		}
 


### PR DESCRIPTION
```bash
$ sqlc-dev generate
# package querytest
query.sql:2:10: syntax error near "SELECTTTT dayname(?);" "
$ echo $?
1
```

Fixes #869 
