### PR TITLE
Remove MYSQL_USER and MYSQL_PASSWORD from docker-compose.yaml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,7 @@ services:
     restart: always
     environment:
       MYSQL_DATABASE: dinotest
-      MYSQL_PASSWORD: mysecretpassword
       MYSQL_ROOT_PASSWORD: mysecretpassword
-      MYSQL_USER: root
 
   postgresql:
     image: "postgres:13"


### PR DESCRIPTION
The right way to configure the *root* password is using the environment variable
`MYSQL_ROOT_PASSWORD`.

It also remove the `MYSQL_PASSWORD` because is only used the root user.

From MySQL log:
```
2021-08-13 20:28:55+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2021-08-13 20:28:55+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.26-1debian10 started.
2021-08-13 20:28:55+00:00 [ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
    Remove MYSQL_USER="root" and use one of the following to control the root user password:
    - MYSQL_ROOT_PASSWORD
    - MYSQL_ALLOW_EMPTY_PASSWORD
    - MYSQL_RANDOM_ROOT_PASSWORD
```