### PR TITLE
Bug: ALTER TABLE SET SCHEMA

### DIFF
--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/go/models.go
@@ -2,7 +2,10 @@
 
 package querytest
 
-import ()
+import (
+	"database/sql"
+)
 
 type FooBar struct {
+	Name sql.NullString
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/go/query.sql.go
@@ -5,13 +5,23 @@ package querytest
 
 import (
 	"context"
+	"database/sql"
 )
 
-const placeholder = `-- name: Placeholder :exec
-SELECT 1
+const getFooBar = `-- name: GetFooBar :exec
+SELECT name FROM foo.bar
 `
 
-func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.Exec(ctx, placeholder)
+func (q *Queries) GetFooBar(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, getFooBar)
+	return err
+}
+
+const updateFooBar = `-- name: UpdateFooBar :exec
+UPDATE foo.bar SET name = $1
+`
+
+func (q *Queries) UpdateFooBar(ctx context.Context, name sql.NullString) error {
+	_, err := q.db.Exec(ctx, updateFooBar, name)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/query.sql
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/query.sql
@@ -1,2 +1,5 @@
--- name: Placeholder :exec
-SELECT 1;
+-- name: GetFooBar :exec
+SELECT * FROM foo.bar;
+
+-- name: UpdateFooBar :exec
+UPDATE foo.bar SET name = $1;

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/schema.sql
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/pgx/schema.sql
@@ -1,3 +1,3 @@
 CREATE SCHEMA foo;
-CREATE TABLE bar ();
+CREATE TABLE bar (name text);
 ALTER TABLE bar SET SCHEMA foo;

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/go/models.go
@@ -2,7 +2,10 @@
 
 package querytest
 
-import ()
+import (
+	"database/sql"
+)
 
 type FooBar struct {
+	Name sql.NullString
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/go/query.sql.go
@@ -5,13 +5,23 @@ package querytest
 
 import (
 	"context"
+	"database/sql"
 )
 
-const placeholder = `-- name: Placeholder :exec
-SELECT 1
+const getFooBar = `-- name: GetFooBar :exec
+SELECT name FROM foo.bar
 `
 
-func (q *Queries) Placeholder(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, placeholder)
+func (q *Queries) GetFooBar(ctx context.Context) error {
+	_, err := q.db.ExecContext(ctx, getFooBar)
+	return err
+}
+
+const updateFooBar = `-- name: UpdateFooBar :exec
+UPDATE foo.bar SET name = $1
+`
+
+func (q *Queries) UpdateFooBar(ctx context.Context, name sql.NullString) error {
+	_, err := q.db.ExecContext(ctx, updateFooBar, name)
 	return err
 }

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/query.sql
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/query.sql
@@ -1,2 +1,5 @@
--- name: Placeholder :exec
-SELECT 1;
+-- name: GetFooBar :exec
+SELECT * FROM foo.bar;
+
+-- name: UpdateFooBar :exec
+UPDATE foo.bar SET name = $1;

--- a/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/schema.sql
+++ b/internal/endtoend/testdata/ddl_alter_table_set_schema/postgresql/stdlib/schema.sql
@@ -1,3 +1,3 @@
 CREATE SCHEMA foo;
-CREATE TABLE bar ();
+CREATE TABLE bar (name text);
 ALTER TABLE bar SET SCHEMA foo;

--- a/internal/sql/catalog/table.go
+++ b/internal/sql/catalog/table.go
@@ -110,6 +110,7 @@ func (c *Catalog) alterTableSetSchema(stmt *ast.AlterTableSetSchemaStmt) error {
 	if err != nil {
 		return err
 	}
+	tbl.Rel.Schema = *stmt.NewSchema
 	newSchema, err := c.getSchema(*stmt.NewSchema)
 	if err != nil {
 		return err


### PR DESCRIPTION
Once a table schema has been changes via `ALTER TABLE <name> SET SCHEMA <new_schema>`, any `UPDATE` queries do not recognise the new table name.

Example:
schema.sql
```sql
CREATE SCHEMA foo;
CREATE TABLE bar (name text);
ALTER TABLE bar SET SCHEMA foo;
```

queries.sql
```sql
-- name: UpdateFooBar :exec
UPDATE foo.bar SET name = $1;
```

The compiler does not recognise the `foo.bar` table and throws an error. 