### PR TITLE
Documentation on slice as parameter to a query

### DIFF
--- a/docs/howto/select.md
+++ b/docs/howto/select.md
@@ -189,7 +189,7 @@ In PostgreSQL,
 [ANY](https://www.postgresql.org/docs/current/functions-comparisons.html#id-1.5.8.28.16)
 allows you to check if a value exists in an array expression. Queries using ANY
 with a single parameter will generate method signatures with slices as
-arguments.
+arguments. Use the postgres data types, eg: int, varchar, etc.
 
 ```sql
 CREATE TABLE authors (


### PR DESCRIPTION
I spent quite a time figuring this one out because it's not mentioned in the documentation that we have to pass postgres data types. I was using
```
ANY(sqlc.arg(roles)::string[])
```
which is supposed to be 
```
ANY(sqlc.arg(roles)::varchar[]).
```