### PR TITLE
Add type support for pgtype.Point

### DIFF
--- a/internal/codegen/golang/postgresql_type.go
+++ b/internal/codegen/golang/postgresql_type.go
@@ -255,7 +255,11 @@ func postgresType(req *plugin.CodeGenRequest, col *plugin.Column) string {
 			return "pgtype.Hstore"
 		}
 		return "interface{}"
-
+	case "point":
+		if driver == SQLDriverPGXV4 {
+			return "pgtype.Point"
+		}
+		return "interface{}"
 	case "void":
 		// A void value can only be scanned into an empty interface.
 		return "interface{}"


### PR DESCRIPTION
This PR adds support for the `pgtype.Point` type to postgresql_type.go.