### PR TITLE
feat: add custom tags

### DIFF
--- a/internal/codegen/golang/custom_tags.go
+++ b/internal/codegen/golang/custom_tags.go
@@ -1,0 +1,55 @@
+package golang
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+)
+
+const tagKeyValueSplit = "__@CUSTOM_TAG_VALUE__"
+
+var tagReg = regexp.MustCompile(`^@.*\:`)
+
+// Comment parse go struct tags
+//
+// Example:
+// COMMENT ON COLUMN account.id is '@gorm:primaryKey @validate:required,min=3,max=32';
+//
+// To:
+// type Account {
+//   id int64 `gorm:"primaryKey" validate:"required,min=3,max=32"`
+// }
+//
+func customTags(tags *map[string]string, column *catalog.Column) {
+	if column.Comment == "" {
+		return
+	}
+
+	comments := strings.Split(column.Comment, " ")
+	fliterComments := make([]string, len(comments))
+
+	for _, tag := range comments {
+		if tagReg.Match([]byte(tag)) {
+			tag = strings.Replace(tag, "@", "", 1)
+			tag := strings.Replace(tag, ":", tagKeyValueSplit, 1)
+			kv := strings.Split(tag, tagKeyValueSplit)
+			if len(kv) < 2 {
+				panic(fmt.Sprintf("comment tags JSON tags style error:  %s %s in %s", column.Type.Name, column.Name, column.Comment))
+			}
+			k := kv[0]
+			v := kv[1]
+			key := k + ":"
+			(*tags)[key] = v
+		} else {
+			fliterComments = append(fliterComments, tag)
+		}
+	}
+
+	// clear tags in Comment
+	if len(fliterComments) > 0 {
+		column.Comment = strings.Join(fliterComments, " ")
+		column.Comment = strings.Trim(column.Comment, " ")
+	}
+}

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -80,6 +80,7 @@ func buildStructs(r *compiler.Result, settings config.CombinedSettings) []Struct
 			}
 			for _, column := range table.Columns {
 				tags := map[string]string{}
+				customTags(&tags, column)
 				if settings.Go.EmitDBTags {
 					tags["db:"] = column.Name
 				}


### PR DESCRIPTION
sqlc is very perfect database model generation tool, we use sqlc and gorm(use dynamic query).
This pull request is extends use sql comment custom go struct tags it's style:

Schema example code in comment:

```
@<tagName>:<tagValue>
```

## Examples:

Add comment in SQL(Postgres):

```sql
COMMENT ON COLUMN account.id is '@gorm:primaryKey @validate:required,min=3,max=32';
```

Generate go struct code:

```go
type Account struct {
  ID  int32  `gorm:"primaryKey" json:"id" validate:"required,min=3,max=32"`
}
```