### PR TITLE
Fix panic when calling cmd.Do subsequently

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -19,6 +19,10 @@ import (
 	"github.com/kyleconroy/sqlc/internal/tracer"
 )
 
+func init() {
+	uploadCmd.Flags().BoolP("dry-run", "", false, "dump upload request (default: false)")
+}
+
 // Do runs the command logic.
 func Do(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
 	rootCmd := &cobra.Command{Use: "sqlc", SilenceUsage: true}
@@ -29,7 +33,6 @@ func Do(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int 
 	rootCmd.AddCommand(genCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(versionCmd)
-	uploadCmd.Flags().BoolP("dry-run", "", false, "dump upload request (default: false)")
 	rootCmd.AddCommand(uploadCmd)
 
 	rootCmd.SetArgs(args)


### PR DESCRIPTION
If you call cmd.Do programmatically more than once, it panics on the 2nd run due to this error:
```
panic: upload flag redefined: dry-run

goroutine 1 [running]:
github.com/spf13/pflag.(*FlagSet).AddFlag(0xc0005b1300, 0xc0001243c0)
        external/com_github_spf13_pflag/flag.go:848 +0x825
github.com/spf13/pflag.(*FlagSet).VarPF(0xc0005b1300, 0x5122970, 0xc0005cef19, 0x4e6bd3d, 0x7, 0x0, 0x0, 0x4e9006b, 0x24, 0xc0005cef19)
        external/com_github_spf13_pflag/flag.go:831 +0x10b
github.com/spf13/pflag.(*FlagSet).BoolVarP(0xc0005b1300, 0xc0005cef19, 0x4e6bd3d, 0x7, 0x0, 0x0, 0x0, 0x4e9006b, 0x24)
        external/com_github_spf13_pflag/bool.go:55 +0x97
github.com/spf13/pflag.(*FlagSet).BoolP(...)
        external/com_github_spf13_pflag/bool.go:80
github.com/kyleconroy/sqlc/internal/cmd.Do(0xc00003c210, 0x0, 0x0, 0x5119220, 0xc000010010, 0x5119260, 0xc000010018, 0x5119260, 0xc000010020, 0x0)
        external/com_github_kyleconroy_sqlc/internal/cmd/cmd.go:32 +0x2e5
main.main()
```

To avoid have redefined flags, we can add the upload dry-run flag in the init() function instead.

This fixes #1616