### PR TITLE
docs: Replace deprecated go get with go install

### DIFF
--- a/docs/overview/install.md
+++ b/docs/overview/install.md
@@ -14,10 +14,10 @@ brew install sqlc
 sudo snap install sqlc
 ```
 
-## go get
+## go install
 
 ```
-go get github.com/kyleconroy/sqlc/cmd/sqlc
+go install github.com/kyleconroy/sqlc/cmd/sqlc@latest
 ```
 
 ## Docker


### PR DESCRIPTION
Fixes #1174 