### PR TITLE
docs: Specify which db_type should be used in overrides

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -92,7 +92,7 @@ overrides:
 Each override document has the following keys:
 
 - `db_type`:
-  - The PostgreSQL or MySQL type to override. Find the full list of supported types in [postgresql_type.go](https://github.com/kyleconroy/sqlc/blob/main/internal/codegen/golang/postgresql_type.go#L12) or [mysql_type.go](https://github.com/kyleconroy/sqlc/blob/main/internal/codegen/golang/mysql_type.go#L12).
+  - The PostgreSQL or MySQL type to override. Find the full list of supported types in [postgresql_type.go](https://github.com/kyleconroy/sqlc/blob/main/internal/codegen/golang/postgresql_type.go#L12) or [mysql_type.go](https://github.com/kyleconroy/sqlc/blob/main/internal/codegen/golang/mysql_type.go#L12). Note that for Postgres you must use the pg_catalog prefixed names where available.
 - `go_type`:
   - A fully qualified name to a Go type to use in the generated code.
 - `nullable`:


### PR DESCRIPTION
The docs link to PG types to be used in overrides, but those include unusable options. For instance, `db_type: smallint` doesn't work, whereas `db_type: pg_catalog.int2` does.

This adds a note to tell the reader to use the `pg_catalog` types when available.