### PR TITLE
plugins(wasm): Change the SHA-256 config key

### DIFF
--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -328,8 +328,8 @@ func codegen(ctx context.Context, combo config.CombinedSettings, sql outPair, re
 			}
 		case plug.WASM != nil:
 			handler = &wasm.Runner{
-				URL:      plug.WASM.URL,
-				Checksum: plug.WASM.Checksum,
+				URL:    plug.WASM.URL,
+				SHA256: plug.WASM.SHA256,
 			}
 		default:
 			return "", nil, fmt.Errorf("unsupported plugin type")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,8 +88,8 @@ type Plugin struct {
 		Cmd string `json:"cmd" yaml:"cmd"`
 	} `json:"process" yaml:"process"`
 	WASM *struct {
-		URL      string `json:"url" yaml:"url"`
-		Checksum string `json:"checksum" yaml:"checksum"`
+		URL    string `json:"url" yaml:"url"`
+		SHA256 string `json:"sha256" yaml:"sha256"`
 	} `json:"wasm" yaml:"wasm"`
 }
 

--- a/internal/endtoend/testdata/wasm_plugin_sqlc_gen_greeter/sqlc.json
+++ b/internal/endtoend/testdata/wasm_plugin_sqlc_gen_greeter/sqlc.json
@@ -18,7 +18,7 @@
       "name": "greeter",
       "wasm": {
         "url": "https://github.com/kyleconroy/sqlc-gen-greeter/releases/download/v0.1.0/sqlc-gen-greeter.wasm",
-        "checksum": "sha256/afc486dac2068d741d7a4110146559d12a013fd0286f42a2fc7dcd802424ad07"
+        "sha256": "afc486dac2068d741d7a4110146559d12a013fd0286f42a2fc7dcd802424ad07"
       }
     }
   ]

--- a/internal/ext/wasm/wasm.go
+++ b/internal/ext/wasm/wasm.go
@@ -45,7 +45,7 @@ type Runner struct {
 // Verify the provided sha256 is valid.
 func (r *Runner) parseChecksum() (string, error) {
 	if r.SHA256 == "" {
-		return "", fmt.Errorf("missing integrity")
+		return "", fmt.Errorf("missing SHA-256 checksum")
 	}
 	return r.SHA256, nil
 }

--- a/internal/ext/wasm/wasm.go
+++ b/internal/ext/wasm/wasm.go
@@ -38,19 +38,16 @@ func cacheDir() (string, error) {
 }
 
 type Runner struct {
-	URL      string
-	Checksum string
+	URL    string
+	SHA256 string
 }
 
 // Verify the provided sha256 is valid.
 func (r *Runner) parseChecksum() (string, error) {
-	if r.Checksum == "" {
-		return "", fmt.Errorf("missing checksum")
+	if r.SHA256 == "" {
+		return "", fmt.Errorf("missing integrity")
 	}
-	if !strings.HasPrefix(r.Checksum, "sha256/") {
-		return "", fmt.Errorf("invalid checksum algo: %s", r.Checksum)
-	}
-	return strings.TrimPrefix(r.Checksum, "sha256/"), nil
+	return r.SHA256, nil
 }
 
 func (r *Runner) loadModule(ctx context.Context, engine *wasmtime.Engine) (*wasmtime.Module, error) {


### PR DESCRIPTION
Use sha256 to match Bazel's http_file directive. I was originally going to make these [subresource integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity#using_subresource_integrity) values, but the spec allows for multiple space-separated values. The checksum is also base64-encoded, which means it can't be used a file name, as it may have a slash in it.