### PR TITLE
golang templates: reduce dbtx interface when not using prepared queries

### DIFF
--- a/internal/codegen/golang/templates/stdlib/dbCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/dbCode.tmpl
@@ -1,7 +1,9 @@
 {{define "dbCodeTemplateStd"}}
 type DBTX interface {
 	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+{{- if .EmitPreparedQueries}}
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
+{{- end}}
 	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
 	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }


### PR DESCRIPTION
Hi there,

i havent seen any PR requirements or existing tests on the repo so this is just the bare bone change.

Basically I am conditionally making the DBTX interface in the golang sql.DB implementation a little smaller by removing the `PrepareContext` when prepared queries are turned off, since all usages of `PrepareContext` are in the part of the template behind the same if statement. In general, if a method is not used, why add it to the interface? 

For some context, we ran across this because we are trying to pass to sqlc a wrapper of sql.DB (from https://pkg.go.dev/github.com/honeycombio/beeline-go/wrappers/hnysql) which has a slightly different PrepareContext return type. We don't use prepared queries so that difference shouldn't impact us. 