### PR TITLE
Initial Windows support

### DIFF
--- a/.github/workflows/equinox.yml
+++ b/.github/workflows/equinox.yml
@@ -18,6 +18,22 @@ jobs:
     - uses: equinox-io/setup@master
     - run: go test -bench . -json -benchmem -run=XXX ./...
 
+  windows:
+    name: release --platforms windows
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.14'
+    - uses: equinox-io/setup-release-tool@v1.1.0
+    - name: equinox release
+      env:
+        EQUINOX_API_TOKEN: ${{ secrets.EQUINOX_API_TOKEN }}
+        EQUINOX_SIGNING_KEY: ${{ secrets.EQUINOX_SIGNING_KEY }}
+      run: go run scripts/release.go -draft windows_amd64
+
   macos:
     name: release --platforms darwin
     runs-on: macos-latest
@@ -37,7 +53,7 @@ jobs:
   linux:
     name: release --platforms linux
     runs-on: ubuntu-latest
-    needs: [macos, benchmark]
+    needs: [macos, windows, benchmark]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Go 1.14

--- a/internal/engine/postgresql/convert.go
+++ b/internal/engine/postgresql/convert.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package postgresql
 
 import (

--- a/internal/engine/postgresql/parse.go
+++ b/internal/engine/postgresql/parse.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package postgresql
 
 import (

--- a/internal/engine/postgresql/parse_windows.go
+++ b/internal/engine/postgresql/parse_windows.go
@@ -1,0 +1,30 @@
+// +build windows
+
+package postgresql
+
+import (
+	"errors"
+	"io"
+
+	"github.com/kyleconroy/sqlc/internal/metadata"
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+)
+
+func NewParser() *Parser {
+	return &Parser{}
+}
+
+type Parser struct {
+}
+
+func (p *Parser) Parse(r io.Reader) ([]ast.Statement, error) {
+	return nil, errors.New("the PostgreSQL engine does not support Windows")
+}
+
+// https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-COMMENTS
+func (p *Parser) CommentSyntax() metadata.CommentSyntax {
+	return metadata.CommentSyntax{
+		Dash:      true,
+		SlashStar: true,
+	}
+}

--- a/internal/engine/postgresql/utils.go
+++ b/internal/engine/postgresql/utils.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package postgresql
 
 import (


### PR DESCRIPTION
The PostgreSQL parser we use does not support Windows. However, the MySQL parser does. Update the `engine/postgresql` package to build on Windows. This version of the PostgreSQL parser always returns an error.