### PR TITLE
Add support for `.pgsql` when looking for query/schema files

### DIFF
--- a/internal/sql/sqlpath/read.go
+++ b/internal/sql/sqlpath/read.go
@@ -33,7 +33,7 @@ func Glob(paths []string) ([]string, error) {
 	}
 	var sqlFiles []string
 	for _, file := range files {
-		if !strings.HasSuffix(file, ".sql") {
+		if !strings.HasSuffix(file, ".sql") && !strings.HasSuffix(file, ".pgsql") {
 			continue
 		}
 		if strings.HasPrefix(filepath.Base(file), ".") {


### PR DESCRIPTION
hey, this adds support for `.pgsql` when looking for query/schema files

without this, i get something like
`error parsing queries: no queries contained in paths project/queries.pgsql`

the usecase for these files is, for me at least, better syntax highlighting in my editor for postgres specific SQL

thanks!
