### PR TITLE
Add nowasm tag, fix nowasm inconsistency

### DIFF
--- a/internal/ext/wasm/nowasm.go
+++ b/internal/ext/wasm/nowasm.go
@@ -1,16 +1,19 @@
-//go:build !(cgo && ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64)))
+//go:build nowasm || !(cgo && ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64)))
 
 package wasm
 
 import (
 	"fmt"
+    "context"
 
 	"github.com/kyleconroy/sqlc/internal/plugin"
 )
 
 type Runner struct {
+	URL    string
+	SHA256 string
 }
 
-func (r *Runner) Generate(req *plugin.CodeGenRequest) (*plugin.CodeGenResponse, error) {
+func (r *Runner) Generate(ctx context.Context, req *plugin.CodeGenRequest) (*plugin.CodeGenResponse, error) {
 	return nil, fmt.Errorf("sqlc built without wasmtime support")
 }

--- a/internal/ext/wasm/wasm.go
+++ b/internal/ext/wasm/wasm.go
@@ -1,4 +1,4 @@
-//go:build cgo && ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64))
+//go:build !nowasm && cgo && ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64))
 
 // The above build constraint is based of the cgo directives in this file:
 // https://github.com/bytecodealliance/wasmtime-go/blob/main/ffi.go


### PR DESCRIPTION
I found an inconsistency between the implementation of the wasm and nowasm files.

I thought that since it seems that this feature can be disabled, it would be nice to be able to control it from a tag. So I added that too.

The reason I came about this in the first place was that it seems that there is a Rust dependency in the wasm implementation, and that conflicts with my build system. I'm sure I could figure it out if this will not be possible in the future.