### PR TITLE
Add skip_db_file_name option

### DIFF
--- a/internal/codegen/golang/gen.go
+++ b/internal/codegen/golang/gen.go
@@ -131,8 +131,10 @@ func generate(settings config.CombinedSettings, enums []Enum, structs []Struct, 
 		querierFileName = golang.OutputQuerierFileName
 	}
 
-	if err := execute(dbFileName, "dbFile"); err != nil {
-		return nil, err
+	if !golang.SkipDBFileName {
+		if err := execute(dbFileName, "dbFile"); err != nil {
+			return nil, err
+		}
 	}
 	if err := execute(modelsFileName, "modelsFile"); err != nil {
 		return nil, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,6 +123,7 @@ type SQLGo struct {
 	Overrides             []Override        `json:"overrides,omitempty" yaml:"overrides"`
 	Rename                map[string]string `json:"rename,omitempty" yaml:"rename"`
 	Driver                string            `json:"driver" yaml:"driver"`
+	SkipDBFileName        bool              `json:"skip_db_file_name" yaml:"skip_db_file_name"`
 	OutputDBFileName      string            `json:"output_db_file_name,omitempty" yaml:"output_db_file_name"`
 	OutputModelsFileName  string            `json:"output_models_file_name,omitempty" yaml:"output_models_file_name"`
 	OutputQuerierFileName string            `json:"output_querier_file_name,omitempty" yaml:"output_querier_file_name"`

--- a/internal/config/v_one.go
+++ b/internal/config/v_one.go
@@ -31,6 +31,7 @@ type v1PackageSettings struct {
 	JSONTagsCaseStyle     string     `json:"json_tags_case_style,omitempty" yaml:"json_tags_case_style"`
 	Driver                string     `json:"driver" yaml:"driver"`
 	Overrides             []Override `json:"overrides" yaml:"overrides"`
+	SkipDBFileName        bool       `json:"skip_db_file_name" yaml:"skip_db_file_name"`
 	OutputDBFileName      string     `json:"output_db_file_name,omitempty" yaml:"output_db_file_name"`
 	OutputModelsFileName  string     `json:"output_models_file_name,omitempty" yaml:"output_models_file_name"`
 	OutputQuerierFileName string     `json:"output_querier_file_name,omitempty" yaml:"output_querier_file_name"`
@@ -122,6 +123,7 @@ func (c *V1GenerateSettings) Translate() Config {
 					Driver:                pkg.Driver,
 					Overrides:             pkg.Overrides,
 					JSONTagsCaseStyle:     pkg.JSONTagsCaseStyle,
+					SkipDBFileName:        pkg.SkipDBFileName,
 					OutputDBFileName:      pkg.OutputDBFileName,
 					OutputModelsFileName:  pkg.OutputModelsFileName,
 					OutputQuerierFileName: pkg.OutputQuerierFileName,


### PR DESCRIPTION
This will skip the default generation of db.go.
This can be useful when you want to define your own db.go