### PR TITLE
feat: Nullable enums

### DIFF
--- a/examples/batch/postgresql/models.go
+++ b/examples/batch/postgresql/models.go
@@ -5,6 +5,7 @@
 package batch
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"time"
 )
@@ -26,6 +27,36 @@ func (e *BookType) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for BookType: %T", src)
 	}
 	return nil
+}
+
+// NullBookType is the nullable version of BookType.
+type NullBookType struct {
+	BookType BookType
+	Valid    bool
+}
+
+func (e *NullBookType) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.BookType = BookType(s)
+	case string:
+		e.BookType = BookType(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullBookType: %T", src)
+	}
+	e.Valid = len(e.BookType) > 0
+	return nil
+}
+
+func (e *NullBookType) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.BookType), nil
 }
 
 type Author struct {

--- a/examples/booktest/mysql/models.go
+++ b/examples/booktest/mysql/models.go
@@ -5,6 +5,7 @@
 package booktest
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"time"
 )
@@ -26,6 +27,36 @@ func (e *BooksBookType) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for BooksBookType: %T", src)
 	}
 	return nil
+}
+
+// NullBooksBookType is the nullable version of BooksBookType.
+type NullBooksBookType struct {
+	BooksBookType BooksBookType
+	Valid         bool
+}
+
+func (e *NullBooksBookType) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.BooksBookType = BooksBookType(s)
+	case string:
+		e.BooksBookType = BooksBookType(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullBooksBookType: %T", src)
+	}
+	e.Valid = len(e.BooksBookType) > 0
+	return nil
+}
+
+func (e *NullBooksBookType) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.BooksBookType), nil
 }
 
 type Author struct {

--- a/examples/booktest/postgresql/models.go
+++ b/examples/booktest/postgresql/models.go
@@ -5,6 +5,7 @@
 package booktest
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"time"
 )
@@ -26,6 +27,36 @@ func (e *BookType) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for BookType: %T", src)
 	}
 	return nil
+}
+
+// NullBookType is the nullable version of BookType.
+type NullBookType struct {
+	BookType BookType
+	Valid    bool
+}
+
+func (e *NullBookType) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.BookType = BookType(s)
+	case string:
+		e.BookType = BookType(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullBookType: %T", src)
+	}
+	e.Valid = len(e.BookType) > 0
+	return nil
+}
+
+func (e *NullBookType) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.BookType), nil
 }
 
 type Author struct {

--- a/examples/ondeck/mysql/models.go
+++ b/examples/ondeck/mysql/models.go
@@ -6,6 +6,7 @@ package ondeck
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"time"
 )
@@ -27,6 +28,36 @@ func (e *VenuesStatus) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for VenuesStatus: %T", src)
 	}
 	return nil
+}
+
+// NullVenuesStatus is the nullable version of VenuesStatus.
+type NullVenuesStatus struct {
+	VenuesStatus VenuesStatus
+	Valid        bool
+}
+
+func (e *NullVenuesStatus) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.VenuesStatus = VenuesStatus(s)
+	case string:
+		e.VenuesStatus = VenuesStatus(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullVenuesStatus: %T", src)
+	}
+	e.Valid = len(e.VenuesStatus) > 0
+	return nil
+}
+
+func (e *NullVenuesStatus) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.VenuesStatus), nil
 }
 
 type City struct {

--- a/examples/ondeck/postgresql/models.go
+++ b/examples/ondeck/postgresql/models.go
@@ -6,6 +6,7 @@ package ondeck
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"time"
 )
@@ -28,6 +29,36 @@ func (e *Status) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for Status: %T", src)
 	}
 	return nil
+}
+
+// NullStatus is the nullable version of Status.
+type NullStatus struct {
+	Status Status
+	Valid  bool
+}
+
+func (e *NullStatus) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.Status = Status(s)
+	case string:
+		e.Status = Status(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullStatus: %T", src)
+	}
+	e.Valid = len(e.Status) > 0
+	return nil
+}
+
+func (e *NullStatus) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.Status), nil
 }
 
 type City struct {

--- a/internal/codegen/golang/imports.go
+++ b/internal/codegen/golang/imports.go
@@ -264,6 +264,7 @@ func (i *importer) modelImports() fileImports {
 
 	if len(i.Enums) > 0 {
 		std["fmt"] = struct{}{}
+		std["database/sql/driver"] = struct{}{}
 	}
 
 	return sortedImports(std, pkg)

--- a/internal/codegen/golang/postgresql_type.go
+++ b/internal/codegen/golang/postgresql_type.go
@@ -279,11 +279,15 @@ func postgresType(req *plugin.CodeGenRequest, col *plugin.Column) string {
 			}
 
 			for _, enum := range schema.Enums {
+				nullPrefix := ""
+				if !notNull {
+					nullPrefix = "Null"
+				}
 				if rel.Name == enum.Name && rel.Schema == schema.Name {
 					if schema.Name == req.Catalog.DefaultSchema {
-						return StructName(enum.Name, req.Settings)
+						return nullPrefix + StructName(enum.Name, req.Settings)
 					}
-					return StructName(schema.Name+"_"+enum.Name, req.Settings)
+					return nullPrefix + StructName(schema.Name+"_"+enum.Name, req.Settings)
 				}
 			}
 

--- a/internal/codegen/golang/templates/template.tmpl
+++ b/internal/codegen/golang/templates/template.tmpl
@@ -86,6 +86,36 @@ func (e *{{.Name}}) Scan(src interface{}) error {
 	}
 	return nil
 }
+
+// Null{{.Name}} is the nullable version of {{.Name}}.
+type Null{{.Name}} struct {
+	{{.Name}} {{.Name}}
+	Valid bool
+}
+
+func (e *Null{{.Name}}) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.{{.Name}} = {{.Name}}(s)
+	case string:
+		e.{{.Name}} = {{.Name}}(s)
+	default:
+		return fmt.Errorf("unsupported scan type for Null{{.Name}}: %T", src)
+	}
+	e.Valid = len(e.{{.Name}}) > 0
+	return nil
+}
+
+func (e *Null{{.Name}}) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.{{.Name}}), nil
+}
 {{end}}
 
 {{range .Structs}}

--- a/internal/endtoend/testdata/comment_on/postgresql/pgx/go/models.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/pgx/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -27,6 +28,36 @@ func (e *FooMood) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for FooMood: %T", src)
 	}
 	return nil
+}
+
+// NullFooMood is the nullable version of FooMood.
+type NullFooMood struct {
+	FooMood FooMood
+	Valid   bool
+}
+
+func (e *NullFooMood) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.FooMood = FooMood(s)
+	case string:
+		e.FooMood = FooMood(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullFooMood: %T", src)
+	}
+	e.Valid = len(e.FooMood) > 0
+	return nil
+}
+
+func (e *NullFooMood) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.FooMood), nil
 }
 
 // this is the bar table

--- a/internal/endtoend/testdata/comment_on/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/comment_on/postgresql/stdlib/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -27,6 +28,36 @@ func (e *FooMood) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for FooMood: %T", src)
 	}
 	return nil
+}
+
+// NullFooMood is the nullable version of FooMood.
+type NullFooMood struct {
+	FooMood FooMood
+	Valid   bool
+}
+
+func (e *NullFooMood) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.FooMood = FooMood(s)
+	case string:
+		e.FooMood = FooMood(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullFooMood: %T", src)
+	}
+	e.Valid = len(e.FooMood) > 0
+	return nil
+}
+
+func (e *NullFooMood) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.FooMood), nil
 }
 
 // this is the bar table

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/pgx/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -26,4 +27,34 @@ func (e *Status) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for Status: %T", src)
 	}
 	return nil
+}
+
+// NullStatus is the nullable version of Status.
+type NullStatus struct {
+	Status Status
+	Valid  bool
+}
+
+func (e *NullStatus) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.Status = Status(s)
+	case string:
+		e.Status = Status(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullStatus: %T", src)
+	}
+	e.Valid = len(e.Status) > 0
+	return nil
+}
+
+func (e *NullStatus) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.Status), nil
 }

--- a/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_add_value/postgresql/stdlib/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -26,4 +27,34 @@ func (e *Status) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for Status: %T", src)
 	}
 	return nil
+}
+
+// NullStatus is the nullable version of Status.
+type NullStatus struct {
+	Status Status
+	Valid  bool
+}
+
+func (e *NullStatus) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.Status = Status(s)
+	case string:
+		e.Status = Status(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullStatus: %T", src)
+	}
+	e.Valid = len(e.Status) > 0
+	return nil
+}
+
+func (e *NullStatus) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.Status), nil
 }

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/pgx/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -25,6 +26,36 @@ func (e *NewEvent) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for NewEvent: %T", src)
 	}
 	return nil
+}
+
+// NullNewEvent is the nullable version of NewEvent.
+type NullNewEvent struct {
+	NewEvent NewEvent
+	Valid    bool
+}
+
+func (e *NullNewEvent) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.NewEvent = NewEvent(s)
+	case string:
+		e.NewEvent = NewEvent(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullNewEvent: %T", src)
+	}
+	e.Valid = len(e.NewEvent) > 0
+	return nil
+}
+
+func (e *NullNewEvent) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.NewEvent), nil
 }
 
 type LogLine struct {

--- a/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename/postgresql/stdlib/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -25,6 +26,36 @@ func (e *NewEvent) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for NewEvent: %T", src)
 	}
 	return nil
+}
+
+// NullNewEvent is the nullable version of NewEvent.
+type NullNewEvent struct {
+	NewEvent NewEvent
+	Valid    bool
+}
+
+func (e *NullNewEvent) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.NewEvent = NewEvent(s)
+	case string:
+		e.NewEvent = NewEvent(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullNewEvent: %T", src)
+	}
+	e.Valid = len(e.NewEvent) > 0
+	return nil
+}
+
+func (e *NullNewEvent) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.NewEvent), nil
 }
 
 type LogLine struct {

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/pgx/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -25,6 +26,36 @@ func (e *NewEvent) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for NewEvent: %T", src)
 	}
 	return nil
+}
+
+// NullNewEvent is the nullable version of NewEvent.
+type NullNewEvent struct {
+	NewEvent NewEvent
+	Valid    bool
+}
+
+func (e *NullNewEvent) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.NewEvent = NewEvent(s)
+	case string:
+		e.NewEvent = NewEvent(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullNewEvent: %T", src)
+	}
+	e.Valid = len(e.NewEvent) > 0
+	return nil
+}
+
+func (e *NullNewEvent) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.NewEvent), nil
 }
 
 type LogLine struct {

--- a/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_and_update_columns/postgresql/stdlib/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -25,6 +26,36 @@ func (e *NewEvent) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for NewEvent: %T", src)
 	}
 	return nil
+}
+
+// NullNewEvent is the nullable version of NewEvent.
+type NullNewEvent struct {
+	NewEvent NewEvent
+	Valid    bool
+}
+
+func (e *NullNewEvent) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.NewEvent = NewEvent(s)
+	case string:
+		e.NewEvent = NewEvent(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullNewEvent: %T", src)
+	}
+	e.Valid = len(e.NewEvent) > 0
+	return nil
+}
+
+func (e *NullNewEvent) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.NewEvent), nil
 }
 
 type LogLine struct {

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/pgx/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -25,4 +26,34 @@ func (e *Status) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for Status: %T", src)
 	}
 	return nil
+}
+
+// NullStatus is the nullable version of Status.
+type NullStatus struct {
+	Status Status
+	Valid  bool
+}
+
+func (e *NullStatus) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.Status = Status(s)
+	case string:
+		e.Status = Status(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullStatus: %T", src)
+	}
+	e.Valid = len(e.Status) > 0
+	return nil
+}
+
+func (e *NullStatus) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.Status), nil
 }

--- a/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/ddl_alter_type_rename_value/postgresql/stdlib/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -25,4 +26,34 @@ func (e *Status) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for Status: %T", src)
 	}
 	return nil
+}
+
+// NullStatus is the nullable version of Status.
+type NullStatus struct {
+	Status Status
+	Valid  bool
+}
+
+func (e *NullStatus) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.Status = Status(s)
+	case string:
+		e.Status = Status(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullStatus: %T", src)
+	}
+	e.Valid = len(e.Status) > 0
+	return nil
+}
+
+func (e *NullStatus) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.Status), nil
 }

--- a/internal/endtoend/testdata/ddl_comment/postgresql/pgx/go/models.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/pgx/go/models.go
@@ -6,6 +6,7 @@ package querytest
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -26,6 +27,36 @@ func (e *FooBat) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for FooBat: %T", src)
 	}
 	return nil
+}
+
+// NullFooBat is the nullable version of FooBat.
+type NullFooBat struct {
+	FooBat FooBat
+	Valid  bool
+}
+
+func (e *NullFooBat) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.FooBat = FooBat(s)
+	case string:
+		e.FooBat = FooBat(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullFooBat: %T", src)
+	}
+	e.Valid = len(e.FooBat) > 0
+	return nil
+}
+
+func (e *NullFooBat) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.FooBat), nil
 }
 
 // Table comment

--- a/internal/endtoend/testdata/ddl_comment/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/ddl_comment/postgresql/stdlib/go/models.go
@@ -6,6 +6,7 @@ package querytest
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -26,6 +27,36 @@ func (e *FooBat) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for FooBat: %T", src)
 	}
 	return nil
+}
+
+// NullFooBat is the nullable version of FooBat.
+type NullFooBat struct {
+	FooBat FooBat
+	Valid  bool
+}
+
+func (e *NullFooBat) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.FooBat = FooBat(s)
+	case string:
+		e.FooBat = FooBat(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullFooBat: %T", src)
+	}
+	e.Valid = len(e.FooBat) > 0
+	return nil
+}
+
+func (e *NullFooBat) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.FooBat), nil
 }
 
 // Table comment

--- a/internal/endtoend/testdata/ddl_create_enum/mysql/go/models.go
+++ b/internal/endtoend/testdata/ddl_create_enum/mysql/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -37,6 +38,36 @@ func (e *FooDigit) Scan(src interface{}) error {
 	return nil
 }
 
+// NullFooDigit is the nullable version of FooDigit.
+type NullFooDigit struct {
+	FooDigit FooDigit
+	Valid    bool
+}
+
+func (e *NullFooDigit) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.FooDigit = FooDigit(s)
+	case string:
+		e.FooDigit = FooDigit(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullFooDigit: %T", src)
+	}
+	e.Valid = len(e.FooDigit) > 0
+	return nil
+}
+
+func (e *NullFooDigit) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.FooDigit), nil
+}
+
 type FooFoobar string
 
 const (
@@ -59,6 +90,36 @@ func (e *FooFoobar) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for FooFoobar: %T", src)
 	}
 	return nil
+}
+
+// NullFooFoobar is the nullable version of FooFoobar.
+type NullFooFoobar struct {
+	FooFoobar FooFoobar
+	Valid     bool
+}
+
+func (e *NullFooFoobar) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.FooFoobar = FooFoobar(s)
+	case string:
+		e.FooFoobar = FooFoobar(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullFooFoobar: %T", src)
+	}
+	e.Valid = len(e.FooFoobar) > 0
+	return nil
+}
+
+func (e *NullFooFoobar) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.FooFoobar), nil
 }
 
 type Foo struct {

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/go/models.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/pgx/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -37,6 +38,36 @@ func (e *Digit) Scan(src interface{}) error {
 	return nil
 }
 
+// NullDigit is the nullable version of Digit.
+type NullDigit struct {
+	Digit Digit
+	Valid bool
+}
+
+func (e *NullDigit) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.Digit = Digit(s)
+	case string:
+		e.Digit = Digit(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullDigit: %T", src)
+	}
+	e.Valid = len(e.Digit) > 0
+	return nil
+}
+
+func (e *NullDigit) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.Digit), nil
+}
+
 type Foobar string
 
 const (
@@ -59,6 +90,36 @@ func (e *Foobar) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for Foobar: %T", src)
 	}
 	return nil
+}
+
+// NullFoobar is the nullable version of Foobar.
+type NullFoobar struct {
+	Foobar Foobar
+	Valid  bool
+}
+
+func (e *NullFoobar) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.Foobar = Foobar(s)
+	case string:
+		e.Foobar = Foobar(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullFoobar: %T", src)
+	}
+	e.Valid = len(e.Foobar) > 0
+	return nil
+}
+
+func (e *NullFoobar) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.Foobar), nil
 }
 
 type Foo struct {

--- a/internal/endtoend/testdata/ddl_create_enum/postgresql/stdlib/go/models.go
+++ b/internal/endtoend/testdata/ddl_create_enum/postgresql/stdlib/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -37,6 +38,36 @@ func (e *Digit) Scan(src interface{}) error {
 	return nil
 }
 
+// NullDigit is the nullable version of Digit.
+type NullDigit struct {
+	Digit Digit
+	Valid bool
+}
+
+func (e *NullDigit) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.Digit = Digit(s)
+	case string:
+		e.Digit = Digit(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullDigit: %T", src)
+	}
+	e.Valid = len(e.Digit) > 0
+	return nil
+}
+
+func (e *NullDigit) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.Digit), nil
+}
+
 type Foobar string
 
 const (
@@ -59,6 +90,36 @@ func (e *Foobar) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for Foobar: %T", src)
 	}
 	return nil
+}
+
+// NullFoobar is the nullable version of Foobar.
+type NullFoobar struct {
+	Foobar Foobar
+	Valid  bool
+}
+
+func (e *NullFoobar) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.Foobar = Foobar(s)
+	case string:
+		e.Foobar = Foobar(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullFoobar: %T", src)
+	}
+	e.Valid = len(e.Foobar) > 0
+	return nil
+}
+
+func (e *NullFoobar) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.Foobar), nil
 }
 
 type Foo struct {

--- a/internal/endtoend/testdata/rename/pgx/go/models.go
+++ b/internal/endtoend/testdata/rename/pgx/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -26,6 +27,36 @@ func (e *IPProtocol) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for IPProtocol: %T", src)
 	}
 	return nil
+}
+
+// NullIPProtocol is the nullable version of IPProtocol.
+type NullIPProtocol struct {
+	IPProtocol IPProtocol
+	Valid      bool
+}
+
+func (e *NullIPProtocol) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.IPProtocol = IPProtocol(s)
+	case string:
+		e.IPProtocol = IPProtocol(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullIPProtocol: %T", src)
+	}
+	e.Valid = len(e.IPProtocol) > 0
+	return nil
+}
+
+func (e *NullIPProtocol) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.IPProtocol), nil
 }
 
 type BarNew struct {

--- a/internal/endtoend/testdata/rename/stdlib/go/models.go
+++ b/internal/endtoend/testdata/rename/stdlib/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -26,6 +27,36 @@ func (e *IPProtocol) Scan(src interface{}) error {
 		return fmt.Errorf("unsupported scan type for IPProtocol: %T", src)
 	}
 	return nil
+}
+
+// NullIPProtocol is the nullable version of IPProtocol.
+type NullIPProtocol struct {
+	IPProtocol IPProtocol
+	Valid      bool
+}
+
+func (e *NullIPProtocol) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.IPProtocol = IPProtocol(s)
+	case string:
+		e.IPProtocol = IPProtocol(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullIPProtocol: %T", src)
+	}
+	e.Valid = len(e.IPProtocol) > 0
+	return nil
+}
+
+func (e *NullIPProtocol) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.IPProtocol), nil
 }
 
 type BarNew struct {

--- a/internal/endtoend/testdata/schema_scoped_enum/pgx/go/models.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/pgx/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -27,6 +28,36 @@ func (e *FooTypeUserRole) Scan(src interface{}) error {
 	return nil
 }
 
+// NullFooTypeUserRole is the nullable version of FooTypeUserRole.
+type NullFooTypeUserRole struct {
+	FooTypeUserRole FooTypeUserRole
+	Valid           bool
+}
+
+func (e *NullFooTypeUserRole) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.FooTypeUserRole = FooTypeUserRole(s)
+	case string:
+		e.FooTypeUserRole = FooTypeUserRole(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullFooTypeUserRole: %T", src)
+	}
+	e.Valid = len(e.FooTypeUserRole) > 0
+	return nil
+}
+
+func (e *NullFooTypeUserRole) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.FooTypeUserRole), nil
+}
+
 type FooUser struct {
-	Role FooTypeUserRole
+	Role NullFooTypeUserRole
 }

--- a/internal/endtoend/testdata/schema_scoped_enum/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/pgx/go/query.sql.go
@@ -13,15 +13,15 @@ const listUsersByRole = `-- name: ListUsersByRole :many
 SELECT role FROM foo.users WHERE role = $1
 `
 
-func (q *Queries) ListUsersByRole(ctx context.Context, role FooTypeUserRole) ([]FooTypeUserRole, error) {
+func (q *Queries) ListUsersByRole(ctx context.Context, role NullFooTypeUserRole) ([]NullFooTypeUserRole, error) {
 	rows, err := q.db.Query(ctx, listUsersByRole, role)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []FooTypeUserRole
+	var items []NullFooTypeUserRole
 	for rows.Next() {
-		var role FooTypeUserRole
+		var role NullFooTypeUserRole
 		if err := rows.Scan(&role); err != nil {
 			return nil, err
 		}

--- a/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/models.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/models.go
@@ -5,6 +5,7 @@
 package querytest
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -27,6 +28,36 @@ func (e *FooTypeUserRole) Scan(src interface{}) error {
 	return nil
 }
 
+// NullFooTypeUserRole is the nullable version of FooTypeUserRole.
+type NullFooTypeUserRole struct {
+	FooTypeUserRole FooTypeUserRole
+	Valid           bool
+}
+
+func (e *NullFooTypeUserRole) Scan(src interface{}) error {
+	if src == nil {
+		e.Valid = false
+		return nil
+	}
+	switch s := src.(type) {
+	case []byte:
+		e.FooTypeUserRole = FooTypeUserRole(s)
+	case string:
+		e.FooTypeUserRole = FooTypeUserRole(s)
+	default:
+		return fmt.Errorf("unsupported scan type for NullFooTypeUserRole: %T", src)
+	}
+	e.Valid = len(e.FooTypeUserRole) > 0
+	return nil
+}
+
+func (e *NullFooTypeUserRole) Value() (driver.Value, error) {
+	if !e.Valid {
+		return nil, nil
+	}
+	return string(e.FooTypeUserRole), nil
+}
+
 type FooUser struct {
-	Role FooTypeUserRole
+	Role NullFooTypeUserRole
 }

--- a/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/schema_scoped_enum/stdlib/go/query.sql.go
@@ -13,15 +13,15 @@ const listUsersByRole = `-- name: ListUsersByRole :many
 SELECT role FROM foo.users WHERE role = $1
 `
 
-func (q *Queries) ListUsersByRole(ctx context.Context, role FooTypeUserRole) ([]FooTypeUserRole, error) {
+func (q *Queries) ListUsersByRole(ctx context.Context, role NullFooTypeUserRole) ([]NullFooTypeUserRole, error) {
 	rows, err := q.db.QueryContext(ctx, listUsersByRole, role)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []FooTypeUserRole
+	var items []NullFooTypeUserRole
 	for rows.Next() {
-		var role FooTypeUserRole
+		var role NullFooTypeUserRole
 		if err := rows.Scan(&role); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
For every enum X, generate a type NullX which is a struct with X and
Valid bool.

issue #1097

Remaining work:

- [ ] Get agreement from @kyleconroy 
- [ ] Discuss whether to put in effort to skip generation of NullX when it's unused.
- [ ] Discuss whether the backwards compatibility break (because some inputs/outputs will become NullX) is a problem
- [ ] Test with pgx
- [ ] Test with database/sql postgres
- [ ] Test with database/sql mysql