### PR TITLE
Prepend an underscore to a StructName if it starts with a digit.

### DIFF
--- a/internal/codegen/golang/struct.go
+++ b/internal/codegen/golang/struct.go
@@ -2,6 +2,8 @@ package golang
 
 import (
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/kyleconroy/sqlc/internal/plugin"
 )
@@ -25,5 +27,12 @@ func StructName(name string, settings *plugin.Settings) string {
 			out += strings.Title(p)
 		}
 	}
-	return out
+
+	// If a name has a digit as its first char, prepand an underscore to make it a valid Go name.
+	r, _ := utf8.DecodeRuneInString(out)
+	if unicode.IsDigit(r) {
+		return "_" + out
+	} else {
+		return out
+	}
 }


### PR DESCRIPTION
This situation can occur if the column name starts with an underscore prefix and the following character is a digit:

```
create table thing (
 _1099Form text
);
```

currently the generator would balk because  the generated struct would be :

```
type Thing struct {
  1099Form string
}
```

and `1099Form` is not a valid name (it starts with a digit).

with this change we would instead get instead:

```
type Thing struct {
  _1099Form string
}
```

