### PR TITLE
docs: add go.17+ install instructions

### DIFF
--- a/docs/overview/install.md
+++ b/docs/overview/install.md
@@ -14,10 +14,18 @@ brew install sqlc
 sudo snap install sqlc
 ```
 
-## go install
+## go install 
+
+### Go >= 1.17:
 
 ```
 go install github.com/kyleconroy/sqlc/cmd/sqlc@latest
+```
+
+### Go < 1.17:
+
+```
+go get github.com/kyleconroy/sqlc/cmd/sqlc
 ```
 
 ## Docker


### PR DESCRIPTION
Add go 1.17+ install intructions, `go get` has been deprecated
from go 1.17 and onwards as an install method.