### PR TITLE
docs: Bump version to 1.11.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2021, Kyle Conroy'
 author = 'Kyle Conroy'
 
 # The full version, including alpha/beta/rc tags
-release = '1.10.0'
+release = '1.11.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/overview/install.md
+++ b/docs/overview/install.md
@@ -42,8 +42,8 @@ docker run --rm -v $(pwd):/src -w /src kjconroy/sqlc generate
 
 ## Downloads
 
-Get pre-built binaries for *v1.10.0*:
+Get pre-built binaries for *v1.11.0*:
 
-- [Linux](https://github.com/kyleconroy/sqlc/releases/download/v1.10.0/sqlc_1.10.0_linux_amd64.tar.gz)
-- [macOS](https://github.com/kyleconroy/sqlc/releases/download/v1.10.0/sqlc_1.10.0_darwin_amd64.zip)
-- [Windows (MySQL only)](https://github.com/kyleconroy/sqlc/releases/download/v1.10.0/sqlc_1.10.0_windows_amd64.zip)
+- [Linux](https://github.com/kyleconroy/sqlc/releases/download/v1.11.0/sqlc_1.11.0_linux_amd64.tar.gz)
+- [macOS](https://github.com/kyleconroy/sqlc/releases/download/v1.11.0/sqlc_1.11.0_darwin_amd64.zip)
+- [Windows (MySQL only)](https://github.com/kyleconroy/sqlc/releases/download/v1.11.0/sqlc_1.11.0_windows_amd64.zip)


### PR DESCRIPTION
Update download links to point to v1.11.0