### PR TITLE
feat: run sqlc with docker on windows cmd

### DIFF
--- a/docs/overview/install.md
+++ b/docs/overview/install.md
@@ -40,6 +40,12 @@ Run `sqlc` using `docker run`:
 docker run --rm -v $(pwd):/src -w /src kjconroy/sqlc generate
 ```
 
+Run `sqlc` using `docker run` in the Command Prompt on Windows (`cmd`):
+
+```
+docker run --rm -v "%cd%:/src" -w /src kjconroy/sqlc generate
+```
+
 ## Downloads
 
 Get pre-built binaries for *v1.13.0*:


### PR DESCRIPTION
For running sqlc with docker on windows cmd, instead of specifying the root folder with `pwd` , it should be specified with `cd` on documentation.