### PR TITLE
Map postgres interval to go string rather than int64

### DIFF
--- a/internal/codegen/golang/postgresql_type.go
+++ b/internal/codegen/golang/postgresql_type.go
@@ -180,9 +180,9 @@ func postgresType(r *compiler.Result, col *compiler.Column, settings config.Comb
 
 	case "interval", "pg_catalog.interval":
 		if notNull {
-			return "int64"
+			return "string"
 		}
-		return "sql.NullInt64"
+		return "sql.NullString"
 
 	case "daterange":
 		if driver == SQLDriverPGXV4 {


### PR DESCRIPTION
Currently, Postgres's interval type is mapped to Go's int64 type.

I got around this by using an override, but I figured I'd open this PR as I don't believe it's ever correct to map interval to int64. Namely, I added this block to my `sqlc.yaml` and it fixed my issues:
```
overrides:
  - db_type: "pg_catalog.interval"
    go_type: "string"
  - db_type: "pg_catalog.interval"
    go_type: "database/sql.NullString"
    nullable: true
```

To prevent needing to use an override, I've updated the default type mapping in this PR. Please let me know if I've missed something and this isn't correct.
