### PR TITLE
doc: typo fix in overrides config example

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -106,7 +106,7 @@ packages: [...]
 overrides:
   - db_type: "uuid"
     go_type:
-    - import: "a/b/v2"
+      import: "a/b/v2"
       package: "b"
       type: "MyType"
       pointer: false # or true


### PR DESCRIPTION
`go_type` is an object, not sequence