### PR TITLE
Correctly generate code for MySQL cool

### DIFF
--- a/internal/compiler/output_columns.go
+++ b/internal/compiler/output_columns.go
@@ -142,6 +142,7 @@ func outputColumns(qc *QueryCatalog, node ast.Node) ([]*Column, error) {
 							DataType: c.DataType,
 							NotNull:  c.NotNull,
 							IsArray:  c.IsArray,
+							Length:   c.Length,
 						})
 					}
 				}
@@ -321,6 +322,7 @@ func outputColumnRefs(res *ast.ResTarget, tables []*Table, node *ast.ColumnRef) 
 					DataType: c.DataType,
 					NotNull:  c.NotNull,
 					IsArray:  c.IsArray,
+					Length:   c.Length,
 				})
 			}
 		}

--- a/internal/compiler/resolve.go
+++ b/internal/compiler/resolve.go
@@ -154,6 +154,7 @@ func resolveCatalogRefs(c *catalog.Catalog, rvs []*ast.RangeVar, args []paramRef
 								DataType: dataType(&c.Type),
 								NotNull:  c.IsNotNull,
 								IsArray:  c.IsArray,
+								Length:   c.Length,
 								Table:    table,
 							},
 						})
@@ -295,6 +296,7 @@ func resolveCatalogRefs(c *catalog.Catalog, rvs []*ast.RangeVar, args []paramRef
 						NotNull:  c.IsNotNull,
 						IsArray:  c.IsArray,
 						Table:    &ast.TableName{Schema: schema, Name: rel},
+						Length:   c.Length,
 					},
 				})
 			} else {

--- a/internal/endtoend/testdata/data_type_boolean/mysql/db/query.sql.go
+++ b/internal/endtoend/testdata/data_type_boolean/mysql/db/query.sql.go
@@ -5,28 +5,21 @@ package db
 
 import (
 	"context"
-	"database/sql"
 )
 
 const listBar = `-- name: ListBar :many
 SELECT col_a, col_b, col_c FROM bar
 `
 
-type ListBarRow struct {
-	ColA sql.NullInt32
-	ColB sql.NullInt32
-	ColC sql.NullInt32
-}
-
-func (q *Queries) ListBar(ctx context.Context) ([]ListBarRow, error) {
+func (q *Queries) ListBar(ctx context.Context) ([]Bar, error) {
 	rows, err := q.db.QueryContext(ctx, listBar)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ListBarRow
+	var items []Bar
 	for rows.Next() {
-		var i ListBarRow
+		var i Bar
 		if err := rows.Scan(&i.ColA, &i.ColB, &i.ColC); err != nil {
 			return nil, err
 		}
@@ -45,21 +38,15 @@ const listFoo = `-- name: ListFoo :many
 SELECT col_a, col_b, col_c FROM foo
 `
 
-type ListFooRow struct {
-	ColA int32
-	ColB int32
-	ColC int32
-}
-
-func (q *Queries) ListFoo(ctx context.Context) ([]ListFooRow, error) {
+func (q *Queries) ListFoo(ctx context.Context) ([]Foo, error) {
 	rows, err := q.db.QueryContext(ctx, listFoo)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ListFooRow
+	var items []Foo
 	for rows.Next() {
-		var i ListFooRow
+		var i Foo
 		if err := rows.Scan(&i.ColA, &i.ColB, &i.ColC); err != nil {
 			return nil, err
 		}

--- a/internal/endtoend/testdata/insert_select/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/insert_select/mysql/go/query.sql.go
@@ -15,7 +15,7 @@ FROM bar WHERE ready = ?
 
 type InsertSelectParams struct {
 	Meta  string
-	Ready int32
+	Ready bool
 }
 
 func (q *Queries) InsertSelect(ctx context.Context, arg InsertSelectParams) error {


### PR DESCRIPTION
Since MySQL doesn't have native boolean support, we turn all values with data type `tinyint(1)` into bools. We need to have the associated length with the datatype for this to work. Make sure that we pass length in all the required spots.

Fixes #856 