### PR TITLE
Fix/nullable joins

### DIFF
--- a/internal/compiler/compat.go
+++ b/internal/compiler/compat.go
@@ -16,10 +16,6 @@ func stringSlice(list *ast.List) []string {
 			items = append(items, n.Str)
 			continue
 		}
-		if n, ok := item.(*ast.String); ok {
-			items = append(items, n.Str)
-			continue
-		}
 	}
 	return items
 }

--- a/internal/compiler/output_columns.go
+++ b/internal/compiler/output_columns.go
@@ -182,14 +182,15 @@ func outputColumns(qc *QueryCatalog, node ast.Node) ([]*Column, error) {
 							cname = *res.Name
 						}
 						cols = append(cols, &Column{
-							Name:     cname,
-							Type:     c.Type,
-							Scope:    scope,
-							Table:    c.Table,
-							DataType: c.DataType,
-							NotNull:  c.NotNull,
-							IsArray:  c.IsArray,
-							Length:   c.Length,
+							Name:       cname,
+							Type:       c.Type,
+							Scope:      scope,
+							Table:      c.Table,
+							DataType:   c.DataType,
+							NotNull:    c.NotNull,
+							IsArray:    c.IsArray,
+							Length:     c.Length,
+							TableAlias: t.Rel.Name,
 						})
 					}
 				}

--- a/internal/endtoend/testdata/join_left/mysql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left/mysql/go/query.sql.go
@@ -83,3 +83,97 @@ func (q *Queries) GetMayorsOptional(ctx context.Context) ([]GetMayorsOptionalRow
 	}
 	return items, nil
 }
+
+const getMayorsOptionalWildcard = `-- name: GetMayorsOptionalWildcard :many
+SELECT
+    user_id, users.city_id, cities.city_id, cities.mayor_id, mayors.mayor_id, full_name
+FROM users
+LEFT JOIN cities USING (city_id)
+LEFT JOIN mayors USING (mayor_id)
+`
+
+type GetMayorsOptionalWildcardRow struct {
+	UserID    int32
+	CityID    sql.NullInt32
+	CityID_2  sql.NullInt32
+	MayorID   sql.NullInt32
+	MayorID_2 sql.NullInt32
+	FullName  sql.NullString
+}
+
+func (q *Queries) GetMayorsOptionalWildcard(ctx context.Context) ([]GetMayorsOptionalWildcardRow, error) {
+	rows, err := q.db.QueryContext(ctx, getMayorsOptionalWildcard)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetMayorsOptionalWildcardRow
+	for rows.Next() {
+		var i GetMayorsOptionalWildcardRow
+		if err := rows.Scan(
+			&i.UserID,
+			&i.CityID,
+			&i.CityID_2,
+			&i.MayorID,
+			&i.MayorID_2,
+			&i.FullName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getMayorsWildcard = `-- name: GetMayorsWildcard :many
+SELECT
+    user_id, users.city_id, cities.city_id, cities.mayor_id, mayors.mayor_id, full_name
+FROM users
+LEFT JOIN cities USING (city_id)
+INNER JOIN mayors USING (mayor_id)
+`
+
+type GetMayorsWildcardRow struct {
+	UserID    int32
+	CityID    sql.NullInt32
+	CityID_2  int32
+	MayorID   int32
+	MayorID_2 int32
+	FullName  string
+}
+
+func (q *Queries) GetMayorsWildcard(ctx context.Context) ([]GetMayorsWildcardRow, error) {
+	rows, err := q.db.QueryContext(ctx, getMayorsWildcard)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetMayorsWildcardRow
+	for rows.Next() {
+		var i GetMayorsWildcardRow
+		if err := rows.Scan(
+			&i.UserID,
+			&i.CityID,
+			&i.CityID_2,
+			&i.MayorID,
+			&i.MayorID_2,
+			&i.FullName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/internal/endtoend/testdata/join_left/mysql/query.sql
+++ b/internal/endtoend/testdata/join_left/mysql/query.sql
@@ -20,11 +20,25 @@ FROM users
 LEFT JOIN cities USING (city_id)
 INNER JOIN mayors USING (mayor_id);
 
+-- name: GetMayorsWildcard :many
+SELECT
+    *
+FROM users
+LEFT JOIN cities USING (city_id)
+INNER JOIN mayors USING (mayor_id);
+
 -- name: GetMayorsOptional :many
 SELECT
     user_id,
     cities.city_id,
     mayors.full_name
+FROM users
+LEFT JOIN cities USING (city_id)
+LEFT JOIN mayors USING (mayor_id);
+
+-- name: GetMayorsOptionalWildcard :many
+SELECT
+    *
 FROM users
 LEFT JOIN cities USING (city_id)
 LEFT JOIN mayors USING (mayor_id);

--- a/internal/endtoend/testdata/join_left/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left/postgresql/go/query.sql.go
@@ -48,6 +48,7 @@ func (q *Queries) GetMayors(ctx context.Context) ([]GetMayorsRow, error) {
 const getMayorsOptional = `-- name: GetMayorsOptional :many
 SELECT
     user_id,
+    cities.city_id,
     mayors.full_name
 FROM users
 LEFT JOIN cities USING (city_id)
@@ -56,6 +57,7 @@ LEFT JOIN mayors USING (mayor_id)
 
 type GetMayorsOptionalRow struct {
 	UserID   int32
+	CityID   sql.NullInt32
 	FullName sql.NullString
 }
 
@@ -68,7 +70,101 @@ func (q *Queries) GetMayorsOptional(ctx context.Context) ([]GetMayorsOptionalRow
 	var items []GetMayorsOptionalRow
 	for rows.Next() {
 		var i GetMayorsOptionalRow
-		if err := rows.Scan(&i.UserID, &i.FullName); err != nil {
+		if err := rows.Scan(&i.UserID, &i.CityID, &i.FullName); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getMayorsOptionalWildcard = `-- name: GetMayorsOptionalWildcard :many
+SELECT
+    user_id, users.city_id, cities.city_id, cities.mayor_id, mayors.mayor_id, full_name
+FROM users
+LEFT JOIN cities USING (city_id)
+LEFT JOIN mayors USING (mayor_id)
+`
+
+type GetMayorsOptionalWildcardRow struct {
+	UserID    int32
+	CityID    sql.NullInt32
+	CityID_2  sql.NullInt32
+	MayorID   sql.NullInt32
+	MayorID_2 sql.NullInt32
+	FullName  sql.NullString
+}
+
+func (q *Queries) GetMayorsOptionalWildcard(ctx context.Context) ([]GetMayorsOptionalWildcardRow, error) {
+	rows, err := q.db.QueryContext(ctx, getMayorsOptionalWildcard)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetMayorsOptionalWildcardRow
+	for rows.Next() {
+		var i GetMayorsOptionalWildcardRow
+		if err := rows.Scan(
+			&i.UserID,
+			&i.CityID,
+			&i.CityID_2,
+			&i.MayorID,
+			&i.MayorID_2,
+			&i.FullName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getMayorsWildcard = `-- name: GetMayorsWildcard :many
+SELECT
+    user_id, users.city_id, cities.city_id, cities.mayor_id, mayors.mayor_id, full_name
+FROM users
+LEFT JOIN cities USING (city_id)
+INNER JOIN mayors USING (mayor_id)
+`
+
+type GetMayorsWildcardRow struct {
+	UserID    int32
+	CityID    sql.NullInt32
+	CityID_2  int32
+	MayorID   int32
+	MayorID_2 int32
+	FullName  string
+}
+
+func (q *Queries) GetMayorsWildcard(ctx context.Context) ([]GetMayorsWildcardRow, error) {
+	rows, err := q.db.QueryContext(ctx, getMayorsWildcard)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetMayorsWildcardRow
+	for rows.Next() {
+		var i GetMayorsWildcardRow
+		if err := rows.Scan(
+			&i.UserID,
+			&i.CityID,
+			&i.CityID_2,
+			&i.MayorID,
+			&i.MayorID_2,
+			&i.FullName,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/endtoend/testdata/join_left/postgresql/query.sql
+++ b/internal/endtoend/testdata/join_left/postgresql/query.sql
@@ -1,4 +1,4 @@
---- https://github.com/kyleconroy/sqlc/issues/604
+-- https://github.com/kyleconroy/sqlc/issues/604
 CREATE TABLE users (
   user_id    INT PRIMARY KEY,
   city_id    INT -- nullable
@@ -20,10 +20,25 @@ FROM users
 LEFT JOIN cities USING (city_id)
 INNER JOIN mayors USING (mayor_id);
 
+-- name: GetMayorsWildcard :many
+SELECT
+    *
+FROM users
+LEFT JOIN cities USING (city_id)
+INNER JOIN mayors USING (mayor_id);
+
 -- name: GetMayorsOptional :many
 SELECT
     user_id,
+    cities.city_id,
     mayors.full_name
+FROM users
+LEFT JOIN cities USING (city_id)
+LEFT JOIN mayors USING (mayor_id);
+
+-- name: GetMayorsOptionalWildcard :many
+SELECT
+    *
 FROM users
 LEFT JOIN cities USING (city_id)
 LEFT JOIN mayors USING (mayor_id);

--- a/internal/endtoend/testdata/join_left_same_table/mysql/query.sql
+++ b/internal/endtoend/testdata/join_left_same_table/mysql/query.sql
@@ -11,5 +11,9 @@ SELECT  a.id,
         p.id as alias_id,
         p.name as alias_name
 FROM    authors a
-        LEFT JOIN authors p
-            ON (authors.parent_id = p.id);
+        LEFT JOIN authors p USING (parent_id);
+
+-- name: AllAuthorsWildcard :many
+SELECT  *
+FROM    authors a
+        LEFT JOIN authors p USING (parent_id);

--- a/internal/endtoend/testdata/join_left_same_table/postgres/go/query.sql.go
+++ b/internal/endtoend/testdata/join_left_same_table/postgres/go/query.sql.go
@@ -51,3 +51,48 @@ func (q *Queries) AllAuthors(ctx context.Context) ([]AllAuthorsRow, error) {
 	}
 	return items, nil
 }
+
+const allAuthorsWildcard = `-- name: AllAuthorsWildcard :many
+SELECT  a.id, a.name, a.parent_id, p.id, p.name, p.parent_id
+FROM    authors a
+        LEFT JOIN authors p USING (parent_id)
+`
+
+type AllAuthorsWildcardRow struct {
+	ID         int32
+	Name       string
+	ParentID   sql.NullInt32
+	ID_2       sql.NullInt32
+	Name_2     sql.NullString
+	ParentID_2 sql.NullInt32
+}
+
+func (q *Queries) AllAuthorsWildcard(ctx context.Context) ([]AllAuthorsWildcardRow, error) {
+	rows, err := q.db.QueryContext(ctx, allAuthorsWildcard)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []AllAuthorsWildcardRow
+	for rows.Next() {
+		var i AllAuthorsWildcardRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.ParentID,
+			&i.ID_2,
+			&i.Name_2,
+			&i.ParentID_2,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/internal/endtoend/testdata/join_left_same_table/postgres/query.sql
+++ b/internal/endtoend/testdata/join_left_same_table/postgres/query.sql
@@ -11,3 +11,8 @@ SELECT  a.id,
         p.name as alias_name
 FROM    authors a
         LEFT JOIN authors p USING (parent_id);
+
+-- name: AllAuthorsWildcard :many
+SELECT  *
+FROM    authors a
+        LEFT JOIN authors p USING (parent_id);


### PR DESCRIPTION
This PR should fix #1334 and #1349

Columns with star reference were lacking the TableAlias attribute. Now it's set to t.Rel.Name like in expand()

- [x] TODO Create tests with star reference 