### PR TITLE
build: Format all Go code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ psql:
 mysqlsh:
 	mysqlsh --sql --user root --password mysecretpassword --database dinotest 127.0.0.1:3306
 
+fmt:
+	go fmt ./...
 
 # $ protoc --version
 # libprotoc 3.17.3

--- a/examples/authors/mysql/db_test.go
+++ b/examples/authors/mysql/db_test.go
@@ -1,3 +1,4 @@
+//go:build examples
 // +build examples
 
 package authors

--- a/examples/authors/postgresql/db_test.go
+++ b/examples/authors/postgresql/db_test.go
@@ -1,3 +1,4 @@
+//go:build examples
 // +build examples
 
 package authors

--- a/examples/booktest/postgresql/db_test.go
+++ b/examples/booktest/postgresql/db_test.go
@@ -1,3 +1,4 @@
+//go:build examples
 // +build examples
 
 package booktest

--- a/examples/ondeck/mysql/db_test.go
+++ b/examples/ondeck/mysql/db_test.go
@@ -1,3 +1,4 @@
+//go:build examples
 // +build examples
 
 package ondeck

--- a/examples/ondeck/postgresql/db_test.go
+++ b/examples/ondeck/postgresql/db_test.go
@@ -1,3 +1,4 @@
+//go:build examples
 // +build examples
 
 package ondeck

--- a/internal/engine/postgresql/parse_windows.go
+++ b/internal/engine/postgresql/parse_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package postgresql

--- a/internal/engine/postgresql/utils.go
+++ b/internal/engine/postgresql/utils.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package postgresql


### PR DESCRIPTION
Make it easier to format code using `make fmt`.