### PR TITLE
fix(config): Fix type name for versioned type overrides

### DIFF
--- a/internal/config/go_type.go
+++ b/internal/config/go_type.go
@@ -149,6 +149,21 @@ func (gt GoType) Parse() (*ParsedGoType, error) {
 			typename = typename[:len(typename)-len("-go")]
 		}
 		o.ImportPath = input[:lastDot]
+
+		// set versioned overrides to reference the underlying package
+		// name. for example, the type for a/b/v2.C is b.C, not v2.C.
+		parts := strings.Split(input, "/")
+		if len(parts) >= 2 {
+			name := parts[len(parts)-1]
+			lastPeriod := strings.LastIndex(name, ".")
+			if lastPeriod > 0 {
+				version, name := name[:lastPeriod], name[lastPeriod:]
+				if versionNumber.MatchString(version) {
+					pkgName := parts[len(parts)-2]
+					typename = pkgName + name
+				}
+			}
+		}
 	}
 	o.TypeName = typename
 	isPointer := input[0] == '*'


### PR DESCRIPTION
This fixes a bug for go_type overrides which have versions. Previously for something like this:

```
go_type: a/b/v2.MyType
```

sqlc would generate:

```
import "a/b/v2"

type MyStruct struct {
    A v2.MyType
}
```

Which is invalid and doesn't compile. This leaves the import statement alone but changes the outputted type name to `b.MyType`.