### PR TITLE
fix(config): Fix type name for versioned type overrides

### DIFF
--- a/cmd/sqlc/main.go
+++ b/cmd/sqlc/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/kyleconroy/sqlc/internal/cmd"
+	"github.com/egtann/sqlc/internal/cmd"
 )
 
 func main() {

--- a/examples/authors/mysql/db_test.go
+++ b/examples/authors/mysql/db_test.go
@@ -8,7 +8,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/kyleconroy/sqlc/internal/sqltest"
+	"github.com/egtann/sqlc/internal/sqltest"
 )
 
 func TestAuthors(t *testing.T) {

--- a/examples/authors/postgresql/db_test.go
+++ b/examples/authors/postgresql/db_test.go
@@ -8,7 +8,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/kyleconroy/sqlc/internal/sqltest"
+	"github.com/egtann/sqlc/internal/sqltest"
 )
 
 func TestAuthors(t *testing.T) {

--- a/examples/booktest/mysql/db_test.go
+++ b/examples/booktest/mysql/db_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyleconroy/sqlc/internal/sqltest"
+	"github.com/egtann/sqlc/internal/sqltest"
 )
 
 func TestBooks(t *testing.T) {

--- a/examples/booktest/postgresql/db_test.go
+++ b/examples/booktest/postgresql/db_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyleconroy/sqlc/internal/sqltest"
+	"github.com/egtann/sqlc/internal/sqltest"
 )
 
 func TestBooks(t *testing.T) {

--- a/examples/ondeck/mysql/db_test.go
+++ b/examples/ondeck/mysql/db_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kyleconroy/sqlc/internal/sqltest"
+	"github.com/egtann/sqlc/internal/sqltest"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/examples/ondeck/postgresql/db_test.go
+++ b/examples/ondeck/postgresql/db_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kyleconroy/sqlc/internal/sqltest"
+	"github.com/egtann/sqlc/internal/sqltest"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kyleconroy/sqlc
+module github.com/egtann/sqlc
 
 go 1.17
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -13,9 +13,9 @@ import (
 	"github.com/spf13/pflag"
 	yaml "gopkg.in/yaml.v3"
 
-	"github.com/kyleconroy/sqlc/internal/config"
-	"github.com/kyleconroy/sqlc/internal/debug"
-	"github.com/kyleconroy/sqlc/internal/tracer"
+	"github.com/egtann/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/debug"
+	"github.com/egtann/sqlc/internal/tracer"
 )
 
 // Do runs the command logic.

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -11,15 +11,15 @@ import (
 	"runtime/trace"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/codegen/golang"
-	"github.com/kyleconroy/sqlc/internal/codegen/kotlin"
-	"github.com/kyleconroy/sqlc/internal/codegen/python"
-	"github.com/kyleconroy/sqlc/internal/compiler"
-	"github.com/kyleconroy/sqlc/internal/config"
-	"github.com/kyleconroy/sqlc/internal/debug"
-	"github.com/kyleconroy/sqlc/internal/multierr"
-	"github.com/kyleconroy/sqlc/internal/opts"
-	"github.com/kyleconroy/sqlc/internal/plugin"
+	"github.com/egtann/sqlc/internal/codegen/golang"
+	"github.com/egtann/sqlc/internal/codegen/kotlin"
+	"github.com/egtann/sqlc/internal/codegen/python"
+	"github.com/egtann/sqlc/internal/compiler"
+	"github.com/egtann/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/debug"
+	"github.com/egtann/sqlc/internal/multierr"
+	"github.com/egtann/sqlc/internal/opts"
+	"github.com/egtann/sqlc/internal/plugin"
 )
 
 const errMessageNoVersion = `The configuration file must have a version number.

--- a/internal/cmd/shim.go
+++ b/internal/cmd/shim.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/compiler"
-	"github.com/kyleconroy/sqlc/internal/config"
-	"github.com/kyleconroy/sqlc/internal/plugin"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/compiler"
+	"github.com/egtann/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/plugin"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func pluginOverride(o config.Override) *plugin.Override {

--- a/internal/codegen/golang/compat.go
+++ b/internal/codegen/golang/compat.go
@@ -1,8 +1,8 @@
 package golang
 
 import (
-	"github.com/kyleconroy/sqlc/internal/core"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/core"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 func sameTableName(n *ast.TableName, f core.FQN, defaultSchema string) bool {

--- a/internal/codegen/golang/driver.go
+++ b/internal/codegen/golang/driver.go
@@ -1,6 +1,6 @@
 package golang
 
-import "github.com/kyleconroy/sqlc/internal/config"
+import "github.com/egtann/sqlc/internal/config"
 
 type SQLDriver int
 

--- a/internal/codegen/golang/field.go
+++ b/internal/codegen/golang/field.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/config"
 )
 
 type Field struct {

--- a/internal/codegen/golang/gen.go
+++ b/internal/codegen/golang/gen.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/kyleconroy/sqlc/internal/codegen"
-	"github.com/kyleconroy/sqlc/internal/compiler"
-	"github.com/kyleconroy/sqlc/internal/config"
-	"github.com/kyleconroy/sqlc/internal/metadata"
+	"github.com/egtann/sqlc/internal/codegen"
+	"github.com/egtann/sqlc/internal/compiler"
+	"github.com/egtann/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/metadata"
 )
 
 type Generateable interface {

--- a/internal/codegen/golang/go_type.go
+++ b/internal/codegen/golang/go_type.go
@@ -1,8 +1,8 @@
 package golang
 
 import (
-	"github.com/kyleconroy/sqlc/internal/compiler"
-	"github.com/kyleconroy/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/compiler"
+	"github.com/egtann/sqlc/internal/config"
 )
 
 func goType(r *compiler.Result, col *compiler.Column, settings config.CombinedSettings) string {

--- a/internal/codegen/golang/imports.go
+++ b/internal/codegen/golang/imports.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/config"
-	"github.com/kyleconroy/sqlc/internal/metadata"
+	"github.com/egtann/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/metadata"
 )
 
 type fileImports struct {

--- a/internal/codegen/golang/mysql_type.go
+++ b/internal/codegen/golang/mysql_type.go
@@ -3,10 +3,10 @@ package golang
 import (
 	"log"
 
-	"github.com/kyleconroy/sqlc/internal/compiler"
-	"github.com/kyleconroy/sqlc/internal/config"
-	"github.com/kyleconroy/sqlc/internal/debug"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/compiler"
+	"github.com/egtann/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/debug"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func mysqlType(r *compiler.Result, col *compiler.Column, settings config.CombinedSettings) string {

--- a/internal/codegen/golang/postgresql_type.go
+++ b/internal/codegen/golang/postgresql_type.go
@@ -3,10 +3,10 @@ package golang
 import (
 	"log"
 
-	"github.com/kyleconroy/sqlc/internal/compiler"
-	"github.com/kyleconroy/sqlc/internal/config"
-	"github.com/kyleconroy/sqlc/internal/debug"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/compiler"
+	"github.com/egtann/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/debug"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func postgresType(r *compiler.Result, col *compiler.Column, settings config.CombinedSettings) string {

--- a/internal/codegen/golang/query.go
+++ b/internal/codegen/golang/query.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/metadata"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/metadata"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 type QueryValue struct {

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -5,12 +5,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/codegen"
-	"github.com/kyleconroy/sqlc/internal/compiler"
-	"github.com/kyleconroy/sqlc/internal/config"
-	"github.com/kyleconroy/sqlc/internal/core"
-	"github.com/kyleconroy/sqlc/internal/inflection"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/codegen"
+	"github.com/egtann/sqlc/internal/compiler"
+	"github.com/egtann/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/core"
+	"github.com/egtann/sqlc/internal/inflection"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func buildEnums(r *compiler.Result, settings config.CombinedSettings) []Enum {

--- a/internal/codegen/golang/sqlite_type.go
+++ b/internal/codegen/golang/sqlite_type.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/compiler"
-	"github.com/kyleconroy/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/compiler"
+	"github.com/egtann/sqlc/internal/config"
 )
 
 func sqliteType(r *compiler.Result, col *compiler.Column, settings config.CombinedSettings) string {

--- a/internal/codegen/golang/struct.go
+++ b/internal/codegen/golang/struct.go
@@ -3,8 +3,8 @@ package golang
 import (
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/config"
-	"github.com/kyleconroy/sqlc/internal/core"
+	"github.com/egtann/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/core"
 )
 
 type Struct struct {

--- a/internal/codegen/kotlin/gen.go
+++ b/internal/codegen/kotlin/gen.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/kyleconroy/sqlc/internal/codegen"
-	"github.com/kyleconroy/sqlc/internal/inflection"
-	"github.com/kyleconroy/sqlc/internal/metadata"
-	"github.com/kyleconroy/sqlc/internal/plugin"
+	"github.com/egtann/sqlc/internal/codegen"
+	"github.com/egtann/sqlc/internal/inflection"
+	"github.com/egtann/sqlc/internal/metadata"
+	"github.com/egtann/sqlc/internal/plugin"
 )
 
 func sameTableName(n, f *plugin.Identifier) bool {

--- a/internal/codegen/kotlin/imports.go
+++ b/internal/codegen/kotlin/imports.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/plugin"
+	"github.com/egtann/sqlc/internal/plugin"
 )
 
 type importer struct {

--- a/internal/codegen/kotlin/mysql_type.go
+++ b/internal/codegen/kotlin/mysql_type.go
@@ -3,8 +3,8 @@ package kotlin
 import (
 	"log"
 
-	"github.com/kyleconroy/sqlc/internal/debug"
-	"github.com/kyleconroy/sqlc/internal/plugin"
+	"github.com/egtann/sqlc/internal/debug"
+	"github.com/egtann/sqlc/internal/plugin"
 )
 
 func dataType(n *plugin.Identifier) string {

--- a/internal/codegen/kotlin/postgresql_type.go
+++ b/internal/codegen/kotlin/postgresql_type.go
@@ -3,7 +3,7 @@ package kotlin
 import (
 	"log"
 
-	"github.com/kyleconroy/sqlc/internal/plugin"
+	"github.com/egtann/sqlc/internal/plugin"
 )
 
 func postgresType(req *plugin.CodeGenRequest, col *plugin.Column) (string, bool) {

--- a/internal/codegen/python/gen.go
+++ b/internal/codegen/python/gen.go
@@ -8,14 +8,14 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/codegen"
-	"github.com/kyleconroy/sqlc/internal/inflection"
-	"github.com/kyleconroy/sqlc/internal/metadata"
-	"github.com/kyleconroy/sqlc/internal/pattern"
-	"github.com/kyleconroy/sqlc/internal/plugin"
-	pyast "github.com/kyleconroy/sqlc/internal/python/ast"
-	"github.com/kyleconroy/sqlc/internal/python/poet"
-	pyprint "github.com/kyleconroy/sqlc/internal/python/printer"
+	"github.com/egtann/sqlc/internal/codegen"
+	"github.com/egtann/sqlc/internal/inflection"
+	"github.com/egtann/sqlc/internal/metadata"
+	"github.com/egtann/sqlc/internal/pattern"
+	"github.com/egtann/sqlc/internal/plugin"
+	pyast "github.com/egtann/sqlc/internal/python/ast"
+	"github.com/egtann/sqlc/internal/python/poet"
+	pyprint "github.com/egtann/sqlc/internal/python/printer"
 )
 
 type Constant struct {

--- a/internal/codegen/python/imports.go
+++ b/internal/codegen/python/imports.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/plugin"
+	"github.com/egtann/sqlc/internal/plugin"
 )
 
 type importSpec struct {

--- a/internal/codegen/python/postgresql_type.go
+++ b/internal/codegen/python/postgresql_type.go
@@ -3,7 +3,7 @@ package python
 import (
 	"log"
 
-	"github.com/kyleconroy/sqlc/internal/plugin"
+	"github.com/egtann/sqlc/internal/plugin"
 )
 
 func dataType(n *plugin.Identifier) string {

--- a/internal/compiler/compat.go
+++ b/internal/compiler/compat.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/astutils"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/astutils"
 )
 
 // This is mainly copy-pasted from internal/postgresql/parse.go

--- a/internal/compiler/compile.go
+++ b/internal/compiler/compile.go
@@ -9,13 +9,13 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/metadata"
-	"github.com/kyleconroy/sqlc/internal/migrations"
-	"github.com/kyleconroy/sqlc/internal/multierr"
-	"github.com/kyleconroy/sqlc/internal/opts"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlpath"
+	"github.com/egtann/sqlc/internal/metadata"
+	"github.com/egtann/sqlc/internal/migrations"
+	"github.com/egtann/sqlc/internal/multierr"
+	"github.com/egtann/sqlc/internal/opts"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/sqlpath"
 )
 
 // TODO: Rename this interface Engine

--- a/internal/compiler/engine.go
+++ b/internal/compiler/engine.go
@@ -3,12 +3,12 @@ package compiler
 import (
 	"fmt"
 
-	"github.com/kyleconroy/sqlc/internal/config"
-	"github.com/kyleconroy/sqlc/internal/engine/dolphin"
-	"github.com/kyleconroy/sqlc/internal/engine/postgresql"
-	"github.com/kyleconroy/sqlc/internal/engine/sqlite"
-	"github.com/kyleconroy/sqlc/internal/opts"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/engine/dolphin"
+	"github.com/egtann/sqlc/internal/engine/postgresql"
+	"github.com/egtann/sqlc/internal/engine/sqlite"
+	"github.com/egtann/sqlc/internal/opts"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 type Compiler struct {

--- a/internal/compiler/expand.go
+++ b/internal/compiler/expand.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/config"
-	"github.com/kyleconroy/sqlc/internal/source"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/astutils"
+	"github.com/egtann/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/source"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/astutils"
 )
 
 func (c *Compiler) expand(qc *QueryCatalog, raw *ast.RawStmt) ([]source.Edit, error) {

--- a/internal/compiler/find_params.go
+++ b/internal/compiler/find_params.go
@@ -3,8 +3,8 @@ package compiler
 import (
 	"fmt"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/astutils"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/astutils"
 )
 
 func findParameters(root ast.Node) ([]paramRef, error) {

--- a/internal/compiler/output_columns.go
+++ b/internal/compiler/output_columns.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/astutils"
-	"github.com/kyleconroy/sqlc/internal/sql/lang"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/astutils"
+	"github.com/egtann/sqlc/internal/sql/lang"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 // OutputColumns determines which columns a statement will output

--- a/internal/compiler/parse.go
+++ b/internal/compiler/parse.go
@@ -6,15 +6,15 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/config"
-	"github.com/kyleconroy/sqlc/internal/debug"
-	"github.com/kyleconroy/sqlc/internal/metadata"
-	"github.com/kyleconroy/sqlc/internal/opts"
-	"github.com/kyleconroy/sqlc/internal/source"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/astutils"
-	"github.com/kyleconroy/sqlc/internal/sql/rewrite"
-	"github.com/kyleconroy/sqlc/internal/sql/validate"
+	"github.com/egtann/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/debug"
+	"github.com/egtann/sqlc/internal/metadata"
+	"github.com/egtann/sqlc/internal/opts"
+	"github.com/egtann/sqlc/internal/source"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/astutils"
+	"github.com/egtann/sqlc/internal/sql/rewrite"
+	"github.com/egtann/sqlc/internal/sql/validate"
 )
 
 var ErrUnsupportedStatementType = errors.New("parseQuery: unsupported statement type")

--- a/internal/compiler/query.go
+++ b/internal/compiler/query.go
@@ -1,7 +1,7 @@
 package compiler
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 type Function struct {

--- a/internal/compiler/query_catalog.go
+++ b/internal/compiler/query_catalog.go
@@ -3,8 +3,8 @@ package compiler
 import (
 	"fmt"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 type QueryCatalog struct {

--- a/internal/compiler/resolve.go
+++ b/internal/compiler/resolve.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/astutils"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/astutils"
+	"github.com/egtann/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 func dataType(n *ast.TypeName) string {

--- a/internal/compiler/result.go
+++ b/internal/compiler/result.go
@@ -1,7 +1,7 @@
 package compiler
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 type Result struct {

--- a/internal/compiler/to_column.go
+++ b/internal/compiler/to_column.go
@@ -3,8 +3,8 @@ package compiler
 import (
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/astutils"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/astutils"
 )
 
 func isArray(n *ast.TypeName) bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/pattern"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/pattern"
+	"github.com/egtann/sqlc/internal/sql/ast"
 
 	yaml "gopkg.in/yaml.v3"
 )

--- a/internal/config/go_type.go
+++ b/internal/config/go_type.go
@@ -149,6 +149,21 @@ func (gt GoType) Parse() (*ParsedGoType, error) {
 			typename = typename[:len(typename)-len("-go")]
 		}
 		o.ImportPath = input[:lastDot]
+
+		// set versioned overrides to reference the underlying package
+		// name. for example, the type for a/b/v2.C is b.C, not v2.C.
+		parts := strings.Split(input, "/")
+		if len(parts) >= 2 {
+			name := parts[len(parts)-1]
+			lastPeriod := strings.LastIndex(name, ".")
+			if lastPeriod > 0 {
+				version, name := name[:lastPeriod], name[lastPeriod:]
+				if versionNumber.MatchString(version) {
+					pkgName := parts[len(parts)-2]
+					typename = pkgName + name
+				}
+			}
+		}
 	}
 	o.TypeName = typename
 	isPointer := input[0] == '*'

--- a/internal/debug/dump.go
+++ b/internal/debug/dump.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 
-	"github.com/kyleconroy/sqlc/internal/opts"
+	"github.com/egtann/sqlc/internal/opts"
 )
 
 var Active bool

--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/kyleconroy/sqlc/internal/cmd"
+	"github.com/egtann/sqlc/internal/cmd"
 )
 
 func TestExamples(t *testing.T) {

--- a/internal/endtoend/testdata/case_named_params/mysql/query.sql
+++ b/internal/endtoend/testdata/case_named_params/mysql/query.sql
@@ -1,4 +1,4 @@
--- https://github.com/kyleconroy/sqlc/issues/1195
+-- https://github.com/egtann/sqlc/issues/1195
 
 CREATE TABLE authors (
   id   BIGINT PRIMARY KEY,

--- a/internal/endtoend/testdata/case_named_params/postgresql/query.sql
+++ b/internal/endtoend/testdata/case_named_params/postgresql/query.sql
@@ -1,4 +1,4 @@
--- https://github.com/kyleconroy/sqlc/issues/1195
+-- https://github.com/egtann/sqlc/issues/1195
 
 CREATE TABLE authors (
   id   BIGSERIAL PRIMARY KEY,

--- a/internal/endtoend/testdata/invalid_table_alias/mysql/query.sql
+++ b/internal/endtoend/testdata/invalid_table_alias/mysql/query.sql
@@ -1,4 +1,4 @@
--- https://github.com/kyleconroy/sqlc/issues/437
+-- https://github.com/egtann/sqlc/issues/437
 CREATE TABLE authors (
   id   INT PRIMARY KEY,
   name VARCHAR(255) NOT NULL,

--- a/internal/endtoend/testdata/invalid_table_alias/postgresql/query.sql
+++ b/internal/endtoend/testdata/invalid_table_alias/postgresql/query.sql
@@ -1,4 +1,4 @@
--- https://github.com/kyleconroy/sqlc/issues/437
+-- https://github.com/egtann/sqlc/issues/437
 CREATE TABLE authors (
   id   BIGSERIAL PRIMARY KEY,
   name text      NOT NULL,

--- a/internal/endtoend/testdata/join_left/mysql/query.sql
+++ b/internal/endtoend/testdata/join_left/mysql/query.sql
@@ -1,4 +1,4 @@
--- https://github.com/kyleconroy/sqlc/issues/604
+-- https://github.com/egtann/sqlc/issues/604
 CREATE TABLE users (
   user_id    INT PRIMARY KEY,
   city_id    INT -- nullable

--- a/internal/endtoend/testdata/join_left/postgresql/query.sql
+++ b/internal/endtoend/testdata/join_left/postgresql/query.sql
@@ -1,4 +1,4 @@
---- https://github.com/kyleconroy/sqlc/issues/604
+--- https://github.com/egtann/sqlc/issues/604
 CREATE TABLE users (
   user_id    INT PRIMARY KEY,
   city_id    INT -- nullable

--- a/internal/endtoend/testdata/missing_semicolon/mysql/query.sql
+++ b/internal/endtoend/testdata/missing_semicolon/mysql/query.sql
@@ -1,4 +1,4 @@
--- https://github.com/kyleconroy/sqlc/issues/1198
+-- https://github.com/egtann/sqlc/issues/1198
 CREATE TABLE authors (
   id   INT PRIMARY KEY,
   name VARCHAR(255) NOT NULL,

--- a/internal/endtoend/testdata/on_duplicate_key_update/mysql/query.sql
+++ b/internal/endtoend/testdata/on_duplicate_key_update/mysql/query.sql
@@ -1,4 +1,4 @@
--- https://github.com/kyleconroy/sqlc/issues/921
+-- https://github.com/egtann/sqlc/issues/921
 CREATE TABLE authors (
   id   BIGINT  NOT NULL AUTO_INCREMENT PRIMARY KEY,
   name text    NOT NULL,

--- a/internal/endtoend/testdata/on_duplicate_key_update/postgresql/query.sql
+++ b/internal/endtoend/testdata/on_duplicate_key_update/postgresql/query.sql
@@ -1,4 +1,4 @@
--- https://github.com/kyleconroy/sqlc/issues/921
+-- https://github.com/egtann/sqlc/issues/921
 CREATE TABLE authors (
   id   BIGSERIAL PRIMARY KEY,
   name text      NOT NULL UNIQUE,

--- a/internal/endtoend/testdata/overrides/mysql/go/models.go
+++ b/internal/endtoend/testdata/overrides/mysql/go/models.go
@@ -3,7 +3,7 @@
 package override
 
 import (
-	"github.com/kyleconroy/sqlc-testdata/pkg"
+	"github.com/egtann/sqlc-testdata/pkg"
 )
 
 type Foo struct {

--- a/internal/endtoend/testdata/overrides/mysql/sqlc.json
+++ b/internal/endtoend/testdata/overrides/mysql/sqlc.json
@@ -9,7 +9,7 @@
       "queries": "query.sql",
       "overrides": [
         {
-          "go_type": "github.com/kyleconroy/sqlc-testdata/pkg.CustomType",
+          "go_type": "github.com/egtann/sqlc-testdata/pkg.CustomType",
           "column": "foo.retyped"
         }
       ]

--- a/internal/endtoend/testdata/overrides/postgresql/pgx/go/models.go
+++ b/internal/endtoend/testdata/overrides/postgresql/pgx/go/models.go
@@ -3,7 +3,7 @@
 package override
 
 import (
-	"github.com/kyleconroy/sqlc-testdata/pkg"
+	"github.com/egtann/sqlc-testdata/pkg"
 	"github.com/lib/pq"
 )
 

--- a/internal/endtoend/testdata/overrides/postgresql/pgx/sqlc.json
+++ b/internal/endtoend/testdata/overrides/postgresql/pgx/sqlc.json
@@ -10,7 +10,7 @@
       "queries": "query.sql",
       "overrides": [
         {
-          "go_type": "github.com/kyleconroy/sqlc-testdata/pkg.CustomType",
+          "go_type": "github.com/egtann/sqlc-testdata/pkg.CustomType",
           "column": "foo.retyped"
         },
         {

--- a/internal/endtoend/testdata/overrides/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/overrides/postgresql/stdlib/go/models.go
@@ -3,7 +3,7 @@
 package override
 
 import (
-	"github.com/kyleconroy/sqlc-testdata/pkg"
+	"github.com/egtann/sqlc-testdata/pkg"
 	"github.com/lib/pq"
 )
 

--- a/internal/endtoend/testdata/overrides/postgresql/stdlib/sqlc.json
+++ b/internal/endtoend/testdata/overrides/postgresql/stdlib/sqlc.json
@@ -9,7 +9,7 @@
       "queries": "query.sql",
       "overrides": [
         {
-          "go_type": "github.com/kyleconroy/sqlc-testdata/pkg.CustomType",
+          "go_type": "github.com/egtann/sqlc-testdata/pkg.CustomType",
           "column": "foo.retyped"
         },
         {

--- a/internal/endtoend/testdata/overrides_go_types/mysql/go/models.go
+++ b/internal/endtoend/testdata/overrides_go_types/mysql/go/models.go
@@ -3,7 +3,7 @@
 package override
 
 import (
-	"github.com/kyleconroy/sqlc-testdata/pkg"
+	"github.com/egtann/sqlc-testdata/pkg"
 )
 
 type Bar struct {

--- a/internal/endtoend/testdata/overrides_go_types/mysql/sqlc.json
+++ b/internal/endtoend/testdata/overrides_go_types/mysql/sqlc.json
@@ -9,11 +9,11 @@
       "queries": "query.sql",
       "overrides": [
         {
-          "go_type": "github.com/kyleconroy/sqlc-testdata/pkg.CustomType",
+          "go_type": "github.com/egtann/sqlc-testdata/pkg.CustomType",
           "column": "foo.retyped"
         },
         {
-          "go_type": "github.com/kyleconroy/sqlc-testdata/pkg.CustomType",
+          "go_type": "github.com/egtann/sqlc-testdata/pkg.CustomType",
           "column": "*.also_retyped"
         }
       ]

--- a/internal/endtoend/testdata/single_param_conflict/mysql/query.sql
+++ b/internal/endtoend/testdata/single_param_conflict/mysql/query.sql
@@ -17,7 +17,7 @@ FROM    authors
 WHERE   id = ?
 LIMIT   1;
 
--- https://github.com/kyleconroy/sqlc/issues/1290
+-- https://github.com/egtann/sqlc/issues/1290
 CREATE TABLE users (
   sub TEXT PRIMARY KEY
 );

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/go/query.sql.go
@@ -57,7 +57,7 @@ WHERE   id = $1
 RETURNING id
 `
 
-// https://github.com/kyleconroy/sqlc/issues/1235
+// https://github.com/egtann/sqlc/issues/1235
 func (q *Queries) SetDefaultName(ctx context.Context, id int64) (int64, error) {
 	row := q.db.QueryRowContext(ctx, setDefaultName, id)
 	err := row.Scan(&id)

--- a/internal/endtoend/testdata/single_param_conflict/postgresql/query.sql
+++ b/internal/endtoend/testdata/single_param_conflict/postgresql/query.sql
@@ -17,7 +17,7 @@ FROM    authors
 WHERE   id = $1
 LIMIT   1;
 
--- https://github.com/kyleconroy/sqlc/issues/1290
+-- https://github.com/egtann/sqlc/issues/1290
 CREATE TABLE users (
   sub UUID PRIMARY KEY
 );
@@ -28,7 +28,7 @@ FROM    users
 WHERE   sub = $1
 LIMIT   1;
 
--- https://github.com/kyleconroy/sqlc/issues/1235
+-- https://github.com/egtann/sqlc/issues/1235
 
 -- name: SetDefaultName :one
 UPDATE  authors

--- a/internal/endtoend/testdata/valid_group_by_reference/mysql/query.sql
+++ b/internal/endtoend/testdata/valid_group_by_reference/mysql/query.sql
@@ -16,7 +16,7 @@ FROM     authors
 GROUP BY name;
 
 
--- https://github.com/kyleconroy/sqlc/issues/1315
+-- https://github.com/egtann/sqlc/issues/1315
 
 CREATE TABLE IF NOT EXISTS weather_metrics
 (

--- a/internal/endtoend/testdata/valid_group_by_reference/postgresql/query.sql
+++ b/internal/endtoend/testdata/valid_group_by_reference/postgresql/query.sql
@@ -15,7 +15,7 @@ FROM     authors
 GROUP BY name;
 
 
--- https://github.com/kyleconroy/sqlc/issues/1315
+-- https://github.com/egtann/sqlc/issues/1315
 
 CREATE TABLE IF NOT EXISTS weather_metrics
 (

--- a/internal/endtoend/testdata/yaml_overrides/go/models.go
+++ b/internal/endtoend/testdata/yaml_overrides/go/models.go
@@ -3,7 +3,7 @@
 package override
 
 import (
-	"github.com/kyleconroy/sqlc-testdata/pkg"
+	"github.com/egtann/sqlc-testdata/pkg"
 	"github.com/lib/pq"
 )
 

--- a/internal/endtoend/testdata/yaml_overrides/sqlc.yaml
+++ b/internal/endtoend/testdata/yaml_overrides/sqlc.yaml
@@ -5,7 +5,7 @@ packages:
     schema: "sql/"
     queries: "sql/"
     overrides:
-      - go_type: "github.com/kyleconroy/sqlc-testdata/pkg.CustomType"
+      - go_type: "github.com/egtann/sqlc-testdata/pkg.CustomType"
         column: "foo.retyped"
       - go_type: "github.com/lib/pq.StringArray"
         column: "foo.langs"

--- a/internal/engine/dolphin/catalog.go
+++ b/internal/engine/dolphin/catalog.go
@@ -1,7 +1,7 @@
 package dolphin
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func NewCatalog() *catalog.Catalog {

--- a/internal/engine/dolphin/convert.go
+++ b/internal/engine/dolphin/convert.go
@@ -10,8 +10,8 @@ import (
 	driver "github.com/pingcap/parser/test_driver"
 	"github.com/pingcap/parser/types"
 
-	"github.com/kyleconroy/sqlc/internal/debug"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/debug"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 type cc struct {

--- a/internal/engine/dolphin/parse.go
+++ b/internal/engine/dolphin/parse.go
@@ -10,9 +10,9 @@ import (
 	"github.com/pingcap/parser"
 	_ "github.com/pingcap/parser/test_driver"
 
-	"github.com/kyleconroy/sqlc/internal/metadata"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/metadata"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 func NewParser() *Parser {

--- a/internal/engine/dolphin/stdlib.go
+++ b/internal/engine/dolphin/stdlib.go
@@ -1,8 +1,8 @@
 package dolphin
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func defaultSchema(name string) *catalog.Schema {

--- a/internal/engine/dolphin/utils.go
+++ b/internal/engine/dolphin/utils.go
@@ -3,7 +3,7 @@ package dolphin
 import (
 	pcast "github.com/pingcap/parser/ast"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 type nodeSearch struct {

--- a/internal/engine/postgresql/catalog.go
+++ b/internal/engine/postgresql/catalog.go
@@ -1,6 +1,6 @@
 package postgresql
 
-import "github.com/kyleconroy/sqlc/internal/sql/catalog"
+import "github.com/egtann/sqlc/internal/sql/catalog"
 
 func NewCatalog() *catalog.Catalog {
 	c := catalog.New("public")

--- a/internal/engine/postgresql/catalog_test.go
+++ b/internal/engine/postgresql/catalog_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/internal/engine/postgresql/contrib/adminpack.go
+++ b/internal/engine/postgresql/contrib/adminpack.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Adminpack() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/amcheck.go
+++ b/internal/engine/postgresql/contrib/amcheck.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Amcheck() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/btree_gin.go
+++ b/internal/engine/postgresql/contrib/btree_gin.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func BtreeGin() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/btree_gist.go
+++ b/internal/engine/postgresql/contrib/btree_gist.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func BtreeGist() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/citext.go
+++ b/internal/engine/postgresql/contrib/citext.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Citext() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/cube.go
+++ b/internal/engine/postgresql/contrib/cube.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Cube() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/dblink.go
+++ b/internal/engine/postgresql/contrib/dblink.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Dblink() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/earthdistance.go
+++ b/internal/engine/postgresql/contrib/earthdistance.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Earthdistance() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/file_fdw.go
+++ b/internal/engine/postgresql/contrib/file_fdw.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func FileFdw() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/fuzzystrmatch.go
+++ b/internal/engine/postgresql/contrib/fuzzystrmatch.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Fuzzystrmatch() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/hstore.go
+++ b/internal/engine/postgresql/contrib/hstore.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Hstore() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/intagg.go
+++ b/internal/engine/postgresql/contrib/intagg.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Intagg() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/intarray.go
+++ b/internal/engine/postgresql/contrib/intarray.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Intarray() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/isn.go
+++ b/internal/engine/postgresql/contrib/isn.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Isn() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/lo.go
+++ b/internal/engine/postgresql/contrib/lo.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Lo() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/ltree.go
+++ b/internal/engine/postgresql/contrib/ltree.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Ltree() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/pageinspect.go
+++ b/internal/engine/postgresql/contrib/pageinspect.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Pageinspect() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/pg_buffercache.go
+++ b/internal/engine/postgresql/contrib/pg_buffercache.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func PgBuffercache() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/pg_freespacemap.go
+++ b/internal/engine/postgresql/contrib/pg_freespacemap.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func PgFreespacemap() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/pg_prewarm.go
+++ b/internal/engine/postgresql/contrib/pg_prewarm.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func PgPrewarm() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/pg_stat_statements.go
+++ b/internal/engine/postgresql/contrib/pg_stat_statements.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func PgStatStatements() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/pg_trgm.go
+++ b/internal/engine/postgresql/contrib/pg_trgm.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func PgTrgm() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/pg_visibility.go
+++ b/internal/engine/postgresql/contrib/pg_visibility.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func PgVisibility() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/pgcrypto.go
+++ b/internal/engine/postgresql/contrib/pgcrypto.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Pgcrypto() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/pgstattuple.go
+++ b/internal/engine/postgresql/contrib/pgstattuple.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Pgstattuple() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/postgres_fdw.go
+++ b/internal/engine/postgresql/contrib/postgres_fdw.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func PostgresFdw() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/seg.go
+++ b/internal/engine/postgresql/contrib/seg.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Seg() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/sslinfo.go
+++ b/internal/engine/postgresql/contrib/sslinfo.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Sslinfo() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/tablefunc.go
+++ b/internal/engine/postgresql/contrib/tablefunc.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Tablefunc() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/tcn.go
+++ b/internal/engine/postgresql/contrib/tcn.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Tcn() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/unaccent.go
+++ b/internal/engine/postgresql/contrib/unaccent.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Unaccent() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/uuid_ossp.go
+++ b/internal/engine/postgresql/contrib/uuid_ossp.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func UuidOssp() *catalog.Schema {

--- a/internal/engine/postgresql/contrib/xml2.go
+++ b/internal/engine/postgresql/contrib/xml2.go
@@ -3,8 +3,8 @@
 package contrib
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func Xml2() *catalog.Schema {

--- a/internal/engine/postgresql/convert.go
+++ b/internal/engine/postgresql/convert.go
@@ -8,7 +8,7 @@ import (
 
 	pg "github.com/pganalyze/pg_query_go/v2"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 func convertFuncParamMode(m pg.FunctionParameterMode) (ast.FuncParamMode, error) {

--- a/internal/engine/postgresql/extension.go
+++ b/internal/engine/postgresql/extension.go
@@ -3,8 +3,8 @@
 package postgresql
 
 import (
-	"github.com/kyleconroy/sqlc/internal/engine/postgresql/contrib"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/engine/postgresql/contrib"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func loadExtension(name string) *catalog.Schema {

--- a/internal/engine/postgresql/parse.go
+++ b/internal/engine/postgresql/parse.go
@@ -11,8 +11,8 @@ import (
 
 	nodes "github.com/pganalyze/pg_query_go/v2"
 
-	"github.com/kyleconroy/sqlc/internal/metadata"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/metadata"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 func stringSlice(list *nodes.List) []string {

--- a/internal/engine/postgresql/parse_windows.go
+++ b/internal/engine/postgresql/parse_windows.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"io"
 
-	"github.com/kyleconroy/sqlc/internal/metadata"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/metadata"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 func NewParser() *Parser {

--- a/internal/engine/postgresql/pg_catalog.go
+++ b/internal/engine/postgresql/pg_catalog.go
@@ -3,8 +3,8 @@
 package postgresql
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func genPGCatalog() *catalog.Schema {

--- a/internal/engine/postgresql/pg_temp.go
+++ b/internal/engine/postgresql/pg_temp.go
@@ -1,8 +1,8 @@
 package postgresql
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func pgTemp() *catalog.Schema {

--- a/internal/engine/postgresql/rewrite_test.go
+++ b/internal/engine/postgresql/rewrite_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/astutils"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/astutils"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/internal/engine/sqlite/catalog.go
+++ b/internal/engine/sqlite/catalog.go
@@ -1,6 +1,6 @@
 package sqlite
 
-import "github.com/kyleconroy/sqlc/internal/sql/catalog"
+import "github.com/egtann/sqlc/internal/sql/catalog"
 
 func NewCatalog() *catalog.Catalog {
 	c := catalog.New("main")

--- a/internal/engine/sqlite/catalog_test.go
+++ b/internal/engine/sqlite/catalog_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/internal/engine/sqlite/convert.go
+++ b/internal/engine/sqlite/convert.go
@@ -3,8 +3,8 @@ package sqlite
 import (
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 
-	"github.com/kyleconroy/sqlc/internal/engine/sqlite/parser"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/engine/sqlite/parser"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 type node interface {

--- a/internal/engine/sqlite/parse.go
+++ b/internal/engine/sqlite/parse.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 
-	"github.com/kyleconroy/sqlc/internal/engine/sqlite/parser"
-	"github.com/kyleconroy/sqlc/internal/metadata"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/engine/sqlite/parser"
+	"github.com/egtann/sqlc/internal/metadata"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 type errorListener struct {

--- a/internal/engine/sqlite/utils.go
+++ b/internal/engine/sqlite/utils.go
@@ -1,8 +1,8 @@
 package sqlite
 
 import (
-	"github.com/kyleconroy/sqlc/internal/engine/sqlite/parser"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/engine/sqlite/parser"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 type tableNamer interface {

--- a/internal/inflection/singular.go
+++ b/internal/inflection/singular.go
@@ -9,14 +9,14 @@ import (
 func Singular(name string) string {
 	// Manual fix for incorrect handling of "campus"
 	//
-	// https://github.com/kyleconroy/sqlc/issues/430
+	// https://github.com/egtann/sqlc/issues/430
 	// https://github.com/jinzhu/inflection/issues/13
 	if strings.ToLower(name) == "campus" {
 		return name
 	}
 	// Manual fix for incorrect handling of "meta"
 	//
-	// https://github.com/kyleconroy/sqlc/issues/1217
+	// https://github.com/egtann/sqlc/issues/1217
 	// https://github.com/jinzhu/inflection/issues/21
 	if strings.ToLower(name) == "meta" {
 		return name

--- a/internal/multierr/error.go
+++ b/internal/multierr/error.go
@@ -3,8 +3,8 @@ package multierr
 import (
 	"fmt"
 
-	"github.com/kyleconroy/sqlc/internal/source"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/source"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 type FileError struct {

--- a/internal/python/poet/builders.go
+++ b/internal/python/poet/builders.go
@@ -1,6 +1,6 @@
 package poet
 
-import "github.com/kyleconroy/sqlc/internal/python/ast"
+import "github.com/egtann/sqlc/internal/python/ast"
 
 func Alias(name string) *ast.Node {
 	return &ast.Node{

--- a/internal/python/poet/poet.go
+++ b/internal/python/poet/poet.go
@@ -1,7 +1,7 @@
 package poet
 
 import (
-	"github.com/kyleconroy/sqlc/internal/python/ast"
+	"github.com/egtann/sqlc/internal/python/ast"
 )
 
 type proto interface {

--- a/internal/python/printer/printer.go
+++ b/internal/python/printer/printer.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/python/ast"
+	"github.com/egtann/sqlc/internal/python/ast"
 )
 
 type writer struct {

--- a/internal/python/printer/printer_test.go
+++ b/internal/python/printer/printer_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/kyleconroy/sqlc/internal/python/ast"
+	"github.com/egtann/sqlc/internal/python/ast"
 )
 
 type testcase struct {

--- a/internal/sql/astutils/join.go
+++ b/internal/sql/astutils/join.go
@@ -3,7 +3,7 @@ package astutils
 import (
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 func Join(list *ast.List, sep string) string {

--- a/internal/sql/astutils/rewrite.go
+++ b/internal/sql/astutils/rewrite.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 // An ApplyFunc is invoked by Apply for each node n, even if n is nil,

--- a/internal/sql/astutils/search.go
+++ b/internal/sql/astutils/search.go
@@ -1,6 +1,6 @@
 package astutils
 
-import "github.com/kyleconroy/sqlc/internal/sql/ast"
+import "github.com/egtann/sqlc/internal/sql/ast"
 
 type nodeSearch struct {
 	list  *ast.List

--- a/internal/sql/astutils/walk.go
+++ b/internal/sql/astutils/walk.go
@@ -3,7 +3,7 @@ package astutils
 import (
 	"fmt"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 type Visitor interface {

--- a/internal/sql/catalog/catalog.go
+++ b/internal/sql/catalog/catalog.go
@@ -3,8 +3,8 @@ package catalog
 import (
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 func stringSlice(list *ast.List) []string {

--- a/internal/sql/catalog/comment_on.go
+++ b/internal/sql/catalog/comment_on.go
@@ -1,8 +1,8 @@
 package catalog
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 func (c *Catalog) commentOnColumn(stmt *ast.CommentOnColumnStmt) error {

--- a/internal/sql/catalog/extension.go
+++ b/internal/sql/catalog/extension.go
@@ -1,7 +1,7 @@
 package catalog
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 func (c *Catalog) createExtension(stmt *ast.CreateExtensionStmt) error {

--- a/internal/sql/catalog/func.go
+++ b/internal/sql/catalog/func.go
@@ -3,8 +3,8 @@ package catalog
 import (
 	"errors"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 func (c *Catalog) createFunction(stmt *ast.CreateFunctionStmt) error {

--- a/internal/sql/catalog/public.go
+++ b/internal/sql/catalog/public.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 func (c *Catalog) schemasToSearch(ns string) []string {

--- a/internal/sql/catalog/schema.go
+++ b/internal/sql/catalog/schema.go
@@ -3,8 +3,8 @@ package catalog
 import (
 	"fmt"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 func (c *Catalog) createSchema(stmt *ast.CreateSchemaStmt) error {

--- a/internal/sql/catalog/table.go
+++ b/internal/sql/catalog/table.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 func (c *Catalog) alterTable(stmt *ast.AlterTableStmt) error {

--- a/internal/sql/catalog/types.go
+++ b/internal/sql/catalog/types.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 func (c *Catalog) createEnum(stmt *ast.CreateEnumStmt) error {

--- a/internal/sql/catalog/view.go
+++ b/internal/sql/catalog/view.go
@@ -1,8 +1,8 @@
 package catalog
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 func (c *Catalog) createView(stmt *ast.ViewStmt, colGen columnGenerator) error {

--- a/internal/sql/info/info.go
+++ b/internal/sql/info/info.go
@@ -1,7 +1,7 @@
 package info
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 // Provide a read-only view into the catalog

--- a/internal/sql/named/is.go
+++ b/internal/sql/named/is.go
@@ -1,8 +1,8 @@
 package named
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/astutils"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/astutils"
 )
 
 func IsParamFunc(node ast.Node) bool {

--- a/internal/sql/rewrite/parameters.go
+++ b/internal/sql/rewrite/parameters.go
@@ -3,11 +3,11 @@ package rewrite
 import (
 	"fmt"
 
-	"github.com/kyleconroy/sqlc/internal/config"
-	"github.com/kyleconroy/sqlc/internal/source"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/astutils"
-	"github.com/kyleconroy/sqlc/internal/sql/named"
+	"github.com/egtann/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/source"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/astutils"
+	"github.com/egtann/sqlc/internal/sql/named"
 )
 
 // Given an AST node, return the string representation of names

--- a/internal/sql/sqlpath/read.go
+++ b/internal/sql/sqlpath/read.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/kyleconroy/sqlc/internal/migrations"
+	"github.com/egtann/sqlc/internal/migrations"
 )
 
 // Return a list of SQL files in the listed paths. Only includes files ending

--- a/internal/sql/validate/cmd.go
+++ b/internal/sql/validate/cmd.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kyleconroy/sqlc/internal/metadata"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/metadata"
+	"github.com/egtann/sqlc/internal/sql/ast"
 )
 
 func validateCopyfrom(n ast.Node) error {

--- a/internal/sql/validate/func_call.go
+++ b/internal/sql/validate/func_call.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kyleconroy/sqlc/internal/config"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/astutils"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/config"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/astutils"
+	"github.com/egtann/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 type funcCallVisitor struct {

--- a/internal/sql/validate/insert_stmt.go
+++ b/internal/sql/validate/insert_stmt.go
@@ -1,8 +1,8 @@
 package validate
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 func InsertStmt(stmt *ast.InsertStmt) error {

--- a/internal/sql/validate/param_ref.go
+++ b/internal/sql/validate/param_ref.go
@@ -3,9 +3,9 @@ package validate
 import (
 	"errors"
 	"fmt"
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/astutils"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/astutils"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 func ParamRef(n ast.Node) (map[int]bool, bool, error) {

--- a/internal/sql/validate/param_style.go
+++ b/internal/sql/validate/param_style.go
@@ -1,10 +1,10 @@
 package validate
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/astutils"
-	"github.com/kyleconroy/sqlc/internal/sql/named"
-	"github.com/kyleconroy/sqlc/internal/sql/sqlerr"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/astutils"
+	"github.com/egtann/sqlc/internal/sql/named"
+	"github.com/egtann/sqlc/internal/sql/sqlerr"
 )
 
 // A query can use one (and only one) of the following formats:

--- a/internal/sqltest/mysql.go
+++ b/internal/sqltest/mysql.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/kyleconroy/sqlc/internal/sql/sqlpath"
+	"github.com/egtann/sqlc/internal/sql/sqlpath"
 
 	_ "github.com/go-sql-driver/mysql"
 )

--- a/internal/sqltest/postgres.go
+++ b/internal/sqltest/postgres.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyleconroy/sqlc/internal/sql/sqlpath"
+	"github.com/egtann/sqlc/internal/sql/sqlpath"
 
 	_ "github.com/lib/pq"
 )

--- a/internal/tools/sqlc-pg-gen/main.go
+++ b/internal/tools/sqlc-pg-gen/main.go
@@ -13,8 +13,8 @@ import (
 
 	pgx "github.com/jackc/pgx/v4"
 
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 // https://stackoverflow.com/questions/25308765/postgresql-how-can-i-inspect-which-arguments-to-a-procedure-have-a-default-valu
@@ -63,8 +63,8 @@ const catalogTmpl = `
 package {{.Pkg}}
 
 import (
-	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/sql/ast"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func {{.Name}}() *catalog.Schema {
@@ -99,8 +99,8 @@ const loaderFuncTmpl = `
 package postgresql
 
 import (
-	"github.com/kyleconroy/sqlc/internal/engine/postgresql/contrib"
-	"github.com/kyleconroy/sqlc/internal/sql/catalog"
+	"github.com/egtann/sqlc/internal/engine/postgresql/contrib"
+	"github.com/egtann/sqlc/internal/sql/catalog"
 )
 
 func loadExtension(name string) *catalog.Schema {

--- a/internal/tracer/trace.go
+++ b/internal/tracer/trace.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"runtime/trace"
 
-	"github.com/kyleconroy/sqlc/internal/debug"
+	"github.com/egtann/sqlc/internal/debug"
 )
 
 func Start(base context.Context) (context.Context, func(), error) {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -8,7 +8,7 @@
 //     import (
 //         "os"
 //
-//         sqlc "github.com/kyleconroy/sqlc/pkg/cli"
+//         sqlc "github.com/egtann/sqlc/pkg/cli"
 //     )
 //
 //     func main() {
@@ -20,7 +20,7 @@ package cli
 import (
 	"os"
 
-	"github.com/kyleconroy/sqlc/internal/cmd"
+	"github.com/egtann/sqlc/internal/cmd"
 )
 
 // Run the sqlc CLI. It takes an array of command-line arguments

--- a/placeholder.go
+++ b/placeholder.go
@@ -1,6 +1,6 @@
 package sqlc
 
 // This is a dummy file that allows SQLC to be "installed" as a module and locked using
-// go.mod and then run using "go run github.com/kyleconroy/sqlc"
+// go.mod and then run using "go run github.com/egtann/sqlc"
 
 type Placeholder struct{}

--- a/scripts/build/main.go
+++ b/scripts/build/main.go
@@ -28,7 +28,7 @@ func main() {
 
 	fmt.Printf("::set-output name=version::%s\n", version)
 
-	x := "-X github.com/kyleconroy/sqlc/internal/cmd.version=" + version
+	x := "-X github.com/egtann/sqlc/internal/cmd.version=" + version
 	args := []string{
 		"build",
 		"-ldflags", x,

--- a/scripts/release.go
+++ b/scripts/release.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	if *docker {
-		x := "-extldflags \"-static\" -X github.com/kyleconroy/sqlc/internal/cmd.version=" + version
+		x := "-extldflags \"-static\" -X github.com/egtann/sqlc/internal/cmd.version=" + version
 		args := []string{
 			"build",
 			"-a",


### PR DESCRIPTION
This fixes a bug for go_type overrides which have versions. Previously for something like this:

```
go_type: a/b/v2.MyType
```

sqlc would generate:

```
import "a/b/v2"

type MyStruct struct {
    A v2.MyType
}
```

Which is invalid and doesn't compile. This leaves the import statement alone but changes the outputted type name to `b.MyType`.