### PR TITLE
Golang SQL: Move defer rows.Close() before error check

### DIFF
--- a/internal/codegen/golang/templates/pgx/batchCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/batchCode.tmpl
@@ -63,10 +63,11 @@ func (b *{{.MethodName}}BatchResults) Exec(f func(int, error)) {
 func (b *{{.MethodName}}BatchResults) Query(f func(int, []{{.Ret.DefineType}}, error)) {
     for {
 		rows, err := b.br.Query()
+        defer rows.Close()
         if err != nil && (err.Error() == "no result" || err.Error() == "batch already closed") {
 			break
 		}
-        defer rows.Close()
+
         {{- if $.EmitEmptySlices}}
         items := []{{.Ret.DefineType}}{}
         {{else}}

--- a/internal/codegen/golang/templates/pgx/batchCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/batchCode.tmpl
@@ -67,7 +67,6 @@ func (b *{{.MethodName}}BatchResults) Query(f func(int, []{{.Ret.DefineType}}, e
         if err != nil && (err.Error() == "no result" || err.Error() == "batch already closed") {
 			break
 		}
-
         {{- if $.EmitEmptySlices}}
         items := []{{.Ret.DefineType}}{}
         {{else}}

--- a/internal/codegen/golang/templates/stdlib/queryCode.tmpl
+++ b/internal/codegen/golang/templates/stdlib/queryCode.tmpl
@@ -57,10 +57,10 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}}) ([]{{.Ret.
     {{- else}}
     rows, err := q.db.QueryContext(ctx, {{.ConstantName}}, {{.Arg.Params}})
     {{- end}}
+    defer rows.Close()
     if err != nil {
         return nil, err
     }
-    defer rows.Close()
     {{- if $.EmitEmptySlices}}
     items := []{{.Ret.DefineType}}{}
     {{else}}


### PR DESCRIPTION
To be safe, move the deferred call to rows.Close before the error check, to handle the case where a connection is left open even though errors were encountered by the sql driver