### PR TITLE
Fix typos in howto/select generated code sample

### DIFF
--- a/docs/howto/select.md
+++ b/docs/howto/select.md
@@ -175,9 +175,9 @@ type GetInfoForAuthorRow struct {
 	BirthYear int
 }
 
-func (q *Queries) GetBioForAuthor(ctx context.Context, id int) (GetBioForAuthor, error) {
+func (q *Queries) GetInfoForAuthor(ctx context.Context, id int) (GetInfoForAuthorRow, error) {
 	row := q.db.QueryRowContext(ctx, getInfoForAuthor, id)
-	var i GetBioForAuthor
+	var i GetInfoForAuthorRow
 	err := row.Scan(&i.Bio, &i.BirthYear)
 	return i, err
 }


### PR DESCRIPTION
This is very minor, but may confuse newcomers.