### PR TITLE
Calling mysql function LAST_INSERT_ID(expr)

### DIFF
--- a/internal/engine/dolphin/stdlib.go
+++ b/internal/engine/dolphin/stdlib.go
@@ -1796,6 +1796,15 @@ func defaultSchema(name string) *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "bigint"},
 		},
 		{
+			Name:       "LAST_INSERT_ID",
+			Args:       []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "any"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
 			Name: "LAST_VALUE",
 			Args: []*catalog.Argument{
 				{


### PR DESCRIPTION
Added support for the mysql function LAST_INSERT_ID with an expression.

Now this query leads to an error `function last_insert_id(unknown) does not exist`
```
INSERT INTO foo (id)
VALUES (LAST_INSERT_ID(UUID_SHORT()))
```