### PR TITLE
Exportable Run function

### DIFF
--- a/placeholder.go
+++ b/placeholder.go
@@ -1,6 +1,17 @@
 package sqlc
 
+import (
+	"io"
+
+	"github.com/kyleconroy/sqlc/internal/cmd"
+)
+
 // This is a dummy file that allows SQLC to be "installed" as a module and locked using
 // go.mod and then run using "go run github.com/kyleconroy/sqlc"
 
 type Placeholder struct{}
+
+// Run the sqlc command
+func Run(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
+	return cmd.Do(args, stdin, stdout, stderr)
+}


### PR DESCRIPTION
Closes #416

This PR adds an exported `Run` function to the root package.

This allows this library to be simply embedded into other cli apps.

Usage is just like https://github.com/kyleconroy/sqlc/blob/main/cmd/sqlc/main.go :
```go
package main

import (
	"os"

	"github.com/kyleconroy/sqlc"
)

func main() {
	os.Exit(sqlc.Run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr))
}
```

This does not export any internal types, but simply exposes the same interface as the CLI to any go program.

---

In my case, I have a `tool` folder in my go project with this file, so that I can run `go run ./tool/sqlc.go` and be sure to have the right version from the project's `go.mod`