### PR TITLE
feat: 'destination' flag to specify directory of gen files during gen

### DIFF
--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -104,7 +104,7 @@ func readConfig(stderr io.Writer, dir, filename string) (string, *config.Config,
 	return configPath, &conf, nil
 }
 
-func Generate(ctx context.Context, e Env, dir, filename string, stderr io.Writer) (map[string]string, error) {
+func Generate(ctx context.Context, e Env, dir, filename, dstDir string, stderr io.Writer) (map[string]string, error) {
 	configPath, conf, err := readConfig(stderr, dir, filename)
 	if err != nil {
 		return nil, err
@@ -236,7 +236,7 @@ func Generate(ctx context.Context, e Env, dir, filename string, stderr io.Writer
 			files[file.Name] = string(file.Contents)
 		}
 		for n, source := range files {
-			filename := filepath.Join(dir, out, n)
+			filename := filepath.Join(dstDir, out, n)
 			output[filename] = source
 		}
 		if packageRegion != nil {


### PR DESCRIPTION
Inspired by personal need for use of sqlc project. 

Adds a `destination` flag to the generate command to add the option of separating the locations of the `sqlc.yaml` file and the generated output files. Allows for more flexibility in project by allowing me to specify a `--destination project/pkg/sqldb/generated` to transform the project hierarchy from:
```
project
|-- client
└-- sqldb
    |-- migrations
    |-- models
    |-- queries
    |-- events.sql.go
    |-- orders.sql.go
    └-- sqlc.yaml
```

into:
```
project
|-- client
└-- sqldb
    |-- generated
    |   |-- events.sql.go
    |   └-- orders.sql.go
    |-- migrations
    |-- models
    |-- queries
    └-- sqlc.yaml
```
