### PR TITLE
chore: fix extra newline in comments for copyfrom

### DIFF
--- a/internal/codegen/golang/templates/pgx/copyfromCopy.tmpl
+++ b/internal/codegen/golang/templates/pgx/copyfromCopy.tmpl
@@ -37,10 +37,10 @@ func (r iteratorFor{{.MethodName}}) Err() error {
 
 {{range .Comments}}//{{.}}
 {{end -}}
-{{- if $.EmitMethodsWithDBArgument}}
+{{- if $.EmitMethodsWithDBArgument -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.SlicePair}}) (int64, error) {
 	return db.CopyFrom(ctx, {{.TableIdentifier}}, {{.Arg.ColumnNames}}, &iteratorFor{{.MethodName}}{rows: {{.Arg.Name}}})
-{{- else}}
+{{- else -}}
 func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.SlicePair}}) (int64, error) {
 	return q.db.CopyFrom(ctx, {{.TableIdentifier}}, {{.Arg.ColumnNames}}, &iteratorFor{{.MethodName}}{rows: {{.Arg.Name}}})
 {{- end}}

--- a/internal/endtoend/testdata/copyfrom/postgresql/pgx/go/copyfrom.go
+++ b/internal/endtoend/testdata/copyfrom/postgresql/pgx/go/copyfrom.go
@@ -36,6 +36,7 @@ func (r iteratorForInsertSingleValue) Err() error {
 	return nil
 }
 
+// InsertSingleValue inserts a single value using copy.
 func (q *Queries) InsertSingleValue(ctx context.Context, a []sql.NullString) (int64, error) {
 	return q.db.CopyFrom(ctx, []string{"myschema", "foo"}, []string{"a"}, &iteratorForInsertSingleValue{rows: a})
 }
@@ -69,6 +70,7 @@ func (r iteratorForInsertValues) Err() error {
 	return nil
 }
 
+// InsertValues inserts multiple values using copy.
 func (q *Queries) InsertValues(ctx context.Context, arg []InsertValuesParams) (int64, error) {
 	return q.db.CopyFrom(ctx, []string{"myschema", "foo"}, []string{"a", "b"}, &iteratorForInsertValues{rows: arg})
 }

--- a/internal/endtoend/testdata/copyfrom/postgresql/pgx/query.sql
+++ b/internal/endtoend/testdata/copyfrom/postgresql/pgx/query.sql
@@ -2,7 +2,9 @@ CREATE SCHEMA myschema;
 CREATE TABLE myschema.foo (a text, b integer);
 
 -- name: InsertValues :copyfrom
+-- InsertValues inserts multiple values using copy.
 INSERT INTO myschema.foo (a, b) VALUES ($1, $2);
 
 -- name: InsertSingleValue :copyfrom
+-- InsertSingleValue inserts a single value using copy.
 INSERT INTO myschema.foo (a) VALUES ($1);


### PR DESCRIPTION
The changes in #1417 fixed newline comments in all queries except for copyfrom.
This PR adds the same changes for copyfrom so generated comments do not have
a new line before the function.

Signed-off-by: Alex Dulin <alex@morningconsult.com>