### PR TITLE
sqlite - use []byte for blobs

### DIFF
--- a/internal/codegen/golang/sqlite_type.go
+++ b/internal/codegen/golang/sqlite_type.go
@@ -21,10 +21,7 @@ func sqliteType(req *plugin.CodeGenRequest, col *plugin.Column) string {
 		return "sql.NullInt64"
 
 	case "blob":
-		if notNull {
-			return "[]uint8"
-		}
-		return "*[]uint8"
+		return "[]byte"
 
 	case "real", "double", "doubleprecision", "float":
 		if notNull {


### PR DESCRIPTION
To keep the API consistent with mysql

```go
case "blob", "binary", "varbinary", "tinyblob", "mediumblob", "longblob":
    return "[]byte"
```

and postgres

```go
case "bytea", "blob", "pg_catalog.bytea":
    return "[]byte"
```

I suggest sqlc uses []byte instead of []uint8. If the field is nullable, it is pointles to have a *[]uint8 (or *[]byte) because slices are already pointers, and a slice can be nil