### PR TITLE
Handle convertPatternInExpr.

### DIFF
--- a/internal/engine/dolphin/convert.go
+++ b/internal/engine/dolphin/convert.go
@@ -873,7 +873,7 @@ func (c *cc) convertPartitionByClause(n *pcast.PartitionByClause) ast.Node {
 }
 
 func (c *cc) convertPatternInExpr(n *pcast.PatternInExpr) ast.Node {
-	return todo(n)
+	return c.convert(n.Sel)
 }
 
 func (c *cc) convertPatternLikeExpr(n *pcast.PatternLikeExpr) ast.Node {


### PR DESCRIPTION
This can be handled just by calling convert on the subquery, and it is
necessary for some kinds of queries.

Like the following, without this we don't pickup the parameter, and thus
can't handle the query at all:

select * from foo where field in (select substring(?, 1, seq) from seq_1_to_19)