### PR TITLE
feat(python): Graduate Python support to beta

### DIFF
--- a/docs/reference/language-support.rst
+++ b/docs/reference/language-support.rst
@@ -6,7 +6,7 @@ Language  MySQL         PostgreSQL
 ========  ============  ============
 Go        Stable        Stable
 Kotlin    Beta          Beta
-Python    Experimental  Experimental
+Python    Beta          Beta
 ========  ============  ============
 
 Future Language Support

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -133,10 +133,6 @@ func Generate(ctx context.Context, e Env, dir, filename string, stderr io.Writer
 			})
 		}
 		if sql.Gen.Python != nil {
-			if !e.ExperimentalFeatures {
-				fmt.Fprintf(stderr, "error parsing %s: unknown target langauge \"python\"\n", base)
-				return nil, fmt.Errorf("unknown target language \"python\"")
-			}
 			pairs = append(pairs, outPair{
 				SQL: sql,
 				Gen: config.SQLGen{Python: sql.Gen.Python},


### PR DESCRIPTION
The use of the `--experimental` flag is no longer required