### PR TITLE
feat(postgres): Add support for sql.NullInt16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,15 +9,34 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/jackc/pgx/v4 v4.14.1
 	github.com/jinzhu/inflection v1.0.0
-	github.com/kr/pretty v0.2.1 // indirect
 	github.com/lib/pq v1.10.4
 	github.com/pganalyze/pg_query_go/v2 v2.1.0
-	github.com/pingcap/log v0.0.0-20210906054005-afc726e70354 // indirect
 	github.com/pingcap/parser v0.0.0-20210914110036-002913dd28ec
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
-	go.uber.org/zap v1.19.1 // indirect
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
+	github.com/jackc/pgconn v1.10.1 // indirect
+	github.com/jackc/pgio v1.0.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgproto3/v2 v2.2.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
+	github.com/jackc/pgtype v1.9.1 // indirect
+	github.com/kr/pretty v0.2.1 // indirect
+	github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63 // indirect
+	github.com/pingcap/log v0.0.0-20210906054005-afc726e70354 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/multierr v1.7.0 // indirect
+	go.uber.org/zap v1.19.1 // indirect
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyleconroy/sqlc
 
-go 1.16
+go 1.17
 
 require (
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20211208212222-82c441726976

--- a/internal/codegen/golang/postgresql_type.go
+++ b/internal/codegen/golang/postgresql_type.go
@@ -28,7 +28,10 @@ func postgresType(r *compiler.Result, col *compiler.Column, settings config.Comb
 		return "sql.NullInt64"
 
 	case "smallserial", "serial2", "pg_catalog.serial2":
-		return "int16"
+		if notNull {
+			return "int16"
+		}
+		return "sql.NullInt16"
 
 	case "integer", "int", "int4", "pg_catalog.int4":
 		if notNull {
@@ -43,7 +46,10 @@ func postgresType(r *compiler.Result, col *compiler.Column, settings config.Comb
 		return "sql.NullInt64"
 
 	case "smallint", "int2", "pg_catalog.int2":
-		return "int16"
+		if notNull {
+			return "int16"
+		}
+		return "sql.NullInt16"
 
 	case "float", "double precision", "float8", "pg_catalog.float8":
 		if notNull {

--- a/internal/endtoend/testdata/datatype/pgx/go/models.go
+++ b/internal/endtoend/testdata/datatype/pgx/go/models.go
@@ -60,17 +60,17 @@ type DtNetTypesNotNull struct {
 }
 
 type DtNumeric struct {
-	A int16
+	A sql.NullInt16
 	B sql.NullInt32
 	C sql.NullInt64
 	D pgtype.Numeric
 	E pgtype.Numeric
 	F sql.NullFloat64
 	G sql.NullFloat64
-	H int16
+	H sql.NullInt16
 	I sql.NullInt32
 	J sql.NullInt64
-	K int16
+	K sql.NullInt16
 	L sql.NullInt32
 	M sql.NullInt64
 }

--- a/internal/endtoend/testdata/datatype/stdlib/go/models.go
+++ b/internal/endtoend/testdata/datatype/stdlib/go/models.go
@@ -60,17 +60,17 @@ type DtNetTypesNotNull struct {
 }
 
 type DtNumeric struct {
-	A int16
+	A sql.NullInt16
 	B sql.NullInt32
 	C sql.NullInt64
 	D sql.NullString
 	E sql.NullString
 	F sql.NullFloat64
 	G sql.NullFloat64
-	H int16
+	H sql.NullInt16
 	I sql.NullInt32
 	J sql.NullInt64
-	K int16
+	K sql.NullInt16
 	L sql.NullInt32
 	M sql.NullInt64
 }

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/go/models.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/pgx/go/models.go
@@ -9,5 +9,5 @@ import (
 type User struct {
 	FirstName sql.NullString `json:"firstName"`
 	LastName  sql.NullString `json:"lastName"`
-	Age       int16          `json:"age"`
+	Age       sql.NullInt16  `json:"age"`
 }

--- a/internal/endtoend/testdata/json_tags/camel_case/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/json_tags/camel_case/postgresql/stdlib/go/models.go
@@ -9,5 +9,5 @@ import (
 type User struct {
 	FirstName sql.NullString `json:"firstName"`
 	LastName  sql.NullString `json:"lastName"`
-	Age       int16          `json:"age"`
+	Age       sql.NullInt16  `json:"age"`
 }

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/go/models.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/pgx/go/models.go
@@ -9,5 +9,5 @@ import (
 type User struct {
 	FirstName sql.NullString `json:"FirstName"`
 	LastName  sql.NullString `json:"LastName"`
-	Age       int16          `json:"Age"`
+	Age       sql.NullInt16  `json:"Age"`
 }

--- a/internal/endtoend/testdata/json_tags/pascal_case/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/json_tags/pascal_case/postgresql/stdlib/go/models.go
@@ -9,5 +9,5 @@ import (
 type User struct {
 	FirstName sql.NullString `json:"FirstName"`
 	LastName  sql.NullString `json:"LastName"`
-	Age       int16          `json:"Age"`
+	Age       sql.NullInt16  `json:"Age"`
 }

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/go/models.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/pgx/go/models.go
@@ -9,5 +9,5 @@ import (
 type User struct {
 	FirstName sql.NullString `json:"first_name"`
 	LastName  sql.NullString `json:"last_name"`
-	Age       int16          `json:"age"`
+	Age       sql.NullInt16  `json:"age"`
 }

--- a/internal/endtoend/testdata/json_tags/snake_case/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/json_tags/snake_case/postgresql/stdlib/go/models.go
@@ -9,5 +9,5 @@ import (
 type User struct {
 	FirstName sql.NullString `json:"first_name"`
 	LastName  sql.NullString `json:"last_name"`
-	Age       int16          `json:"age"`
+	Age       sql.NullInt16  `json:"age"`
 }


### PR DESCRIPTION
Go added support for sql.NullInt16 in the standard library as of go1.17 (https://github.com/golang/go/issues/40082), so sqlc can now use the appropriate nullable type for int16.