### PR TITLE
fix(postgresql): Add quotes for CamelCase columns

### DIFF
--- a/internal/compiler/compile_test.go
+++ b/internal/compiler/compile_test.go
@@ -1,0 +1,38 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/kyleconroy/sqlc/internal/config"
+)
+
+func TestQuoteIdent(t *testing.T) {
+	type test struct {
+		engine config.Engine
+		in     string
+		want   string
+	}
+	tests := []test{
+		{config.EnginePostgreSQL, "age", "age"},
+		{config.EnginePostgreSQL, "Age", `"Age"`},
+		{config.EnginePostgreSQL, "CamelCase", `"CamelCase"`},
+		{config.EngineMySQL, "CamelCase", "CamelCase"},
+		// keywords
+		{config.EnginePostgreSQL, "select", `"select"`},
+		{config.EngineMySQL, "select", "`select`"},
+	}
+
+	for _, spec := range tests {
+		compiler := NewCompiler(config.SQL{
+			Engine: spec.engine,
+		}, config.CombinedSettings{})
+
+		t.Run(spec.in, func(t *testing.T) {
+			got := compiler.quoteIdent(spec.in)
+			if got != spec.want {
+				t.Error("quoteIdent: engine " + string(spec.engine) + " failed for " + spec.in + ", want " + spec.want + ", got " + got)
+			}
+		})
+	}
+
+}

--- a/internal/compiler/expand.go
+++ b/internal/compiler/expand.go
@@ -45,6 +45,12 @@ func (c *Compiler) quoteIdent(ident string) string {
 			return "\"" + ident + "\""
 		}
 	}
+	if c.conf.Engine == config.EnginePostgreSQL {
+		// camelCase means the column is also camelCase
+		if strings.ToLower(ident) != ident {
+			return "\"" + ident + "\""
+		}
+	}
 	return ident
 }
 

--- a/internal/endtoend/testdata/select_star/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/select_star/postgresql/stdlib/go/query.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const getAll = `-- name: GetAll :many
-SELECT id, first_name, last_name, age FROM users
+SELECT id, first_name, last_name, "Age" FROM users
 `
 
 func (q *Queries) GetAll(ctx context.Context) ([]User, error) {

--- a/internal/endtoend/testdata/select_star/postgresql/stdlib/schema.sql
+++ b/internal/endtoend/testdata/select_star/postgresql/stdlib/schema.sql
@@ -1,6 +1,6 @@
 CREATE TABLE users (
-    id integer NOT NULL PRIMARY KEY,
+    ID integer NOT NULL PRIMARY KEY,
     first_name varchar(255) NOT NULL,
     last_name varchar(255),
-    age integer NOT NULL
+    "Age" integer NOT NULL
 );


### PR DESCRIPTION
If columns are created with CamelCase, they have to be quoted or else
postgres won't find them.

This PR only applies to ```SELECT * FROM tablename``` queries. When the column names are specified individually with quotes, it already works.

fixes #1718 