### PR TITLE
fix: 🐛 Correctly switch `coalesce()` result `.NotNull` value

### DIFF
--- a/internal/endtoend/testdata/coalesce/postgresql/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/pgx/go/query.sql.go
@@ -73,7 +73,7 @@ FROM foo
 
 type CoalesceNumericNullRow struct {
 	Baz   sql.NullInt64
-	Baz_2 int64
+	Baz_2 sql.NullInt64
 }
 
 func (q *Queries) CoalesceNumericNull(ctx context.Context) ([]CoalesceNumericNullRow, error) {
@@ -159,7 +159,7 @@ FROM foo
 
 type CoalesceStringNullRow struct {
 	Bar   sql.NullString
-	Bar_2 string
+	Bar_2 sql.NullString
 }
 
 func (q *Queries) CoalesceStringNull(ctx context.Context) ([]CoalesceStringNullRow, error) {

--- a/internal/endtoend/testdata/coalesce/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/coalesce/postgresql/stdlib/go/query.sql.go
@@ -79,7 +79,7 @@ FROM foo
 
 type CoalesceNumericNullRow struct {
 	Baz   sql.NullInt64
-	Baz_2 int64
+	Baz_2 sql.NullInt64
 }
 
 func (q *Queries) CoalesceNumericNull(ctx context.Context) ([]CoalesceNumericNullRow, error) {
@@ -174,7 +174,7 @@ FROM foo
 
 type CoalesceStringNullRow struct {
 	Bar   sql.NullString
-	Bar_2 string
+	Bar_2 sql.NullString
 }
 
 func (q *Queries) CoalesceStringNull(ctx context.Context) ([]CoalesceStringNullRow, error) {


### PR DESCRIPTION
This change follows the previous implementation that mutates and returns the first column, but switches only the `.NotNull` value depending on the situation.

- Is it sufficient that asserting only types of columns and constants?
- Also I'm concerned that the `A_Const` node may contain `Null`.

Also, I am new to Golang OSS, so I may be making some large mistakes. Thank you in advance for your review.

BREAKING CHANGE: 🧨 `coalesce()` may assign nullable results

✅ Closes: #1663