### PR TITLE
feat(codegen): Insert comments in interfaces

### DIFF
--- a/internal/codegen/golang/templates/pgx/interfaceCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/interfaceCode.tmpl
@@ -3,38 +3,66 @@
     {{- $dbtxParam := .EmitMethodsWithDBArgument -}}
     {{- range .GoQueries}}
         {{- if and (eq .Cmd ":one") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) ({{.Ret.DefineType}}, error)
         {{- else if eq .Cmd ":one" }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ({{.Ret.DefineType}}, error)
         {{- end}}
         {{- if and (eq .Cmd ":many") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error)
         {{- else if eq .Cmd ":many" }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error)
         {{- end}}
         {{- if and (eq .Cmd ":exec") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) error
         {{- else if eq .Cmd ":exec" }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) error
         {{- end}}
         {{- if and (eq .Cmd ":execrows") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) (int64, error)
         {{- else if eq .Cmd ":execrows" }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) (int64, error)
         {{- end}}
         {{- if and (eq .Cmd ":execresult") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) (pgconn.CommandTag, error)
         {{- else if eq .Cmd ":execresult" }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) (pgconn.CommandTag, error)
         {{- end}}
         {{- if and (eq .Cmd ":copyfrom") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.SlicePair}}) (int64, error)
         {{- else if eq .Cmd ":copyfrom" }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, {{.Arg.SlicePair}}) (int64, error)
         {{- end}}
         {{- if and (or (eq .Cmd ":batchexec") (eq .Cmd ":batchmany") (eq .Cmd ":batchone")) ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.SlicePair}}) *{{.MethodName}}BatchResults
         {{- else if or (eq .Cmd ":batchexec") (eq .Cmd ":batchmany") (eq .Cmd ":batchone") }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, {{.Arg.SlicePair}}) *{{.MethodName}}BatchResults
         {{- end}}
 

--- a/internal/codegen/golang/templates/stdlib/interfaceCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/interfaceCode.tmpl
@@ -3,28 +3,48 @@
     {{- $dbtxParam := .EmitMethodsWithDBArgument -}}
     {{- range .GoQueries}}
         {{- if and (eq .Cmd ":one") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) ({{.Ret.DefineType}}, error)
         {{- else if eq .Cmd ":one"}}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ({{.Ret.DefineType}}, error)
         {{- end}}
         {{- if and (eq .Cmd ":many") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error)
         {{- else if eq .Cmd ":many"}}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ([]{{.Ret.DefineType}}, error)
         {{- end}}
         {{- if and (eq .Cmd ":exec") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) error
         {{- else if eq .Cmd ":exec"}}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) error
         {{- end}}
         {{- if and (eq .Cmd ":execrows") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) (int64, error)
         {{- else if eq .Cmd ":execrows"}}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) (int64, error)
         {{- end}}
         {{- if and (eq .Cmd ":execresult") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, db DBTX, {{.Arg.Pair}}) (sql.Result, error)
         {{- else if eq .Cmd ":execresult"}}
+            {{range .Comments}}//{{.}}
+            {{end -}}
             {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) (sql.Result, error)
         {{- end}}
     {{- end}}


### PR DESCRIPTION
Related to #1400 I've added the comments into the interface generation the same way it's done for the auto-generated methods.

I've compiled sqlc using `make sqlc-dev`. And ran it on this repo https://github.com/sbres/sqlc_example.

The generated output went from:
```
type Querier interface {
	CheckUserExist(ctx context.Context, email string) (bool, error)
	CreateNewUser(ctx context.Context, arg CreateNewUserParams) (int32, error)
}
```

To 

```
type Querier interface {
	// CheckUserExist will check if the user exist, retuns true if the exists
	CheckUserExist(ctx context.Context, email string) (bool, error)
	// CreateNewUser will create a new user
	CreateNewUser(ctx context.Context, arg CreateNewUserParams) (int32, error)
}
```

I was not able to run the full suite of tests.