### PR TITLE
Make timestampdiff return int.

### DIFF
--- a/internal/engine/dolphin/stdlib.go
+++ b/internal/engine/dolphin/stdlib.go
@@ -5282,7 +5282,7 @@ func defaultSchema(name string) *catalog.Schema {
 					Type: &ast.TypeName{Name: "datetime"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "datetime"},
+			ReturnType: &ast.TypeName{Name: "int"},
 		},
 		{
 			Name: "TIME_FORMAT",


### PR DESCRIPTION
So the mysql timestampdiff documentation does not explicitly declare the
return type, but the documentation heavily implies int.

On the other hand, the MariaDB documentation explicitly specifies it as
int, so we're going to run with int.