### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -75,7 +74,7 @@ var initCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return ioutil.WriteFile(file, blob, 0644)
+		return os.WriteFile(file, blob, 0644)
 	},
 }
 
@@ -123,7 +122,7 @@ var genCmd = &cobra.Command{
 		}
 		for filename, source := range output {
 			os.MkdirAll(filepath.Dir(filename), 0755)
-			if err := ioutil.WriteFile(filename, []byte(source), 0644); err != nil {
+			if err := os.WriteFile(filename, []byte(source), 0644); err != nil {
 				fmt.Fprintf(stderr, "%s: %s\n", filename, err)
 				os.Exit(1)
 			}

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,7 +77,7 @@ func Generate(e Env, dir, filename string, stderr io.Writer) (map[string]string,
 	}
 
 	base := filepath.Base(configPath)
-	blob, err := ioutil.ReadFile(configPath)
+	blob, err := os.ReadFile(configPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "error parsing %s: file does not exist\n", base)
 		return nil, err

--- a/internal/compiler/compile.go
+++ b/internal/compiler/compile.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -60,7 +60,7 @@ func (c *Compiler) parseCatalog(schemas []string) error {
 	}
 	merr := multierr.New()
 	for _, filename := range files {
-		blob, err := ioutil.ReadFile(filename)
+		blob, err := os.ReadFile(filename)
 		if err != nil {
 			merr.Add(filename, "", 0, err)
 			continue
@@ -93,7 +93,7 @@ func (c *Compiler) parseQueries(o opts.Parser) (*Result, error) {
 		return nil, err
 	}
 	for _, filename := range files {
-		blob, err := ioutil.ReadFile(filename)
+		blob, err := os.ReadFile(filename)
 		if err != nil {
 			merr.Add(filename, "", 0, err)
 			continue

--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,7 +20,7 @@ func TestExamples(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	files, err := ioutil.ReadDir(examples)
+	files, err := os.ReadDir(examples)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +48,7 @@ func BenchmarkExamples(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	files, err := ioutil.ReadDir(examples)
+	files, err := os.ReadDir(examples)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -125,7 +124,7 @@ func cmpDirectory(t *testing.T, dir string, actual map[string]string) {
 			strings.HasSuffix(path, "__init__.py") || strings.Contains(path, "/python/src/dbtest/") {
 			return nil
 		}
-		blob, err := ioutil.ReadFile(path)
+		blob, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
@@ -158,7 +157,7 @@ func expectedStderr(t *testing.T, dir string) string {
 	t.Helper()
 	path := filepath.Join(dir, "stderr.txt")
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		blob, err := ioutil.ReadFile(path)
+		blob, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/engine/dolphin/parse.go
+++ b/internal/engine/dolphin/parse.go
@@ -3,7 +3,6 @@ package dolphin
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"strconv"
 	"strings"
@@ -50,7 +49,7 @@ func normalizeErr(err error) error {
 }
 
 func (p *Parser) Parse(r io.Reader) ([]ast.Statement, error) {
-	blob, err := ioutil.ReadAll(r)
+	blob, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/postgresql/parse.go
+++ b/internal/engine/postgresql/parse.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package postgresql
@@ -6,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	nodes "github.com/pganalyze/pg_query_go/v2"
@@ -152,7 +152,7 @@ type Parser struct {
 var errSkip = errors.New("skip stmt")
 
 func (p *Parser) Parse(r io.Reader) ([]ast.Statement, error) {
-	contents, err := ioutil.ReadAll(r)
+	contents, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/sqlite/parse.go
+++ b/internal/engine/sqlite/parse.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 
@@ -40,7 +39,7 @@ type Parser struct {
 }
 
 func (p *Parser) Parse(r io.Reader) ([]ast.Statement, error) {
-	blob, err := ioutil.ReadAll(r)
+	blob, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sql/sqlpath/read.go
+++ b/internal/sql/sqlpath/read.go
@@ -2,7 +2,6 @@ package sqlpath
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +19,7 @@ func Glob(paths []string) ([]string, error) {
 			return nil, fmt.Errorf("path %s does not exist", path)
 		}
 		if f.IsDir() {
-			listing, err := ioutil.ReadDir(path)
+			listing, err := os.ReadDir(path)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/sqltest/mysql.go
+++ b/internal/sqltest/mysql.go
@@ -3,7 +3,6 @@ package sqltest
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -67,7 +66,7 @@ func MySQL(t *testing.T, migrations []string) (*sql.DB, func()) {
 		t.Fatal(err)
 	}
 	for _, f := range files {
-		blob, err := ioutil.ReadFile(f)
+		blob, err := os.ReadFile(f)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/sqltest/postgres.go
+++ b/internal/sqltest/postgres.go
@@ -3,7 +3,6 @@ package sqltest
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -82,7 +81,7 @@ func PostgreSQL(t *testing.T, migrations []string) (*sql.DB, func()) {
 		t.Fatal(err)
 	}
 	for _, f := range files {
-		blob, err := ioutil.ReadFile(f)
+		blob, err := os.ReadFile(f)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/tools/sqlc-pg-gen/main.go
+++ b/internal/tools/sqlc-pg-gen/main.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -251,7 +250,7 @@ func run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join("internal", "engine", "postgresql", "pg_catalog.go"), code, 0644)
+	err = os.WriteFile(filepath.Join("internal", "engine", "postgresql", "pg_catalog.go"), code, 0644)
 	if err != nil {
 		return err
 	}
@@ -292,7 +291,7 @@ func run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = ioutil.WriteFile(filepath.Join("internal", "engine", "postgresql", "contrib", name+".go"), code, 0644)
+		err = os.WriteFile(filepath.Join("internal", "engine", "postgresql", "contrib", name+".go"), code, 0644)
 		if err != nil {
 			return err
 		}
@@ -313,7 +312,7 @@ func run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = ioutil.WriteFile(filepath.Join("internal", "engine", "postgresql", "extension.go"), code, 0644)
+		err = os.WriteFile(filepath.Join("internal", "engine", "postgresql", "extension.go"), code, 0644)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

No breaking changes.