### PR TITLE
codegen/golang: Add pgx support for range types

### DIFF
--- a/internal/codegen/golang/imports.go
+++ b/internal/codegen/golang/imports.go
@@ -133,12 +133,18 @@ var stdlibTypes = map[string]string{
 }
 
 var pgtypeTypes = map[string]struct{}{
-	"pgtype.CIDR":    {},
-	"pgtype.Inet":    {},
-	"pgtype.JSON":    {},
-	"pgtype.JSONB":   {},
-	"pgtype.Macaddr": {},
-	"pgtype.Numeric": {},
+	"pgtype.CIDR":      {},
+	"pgtype.Daterange": {},
+	"pgtype.Inet":      {},
+	"pgtype.Int4range": {},
+	"pgtype.Int8range": {},
+	"pgtype.JSON":      {},
+	"pgtype.JSONB":     {},
+	"pgtype.Macaddr":   {},
+	"pgtype.Numeric":   {},
+	"pgtype.Numrange":  {},
+	"pgtype.Tsrange":   {},
+	"pgtype.Tstzrange": {},
 }
 
 var pqtypeTypes = map[string]struct{}{

--- a/internal/codegen/golang/postgresql_type.go
+++ b/internal/codegen/golang/postgresql_type.go
@@ -184,6 +184,42 @@ func postgresType(r *compiler.Result, col *compiler.Column, settings config.Comb
 		}
 		return "sql.NullInt64"
 
+	case "daterange":
+		if driver == SQLDriverPGXV4 {
+			return "pgtype.Daterange"
+		}
+		return "interface{}"
+
+	case "tsrange":
+		if driver == SQLDriverPGXV4 {
+			return "pgtype.Tsrange"
+		}
+		return "interface{}"
+
+	case "tstzrange":
+		if driver == SQLDriverPGXV4 {
+			return "pgtype.Tstzrange"
+		}
+		return "interface{}"
+
+	case "numrange":
+		if driver == SQLDriverPGXV4 {
+			return "pgtype.Numrange"
+		}
+		return "interface{}"
+
+	case "int4range":
+		if driver == SQLDriverPGXV4 {
+			return "pgtype.Int4range"
+		}
+		return "interface{}"
+
+	case "int8range":
+		if driver == SQLDriverPGXV4 {
+			return "pgtype.Int8range"
+		}
+		return "interface{}"
+
 	case "void":
 		// A void value can only be scanned into an empty interface.
 		return "interface{}"

--- a/internal/endtoend/testdata/datatype/pgx/go/models.go
+++ b/internal/endtoend/testdata/datatype/pgx/go/models.go
@@ -90,3 +90,21 @@ type DtNumericNotNull struct {
 	L int32
 	M int64
 }
+
+type DtRange struct {
+	A pgtype.Int4range
+	B pgtype.Int8range
+	C pgtype.Numrange
+	D pgtype.Tsrange
+	E pgtype.Tstzrange
+	F pgtype.Daterange
+}
+
+type DtRangeNotNull struct {
+	A pgtype.Int4range
+	B pgtype.Int8range
+	C pgtype.Numrange
+	D pgtype.Tsrange
+	E pgtype.Tstzrange
+	F pgtype.Daterange
+}

--- a/internal/endtoend/testdata/datatype/pgx/sql/rangetypes.sql
+++ b/internal/endtoend/testdata/datatype/pgx/sql/rangetypes.sql
@@ -1,0 +1,19 @@
+-- Range Types
+-- https://www.postgresql.org/docs/current/rangetypes.html
+CREATE TABLE dt_range (
+    a int4range,
+    b int8range,
+    c numrange,
+    d tsrange,
+    e tstzrange,
+    f daterange
+);
+
+CREATE TABLE dt_range_not_null (
+    a int4range NOT NULL,
+    b int8range NOT NULL,
+    c numrange NOT NULL,
+    d tsrange NOT NULL,
+    e tstzrange NOT NULL,
+    f daterange NOT NULL
+);

--- a/internal/endtoend/testdata/datatype/stdlib/go/models.go
+++ b/internal/endtoend/testdata/datatype/stdlib/go/models.go
@@ -90,3 +90,21 @@ type DtNumericNotNull struct {
 	L int32
 	M int64
 }
+
+type DtRange struct {
+	A interface{}
+	B interface{}
+	C interface{}
+	D interface{}
+	E interface{}
+	F interface{}
+}
+
+type DtRangeNotNull struct {
+	A interface{}
+	B interface{}
+	C interface{}
+	D interface{}
+	E interface{}
+	F interface{}
+}

--- a/internal/endtoend/testdata/datatype/stdlib/sql/rangetypes.sql
+++ b/internal/endtoend/testdata/datatype/stdlib/sql/rangetypes.sql
@@ -1,0 +1,19 @@
+-- Range Types
+-- https://www.postgresql.org/docs/current/rangetypes.html
+CREATE TABLE dt_range (
+    a int4range,
+    b int8range,
+    c numrange,
+    d tsrange,
+    e tstzrange,
+    f daterange
+);
+
+CREATE TABLE dt_range_not_null (
+    a int4range NOT NULL,
+    b int8range NOT NULL,
+    c numrange NOT NULL,
+    d tsrange NOT NULL,
+    e tstzrange NOT NULL,
+    f daterange NOT NULL
+);


### PR DESCRIPTION
Support all six built-in range types:

* int4range — Range of integer
* int8range — Range of bigint
* numrange — Range of numeric
* tsrange — Range of timestamp without time zone
* tstzrange — Range of timestamp with time zone
* daterange — Range of date

Fixes #323 