### PR TITLE
fix: missing imports for slices

### DIFF
--- a/internal/codegen/golang/imports.go
+++ b/internal/codegen/golang/imports.go
@@ -309,7 +309,8 @@ func (i *importer) queryImports(filename string) fileImports {
 						}
 					}
 				}
-				if strings.HasPrefix(q.Ret.Type(), name) {
+				retType := strings.TrimPrefix(q.Ret.Type(), "[]")
+				if strings.HasPrefix(retType, name) {
 					return true
 				}
 			}
@@ -322,7 +323,8 @@ func (i *importer) queryImports(filename string) fileImports {
 						}
 					}
 				}
-				if strings.HasPrefix(q.Arg.Type(), name) {
+				argType := strings.TrimPrefix(q.Arg.Type(), "[]")
+				if strings.HasPrefix(argType, name) {
 					return true
 				}
 			}
@@ -417,7 +419,8 @@ func (i *importer) batchImports(filename string) fileImports {
 						}
 					}
 				}
-				if strings.HasPrefix(q.Ret.Type(), name) {
+				retType := strings.TrimPrefix(q.Ret.Type(), "[]")
+				if strings.HasPrefix(retType, name) {
 					return true
 				}
 			}
@@ -430,7 +433,8 @@ func (i *importer) batchImports(filename string) fileImports {
 						}
 					}
 				}
-				if strings.HasPrefix(q.Arg.Type(), name) {
+				argType := strings.TrimPrefix(q.Arg.Type(), "[]")
+				if strings.HasPrefix(argType, name) {
 					return true
 				}
 			}


### PR DESCRIPTION
Fixes #1253 by checking for type needed for a given slice, this also allows passing slices to as parameters to queries such as [WHERE ANY](https://docs.sqlc.dev/en/stable/howto/select.html#passing-a-slice-as-a-parameter-to-a-query) without being restricted to postgres data types