### PR TITLE
[FIX] copyfrom imports

### DIFF
--- a/internal/codegen/golang/imports.go
+++ b/internal/codegen/golang/imports.go
@@ -375,11 +375,14 @@ func (i *importer) queryImports(filename string) fileImports {
 }
 
 func (i *importer) copyfromImports() fileImports {
-	std, pkg := buildImports(i.Settings, i.Queries, func(name string) bool {
-		for _, q := range i.Queries {
-			if q.Cmd != metadata.CmdCopyFrom {
-				continue
-			}
+	copyFromQueries := make([]Query, 0, len(i.Queries))
+	for _, q := range i.Queries {
+		if q.Cmd == metadata.CmdCopyFrom {
+			copyFromQueries = append(copyFromQueries, q)
+		}
+	}
+	std, pkg := buildImports(i.Settings, copyFromQueries, func(name string) bool {
+		for _, q := range copyFromQueries {
 			if q.hasRetType() {
 				if strings.HasPrefix(q.Ret.Type(), name) {
 					return true

--- a/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/go/query.sql.go
@@ -8,7 +8,18 @@ package querytest
 import (
 	"context"
 	"database/sql"
+
+	"github.com/jackc/pgconn"
 )
+
+const deleteValues = `-- name: DeleteValues :execresult
+DELETE
+FROM myschema.foo
+`
+
+func (q *Queries) DeleteValues(ctx context.Context) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, deleteValues)
+}
 
 const insertSingleValue = `-- name: InsertSingleValue :exec
 INSERT INTO myschema.foo (a) VALUES ($1)

--- a/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/query.sql
+++ b/internal/endtoend/testdata/copyfrom_imports/postgresql/pgx/query.sql
@@ -6,3 +6,7 @@ INSERT INTO myschema.foo (a, b) VALUES ($1, $2);
 
 -- name: InsertSingleValue :exec
 INSERT INTO myschema.foo (a) VALUES ($1);
+
+-- name: DeleteValues :execresult
+DELETE
+FROM myschema.foo;


### PR DESCRIPTION
Depending on the commands used in your `query.sql` the `copyfrom.go`
may end up with unused package imports.

There is a patch for this problem that was merged in the #1386 PR.
However, it looks like some edge cases were left out of the fix.

This commit ensures that `buildImports` only has `copyfrom` queries
when called from `copyfromImports`.