### PR TITLE
cmd: Add the --experimental flag

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -19,7 +19,7 @@ import (
 func Do(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
 	rootCmd := &cobra.Command{Use: "sqlc", SilenceUsage: true}
 	rootCmd.PersistentFlags().StringP("file", "f", "", "specify an alternate config file (default: sqlc.yaml)")
-	rootCmd.PersistentFlags().BoolP("experimental", "x", false, "enabled experimental features (efault: false)")
+	rootCmd.PersistentFlags().BoolP("experimental", "x", false, "enable experimental features (default: false)")
 
 	rootCmd.AddCommand(checkCmd)
 	rootCmd.AddCommand(genCmd)

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -19,6 +19,7 @@ import (
 func Do(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
 	rootCmd := &cobra.Command{Use: "sqlc", SilenceUsage: true}
 	rootCmd.PersistentFlags().StringP("file", "f", "", "specify an alternate config file (default: sqlc.yaml)")
+	rootCmd.PersistentFlags().BoolP("experimental", "x", false, "enabled experimental features (efault: false)")
 
 	rootCmd.AddCommand(checkCmd)
 	rootCmd.AddCommand(genCmd)
@@ -76,10 +77,12 @@ var initCmd = &cobra.Command{
 }
 
 type Env struct {
+	ExperimentalFeatures bool
 }
 
-func ParseEnv() Env {
-	return Env{}
+func ParseEnv(c *cobra.Command) Env {
+	x := c.Flag("experimental")
+	return Env{ExperimentalFeatures: x != nil && x.Changed}
 }
 
 func getConfigPath(stderr io.Writer, f *pflag.Flag) (string, string) {
@@ -111,7 +114,7 @@ var genCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		stderr := cmd.ErrOrStderr()
 		dir, name := getConfigPath(stderr, cmd.Flag("file"))
-		output, err := Generate(ParseEnv(), dir, name, stderr)
+		output, err := Generate(ParseEnv(cmd), dir, name, stderr)
 		if err != nil {
 			os.Exit(1)
 		}
@@ -131,7 +134,7 @@ var checkCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		stderr := cmd.ErrOrStderr()
 		dir, name := getConfigPath(stderr, cmd.Flag("file"))
-		if _, err := Generate(Env{}, dir, name, stderr); err != nil {
+		if _, err := Generate(ParseEnv(cmd), dir, name, stderr); err != nil {
 			os.Exit(1)
 		}
 		return nil

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -122,6 +122,10 @@ func Generate(e Env, dir, filename string, stderr io.Writer) (map[string]string,
 			})
 		}
 		if sql.Gen.Python != nil {
+			if !e.ExperimentalFeatures {
+				fmt.Fprintf(stderr, "error parsing %s: unknown target langauge \"python\"\n", base)
+				return nil, fmt.Errorf("unknown target language \"python\"")
+			}
 			pairs = append(pairs, outPair{
 				SQL: sql,
 				Gen: config.SQLGen{Python: sql.Gen.Python},

--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -35,7 +35,7 @@ func TestExamples(t *testing.T) {
 			t.Parallel()
 			path := filepath.Join(examples, tc)
 			var stderr bytes.Buffer
-			output, err := cmd.Generate(cmd.Env{}, path, "", &stderr)
+			output, err := cmd.Generate(cmd.Env{ExperimentalFeatures: true}, path, "", &stderr)
 			if err != nil {
 				t.Fatalf("sqlc generate failed: %s", stderr.String())
 			}
@@ -62,7 +62,7 @@ func BenchmarkExamples(b *testing.B) {
 			path := filepath.Join(examples, tc)
 			for i := 0; i < b.N; i++ {
 				var stderr bytes.Buffer
-				cmd.Generate(cmd.Env{}, path, "", &stderr)
+				cmd.Generate(cmd.Env{ExperimentalFeatures: true}, path, "", &stderr)
 			}
 		})
 	}
@@ -91,7 +91,7 @@ func TestReplay(t *testing.T) {
 			path, _ := filepath.Abs(tc)
 			var stderr bytes.Buffer
 			expected := expectedStderr(t, path)
-			output, err := cmd.Generate(cmd.Env{}, path, "", &stderr)
+			output, err := cmd.Generate(cmd.Env{ExperimentalFeatures: true}, path, "", &stderr)
 			if len(expected) == 0 && err != nil {
 				t.Fatalf("sqlc generate failed: %s", stderr.String())
 			}
@@ -188,7 +188,7 @@ func BenchmarkReplay(b *testing.B) {
 			path, _ := filepath.Abs(tc)
 			for i := 0; i < b.N; i++ {
 				var stderr bytes.Buffer
-				cmd.Generate(cmd.Env{}, path, "", &stderr)
+				cmd.Generate(cmd.Env{ExperimentalFeatures: true}, path, "", &stderr)
 			}
 		})
 	}


### PR DESCRIPTION
Put Python support behind the experimental flag. New languages and databases will go behind the flag until their implementation is stable.

cc @robholt 