### PR TITLE
fix: #1574 nullable return types for groupby functions

### DIFF
--- a/internal/compiler/output_columns.go
+++ b/internal/compiler/output_columns.go
@@ -213,12 +213,26 @@ func outputColumns(qc *QueryCatalog, node ast.Node) ([]*Column, error) {
 			}
 			fun, err := qc.catalog.ResolveFuncCall(n)
 			if err == nil {
-				cols = append(cols, &Column{
-					Name:       name,
-					DataType:   dataType(fun.ReturnType),
-					NotNull:    !fun.ReturnTypeNullable,
-					IsFuncCall: true,
-				})
+				if len(fun.Args) > 0 {
+					ref := n.Args.Items[0].(*ast.ColumnRef)
+					columns, err := outputColumnRefs(res, tables, ref)
+					if err != nil {
+						return nil, err
+					}
+					cols = append(cols, &Column{
+						Name:       name,
+						DataType:   columns[0].DataType,
+						NotNull:    !fun.ReturnTypeNullable,
+						IsFuncCall: true,
+					})
+				} else {
+					cols = append(cols, &Column{
+						Name:       name,
+						DataType:   dataType(fun.ReturnType),
+						NotNull:    !fun.ReturnTypeNullable,
+						IsFuncCall: true,
+					})
+				}
 			} else {
 				cols = append(cols, &Column{
 					Name:       name,


### PR DESCRIPTION
This is a proposed fix for https://github.com/kyleconroy/sqlc/issues/1574. I am unsure if this change breaks any tests because I don't have a correctly setup postgres instance to generate `pg_catalog` correctly with all extensions. However, I have checked that this change fixes the bug.