### PR TITLE
fix: Enable strict function checking

### DIFF
--- a/internal/compiler/parse.go
+++ b/internal/compiler/parse.go
@@ -72,7 +72,7 @@ func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query,
 	if rawSQL == "" {
 		return nil, errors.New("missing semicolon at end of file")
 	}
-	if err := validate.FuncCall(c.catalog, raw); err != nil {
+	if err := validate.FuncCall(c.catalog, c.combo, raw); err != nil {
 		return nil, err
 	}
 	name, cmd, err := metadata.Parse(strings.TrimSpace(rawSQL), c.parser.CommentSyntax())
@@ -106,7 +106,7 @@ func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query,
 	if err != nil {
 		return nil, err
 	}
-	params, err := resolveCatalogRefs(c.catalog, qc, rvs, refs, namedParams)
+	params, err := c.resolveCatalogRefs(qc, rvs, refs, namedParams)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/compiler/resolve.go
+++ b/internal/compiler/resolve.go
@@ -259,9 +259,6 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 		case *ast.FuncCall:
 			fun, err := c.ResolveFuncCall(n)
 			if err != nil {
-				if comp.combo.Package.StrictFunctionChecks {
-					return nil, err
-				}
 				// Synthesize a function on the fly to avoid returning with an error
 				// for an unknown Postgres function (e.g. defined in an extension)
 				var args []*catalog.Argument

--- a/internal/compiler/resolve.go
+++ b/internal/compiler/resolve.go
@@ -18,7 +18,9 @@ func dataType(n *ast.TypeName) string {
 	}
 }
 
-func resolveCatalogRefs(c *catalog.Catalog, qc *QueryCatalog, rvs []*ast.RangeVar, args []paramRef, names map[int]string) ([]Parameter, error) {
+func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, args []paramRef, names map[int]string) ([]Parameter, error) {
+	c := comp.catalog
+
 	aliasMap := map[string]*ast.TableName{}
 	// TODO: Deprecate defaultTable
 	var defaultTable *ast.TableName
@@ -257,6 +259,9 @@ func resolveCatalogRefs(c *catalog.Catalog, qc *QueryCatalog, rvs []*ast.RangeVa
 		case *ast.FuncCall:
 			fun, err := c.ResolveFuncCall(n)
 			if err != nil {
+				if comp.combo.Package.StrictFunctionChecks {
+					return nil, err
+				}
 				// Synthesize a function on the fly to avoid returning with an error
 				// for an unknown Postgres function (e.g. defined in an extension)
 				var args []*catalog.Argument

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,10 +97,11 @@ type GenKotlin struct {
 }
 
 type SQL struct {
-	Engine  Engine `json:"engine,omitempty" yaml:"engine"`
-	Schema  Paths  `json:"schema" yaml:"schema"`
-	Queries Paths  `json:"queries" yaml:"queries"`
-	Gen     SQLGen `json:"gen" yaml:"gen"`
+	Engine               Engine `json:"engine,omitempty" yaml:"engine"`
+	Schema               Paths  `json:"schema" yaml:"schema"`
+	Queries              Paths  `json:"queries" yaml:"queries"`
+	StrictFunctionChecks bool   `json:"strict_function_checks" yaml:"strict_function_checks"`
+	Gen                  SQLGen `json:"gen" yaml:"gen"`
 }
 
 type SQLGen struct {

--- a/internal/config/v_one.go
+++ b/internal/config/v_one.go
@@ -38,6 +38,7 @@ type v1PackageSettings struct {
 	OutputModelsFileName      string     `json:"output_models_file_name,omitempty" yaml:"output_models_file_name"`
 	OutputQuerierFileName     string     `json:"output_querier_file_name,omitempty" yaml:"output_querier_file_name"`
 	OutputFilesSuffix         string     `json:"output_files_suffix,omitempty" yaml:"output_files_suffix"`
+	StrictFunctionChecks      bool       `json:"strict_function_checks" yaml:"strict_function_checks"`
 }
 
 func v1ParseConfig(rd io.Reader) (Config, error) {
@@ -134,6 +135,7 @@ func (c *V1GenerateSettings) Translate() Config {
 					OutputFilesSuffix:         pkg.OutputFilesSuffix,
 				},
 			},
+			StrictFunctionChecks: pkg.StrictFunctionChecks,
 		})
 	}
 

--- a/internal/endtoend/testdata/strict_function_checks/postgresql/query.sql
+++ b/internal/endtoend/testdata/strict_function_checks/postgresql/query.sql
@@ -1,0 +1,2 @@
+-- name: F :exec
+SELECT doesntexist();

--- a/internal/endtoend/testdata/strict_function_checks/postgresql/sqlc.json
+++ b/internal/endtoend/testdata/strict_function_checks/postgresql/sqlc.json
@@ -7,7 +7,7 @@
 			"schema": "query.sql",
 			"queries": "query.sql",
 			"engine": "postgresql",
-      "strict_function_checks": true
+			"strict_function_checks": true
 		}
 	]
 }

--- a/internal/endtoend/testdata/strict_function_checks/postgresql/sqlc.json
+++ b/internal/endtoend/testdata/strict_function_checks/postgresql/sqlc.json
@@ -1,0 +1,13 @@
+{
+	"version": "1",
+	"packages": [
+		{
+			"name": "querytest",
+			"path": "go",
+			"schema": "query.sql",
+			"queries": "query.sql",
+			"engine": "postgresql",
+      "strict_function_checks": true
+		}
+	]
+}

--- a/internal/endtoend/testdata/strict_function_checks/postgresql/stderr.txt
+++ b/internal/endtoend/testdata/strict_function_checks/postgresql/stderr.txt
@@ -1,0 +1,2 @@
+# package querytest
+query.sql:1:1: function "doesntexist" does not exist


### PR DESCRIPTION
Fixes #537 

We need to add this behind a flag, otherwise it will break many people's build. To enable this, set `strict_function_checks` to `true`.

```
{
	"version": "1",
	"packages": [
		{
			"name": "querytest",
			"path": "go",
			"schema": "query.sql",
			"queries": "query.sql",
			"engine": "postgresql",
			"strict_function_checks": true
		}
	]
}
```