### PR TITLE
build: Upgrade to Go 1.19

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
-ARG VARIANT=1.18-bullseye
+ARG VARIANT=1.19-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
 
 # [Optional] If your requirements rarely change, uncomment this section to add them to the image.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
       args:
-        VARIANT: 1.18-bullseye
+        VARIANT: 1.19-bullseye
 
     volumes:
       - ..:/workspace:cached

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
 
     - name: install ./...
       run: go install ./...

--- a/examples/batch/postgresql/batch.go
+++ b/examples/batch/postgresql/batch.go
@@ -2,6 +2,7 @@
 // versions:
 //   sqlc v1.14.0
 // source: batch.go
+
 package batch
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyleconroy/sqlc
 
-go 1.18
+go 1.19
 
 require (
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220626175859-9abda183db8e

--- a/internal/codegen/golang/templates/template.tmpl
+++ b/internal/codegen/golang/templates/template.tmpl
@@ -193,6 +193,7 @@ import (
 // versions:
 //   sqlc {{.SqlcVersion}}
 // source: {{.SourceName}}
+
 package {{.Package}}
 
 import (

--- a/internal/endtoend/testdata/batch/postgresql/pgx/go/batch.go
+++ b/internal/endtoend/testdata/batch/postgresql/pgx/go/batch.go
@@ -2,6 +2,7 @@
 // versions:
 //   sqlc v1.14.0
 // source: batch.go
+
 package querytest
 
 import (

--- a/internal/endtoend/testdata/batch_imports/postgresql/pgx/go/batch.go
+++ b/internal/endtoend/testdata/batch_imports/postgresql/pgx/go/batch.go
@@ -2,6 +2,7 @@
 // versions:
 //   sqlc v1.14.0
 // source: batch.go
+
 package querytest
 
 import (


### PR DESCRIPTION
Go 1.19 isn't required as 1.18 will still be supported for the time being.