### PR TITLE
Add barebones support for converting mysql rowexprs

### DIFF
--- a/internal/engine/dolphin/convert.go
+++ b/internal/engine/dolphin/convert.go
@@ -1117,7 +1117,13 @@ func (c *cc) convertRollbackStmt(n *pcast.RollbackStmt) ast.Node {
 }
 
 func (c *cc) convertRowExpr(n *pcast.RowExpr) ast.Node {
-	return todo(n)
+	var items []ast.Node
+	for _, v := range n.Values {
+		items = append(items, c.convert(v))
+	}
+	return &ast.RowExpr{
+		Args: &ast.List{Items: items},
+	}
 }
 
 func (c *cc) convertSetCollationExpr(n *pcast.SetCollationExpr) ast.Node {

--- a/internal/engine/dolphin/convert_test.go
+++ b/internal/engine/dolphin/convert_test.go
@@ -1,0 +1,42 @@
+package dolphin_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kyleconroy/sqlc/internal/engine/dolphin"
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/kyleconroy/sqlc/internal/sql/astutils"
+)
+
+func Test_TupleComparison(t *testing.T) {
+	p := dolphin.NewParser()
+	stmts, err := p.Parse(strings.NewReader("SELECT * WHERE (a, b) > (?, ?)"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if l := len(stmts); l != 1 {
+		t.Fatalf("expected 1 statement, got %d", l)
+	}
+
+	// Right now all this test does is make sure we noticed the two ParamRefs.
+	// This ensures that the Go code is generated correctly.
+	e := &refExtractor{}
+	astutils.Walk(e, stmts[0].Raw.Stmt)
+	if l := len(e.params); l != 2 {
+		t.Fatalf("expected to extract 2 params, got %d", l)
+	}
+}
+
+type refExtractor struct {
+	params []*ast.ParamRef
+}
+
+func (e *refExtractor) Visit(n ast.Node) astutils.Visitor {
+	switch t := n.(type) {
+	case *ast.ParamRef:
+		e.params = append(e.params, t)
+	}
+	return e
+}

--- a/internal/engine/dolphin/convert_test.go
+++ b/internal/engine/dolphin/convert_test.go
@@ -29,6 +29,8 @@ func Test_TupleComparison(t *testing.T) {
 	}
 }
 
+// refExtractor is an astutils.Visitor instance that will extract all of the
+// ParamRef instances it encounters while walking an AST.
 type refExtractor struct {
 	params []*ast.ParamRef
 }


### PR DESCRIPTION
This is a _very_ barebones implementation of support for converting mysql row expressions into the AST.

Fixes https://github.com/kyleconroy/sqlc/issues/1648

~I could not find any obvious place to add a test for this. Should I be adding an example of tuple comparisons to the `examples/` directory? Or would you like me to add some basic unit-tests?~

EDIT: I went ahead and added a basic unit test that will catch regressions specifically around how many ParamRefs we extract.