### PR TITLE
improve mysql container support for testing

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
-ARG VARIANT=1.17-bullseye
+ARG VARIANT=1.18-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
 
 # [Optional] If your requirements rarely change, uncomment this section to add them to the image.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,13 +6,17 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
       args:
-        VARIANT: 1.17-bullseye
+        VARIANT: 1.18-bullseye
 
     volumes:
       - ..:/workspace:cached
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
+
+    links:
+      - mysql
+      - postgresql
 
     environment:
       PG_HOST: postgresql
@@ -24,13 +28,14 @@ services:
       MYSQL_ROOT_PASSWORD: mysecretpassword
 
   mysql:
-    image: "mysql:8"
+    image: "mysql/mysql-server:8.0"
     ports:
       - "3306:3306"
     restart: unless-stopped
     environment:
       MYSQL_DATABASE: dinotest
       MYSQL_ROOT_PASSWORD: mysecretpassword
+      MYSQL_ROOT_HOST: '%'
 
   postgresql:
     image: "postgres:13"
@@ -41,6 +46,5 @@ services:
       POSTGRES_DB: dinotest
       POSTGRES_PASSWORD: mysecretpassword
       POSTGRES_USER: postgres
-
     # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,14 @@
 version: "3.8"
 services:
   mysql:
-    image: "mysql:8"
+    image: "mysql/mysql-server:8.0"
     ports:
       - "3306:3306"
     restart: always
     environment:
       MYSQL_DATABASE: dinotest
       MYSQL_ROOT_PASSWORD: mysecretpassword
+      MYSQL_ROOT_HOST: '%'
 
   postgresql:
     image: "postgres:13"


### PR DESCRIPTION
* update devcontainer go image to 1.18-bullseye to match go.mod
* use [mysql/mysql-server](https://hub.docker.com/r/mysql/mysql-server/tags) image to support arm based machine like M1 Mac
* set `MYSQL_ROOT_HOST: '%'` to allow access from any host
  * https://dev.mysql.com/doc/mysql-installation-excerpt/8.0/en/docker-mysql-more-topics.html#docker_var_mysql-root-host
* add `links` section to avoid DNS lookup failure