### PR TITLE
Fix postgresql time

### DIFF
--- a/internal/codegen/golang/imports.go
+++ b/internal/codegen/golang/imports.go
@@ -150,6 +150,7 @@ var pgtypeTypes = map[string]struct{}{
 	"pgtype.Macaddr":   {},
 	"pgtype.Numeric":   {},
 	"pgtype.Numrange":  {},
+	"pgtype.Time":      {},
 	"pgtype.Tsrange":   {},
 	"pgtype.Tstzrange": {},
 }

--- a/internal/codegen/golang/postgresql_type.go
+++ b/internal/codegen/golang/postgresql_type.go
@@ -143,7 +143,10 @@ func postgresType(req *plugin.CodeGenRequest, col *plugin.Column) string {
 		}
 		return "sql.NullTime"
 
-	case "pg_catalog.time", "pg_catalog.timetz":
+	case "pg_catalog.time":
+		return "pgtype.Time"
+
+	case "pg_catalog.timetz":
 		if notNull {
 			return "time.Time"
 		}

--- a/internal/endtoend/testdata/cast_null/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/cast_null/pgx/go/query.sql.go
@@ -8,6 +8,8 @@ package querytest
 import (
 	"context"
 	"database/sql"
+
+	"github.com/jackc/pgtype"
 )
 
 const listNullable = `-- name: ListNullable :many
@@ -23,7 +25,7 @@ type ListNullableRow struct {
 	A sql.NullString
 	B sql.NullInt32
 	C sql.NullInt64
-	D sql.NullTime
+	D pgtype.Time
 }
 
 func (q *Queries) ListNullable(ctx context.Context) ([]ListNullableRow, error) {

--- a/internal/endtoend/testdata/cast_null/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/cast_null/stdlib/go/query.sql.go
@@ -8,6 +8,8 @@ package querytest
 import (
 	"context"
 	"database/sql"
+
+	"github.com/jackc/pgtype"
 )
 
 const listNullable = `-- name: ListNullable :many
@@ -23,7 +25,7 @@ type ListNullableRow struct {
 	A sql.NullString
 	B sql.NullInt32
 	C sql.NullInt64
-	D sql.NullTime
+	D pgtype.Time
 }
 
 func (q *Queries) ListNullable(ctx context.Context) ([]ListNullableRow, error) {

--- a/internal/endtoend/testdata/datatype/pgx/go/models.go
+++ b/internal/endtoend/testdata/datatype/pgx/go/models.go
@@ -29,8 +29,8 @@ type DtCharacterNotNull struct {
 
 type DtDatetime struct {
 	A sql.NullTime
-	B sql.NullTime
-	C sql.NullTime
+	B pgtype.Time
+	C pgtype.Time
 	D sql.NullTime
 	E sql.NullTime
 	F sql.NullTime
@@ -40,8 +40,8 @@ type DtDatetime struct {
 
 type DtDatetimeNotNull struct {
 	A time.Time
-	B time.Time
-	C time.Time
+	B pgtype.Time
+	C pgtype.Time
 	D time.Time
 	E time.Time
 	F time.Time

--- a/internal/endtoend/testdata/datatype/stdlib/go/models.go
+++ b/internal/endtoend/testdata/datatype/stdlib/go/models.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/jackc/pgtype"
 	"github.com/tabbed/pqtype"
 )
 
@@ -29,8 +30,8 @@ type DtCharacterNotNull struct {
 
 type DtDatetime struct {
 	A sql.NullTime
-	B sql.NullTime
-	C sql.NullTime
+	B pgtype.Time
+	C pgtype.Time
 	D sql.NullTime
 	E sql.NullTime
 	F sql.NullTime
@@ -40,8 +41,8 @@ type DtDatetime struct {
 
 type DtDatetimeNotNull struct {
 	A time.Time
-	B time.Time
-	C time.Time
+	B pgtype.Time
+	C pgtype.Time
 	D time.Time
 	E time.Time
 	F time.Time


### PR DESCRIPTION
Go's `time.Time` type is not compatible with Postgres' `pg_catalog.time` type. Therefore this fix uses `pgtype.Time` which is the correct one. `pg_catalog.timetz` would also need to be fixed, but there is no `pgtype.TimeTZ` (see https://github.com/jackc/pgtype/issues/150 and https://github.com/jackc/pgx/issues/759).