### PR TITLE
pg-gen: make sqlc-pg-gen the complete source of truth for pg_catalog.go

### DIFF
--- a/internal/endtoend/testdata/valid_group_by_reference/postgresql/go/query.sql.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/postgresql/go/query.sql.go
@@ -79,7 +79,7 @@ ORDER BY bucket DESC
 type ListMetricsRow struct {
 	Bucket   interface{}
 	CityName sql.NullString
-	Avg      string
+	Avg      float64
 }
 
 func (q *Queries) ListMetrics(ctx context.Context) ([]ListMetricsRow, error) {

--- a/internal/engine/postgresql/contrib/adminpack.go
+++ b/internal/engine/postgresql/contrib/adminpack.go
@@ -19,9 +19,6 @@ func Adminpack() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
@@ -34,8 +31,20 @@ func Adminpack() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "pg_file_sync",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "void"},
 		},
 		{
 			Name: "pg_file_unlink",

--- a/internal/engine/postgresql/contrib/citext.go
+++ b/internal/engine/postgresql/contrib/citext.go
@@ -23,7 +23,7 @@ func Citext() *catalog.Schema {
 			Name: "citext",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "inet"},
+					Type: &ast.TypeName{Name: "character"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "citext"},
@@ -32,7 +32,7 @@ func Citext() *catalog.Schema {
 			Name: "citext",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "character"},
+					Type: &ast.TypeName{Name: "inet"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "citext"},
@@ -307,9 +307,6 @@ func Citext() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "citext"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text[]"},
 		},
@@ -322,6 +319,9 @@ func Citext() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "citext"},
 				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
 			},
 			ReturnType: &ast.TypeName{Name: "text[]"},
 		},
@@ -367,9 +367,6 @@ func Citext() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "citext"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text[]"},
 		},
@@ -381,6 +378,9 @@ func Citext() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "citext"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text[]"},
@@ -485,7 +485,7 @@ func Citext() *catalog.Schema {
 					Type: &ast.TypeName{Name: "citext"},
 				},
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "citext"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -497,7 +497,7 @@ func Citext() *catalog.Schema {
 					Type: &ast.TypeName{Name: "citext"},
 				},
 				{
-					Type: &ast.TypeName{Name: "citext"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},

--- a/internal/engine/postgresql/contrib/cube.go
+++ b/internal/engine/postgresql/contrib/cube.go
@@ -14,31 +14,10 @@ func Cube() *catalog.Schema {
 			Name: "cube",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "double precision"},
+					Type: &ast.TypeName{Name: "cube"},
 				},
 				{
 					Type: &ast.TypeName{Name: "double precision"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "cube"},
-		},
-		{
-			Name: "cube",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "double precision[]"},
-				},
-				{
-					Type: &ast.TypeName{Name: "double precision[]"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "cube"},
-		},
-		{
-			Name: "cube",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "double precision[]"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "cube"},
@@ -71,10 +50,31 @@ func Cube() *catalog.Schema {
 			Name: "cube",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "cube"},
+					Type: &ast.TypeName{Name: "double precision"},
 				},
 				{
 					Type: &ast.TypeName{Name: "double precision"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "cube"},
+		},
+		{
+			Name: "cube",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "double precision[]"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "cube"},
+		},
+		{
+			Name: "cube",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "double precision[]"},
+				},
+				{
+					Type: &ast.TypeName{Name: "double precision[]"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "cube"},

--- a/internal/engine/postgresql/contrib/dblink.go
+++ b/internal/engine/postgresql/contrib/dblink.go
@@ -16,24 +16,6 @@ func Dblink() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "record"},
-		},
-		{
-			Name: "dblink",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "record"},
 		},
@@ -54,6 +36,24 @@ func Dblink() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "dblink",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "record"},
@@ -133,27 +133,12 @@ func Dblink() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "dblink_close",
 			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "dblink_close",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -166,6 +151,21 @@ func Dblink() *catalog.Schema {
 		{
 			Name: "dblink_close",
 			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "dblink_close",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -223,17 +223,17 @@ func Dblink() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
+			Name:       "dblink_disconnect",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
 			Name: "dblink_disconnect",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name:       "dblink_disconnect",
-			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
@@ -314,27 +314,6 @@ func Dblink() *catalog.Schema {
 					Type: &ast.TypeName{Name: "text"},
 				},
 				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "record"},
-		},
-		{
-			Name: "dblink_fetch",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
 					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
@@ -362,7 +341,28 @@ func Dblink() *catalog.Schema {
 					Type: &ast.TypeName{Name: "text"},
 				},
 				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
 					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "dblink_fetch",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "record"},
@@ -387,9 +387,6 @@ func Dblink() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "record"},
 		},
@@ -398,6 +395,9 @@ func Dblink() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "record"},
@@ -420,24 +420,6 @@ func Dblink() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "dblink_open",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
@@ -467,6 +449,24 @@ func Dblink() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "dblink_open",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},

--- a/internal/engine/postgresql/contrib/dblink.go
+++ b/internal/engine/postgresql/contrib/dblink.go
@@ -373,6 +373,21 @@ func Dblink() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "text[]"},
 		},
 		{
+			Name:       "dblink_get_notify",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "dblink_get_notify",
+			Args: []*catalog.Argument{
+				{
+					Name: "conname",
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "dblink_get_pkey",
 			Args: []*catalog.Argument{
 				{

--- a/internal/engine/postgresql/contrib/fuzzystrmatch.go
+++ b/internal/engine/postgresql/contrib/fuzzystrmatch.go
@@ -85,15 +85,6 @@ func Fuzzystrmatch() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "integer"},
 				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
 		},
@@ -105,6 +96,15 @@ func Fuzzystrmatch() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
 				},
 				{
 					Type: &ast.TypeName{Name: "integer"},

--- a/internal/engine/postgresql/contrib/hstore.go
+++ b/internal/engine/postgresql/contrib/hstore.go
@@ -77,6 +77,16 @@ func Hstore() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "hstore"},
 		},
 		{
+			Name: "each",
+			Args: []*catalog.Argument{
+				{
+					Name: "hs",
+					Type: &ast.TypeName{Name: "hstore"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "exist",
 			Args: []*catalog.Argument{
 				{

--- a/internal/engine/postgresql/contrib/hstore.go
+++ b/internal/engine/postgresql/contrib/hstore.go
@@ -47,6 +47,18 @@ func Hstore() *catalog.Schema {
 					Type: &ast.TypeName{Name: "hstore"},
 				},
 				{
+					Type: &ast.TypeName{Name: "hstore"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "hstore"},
+		},
+		{
+			Name: "delete",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "hstore"},
+				},
+				{
 					Type: &ast.TypeName{Name: "text"},
 				},
 			},
@@ -60,18 +72,6 @@ func Hstore() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "text[]"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "hstore"},
-		},
-		{
-			Name: "delete",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "hstore"},
-				},
-				{
-					Type: &ast.TypeName{Name: "hstore"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "hstore"},
@@ -191,6 +191,18 @@ func Hstore() *catalog.Schema {
 			Name: "hstore",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "hstore"},
+		},
+		{
+			Name: "hstore",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "text[]"},
 				},
 			},
@@ -204,18 +216,6 @@ func Hstore() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "text[]"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "hstore"},
-		},
-		{
-			Name: "hstore",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "hstore"},

--- a/internal/engine/postgresql/contrib/intarray.go
+++ b/internal/engine/postgresql/contrib/intarray.go
@@ -301,9 +301,6 @@ func Intarray() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "integer"},
 				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer[]"},
 		},
@@ -312,6 +309,9 @@ func Intarray() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "integer[]"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
 				},
 				{
 					Type: &ast.TypeName{Name: "integer"},

--- a/internal/engine/postgresql/contrib/isn.go
+++ b/internal/engine/postgresql/contrib/isn.go
@@ -29,6 +29,30 @@ func Isn() *catalog.Schema {
 					Type: &ast.TypeName{Name: "ean13"},
 				},
 				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "btean13cmp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "btean13cmp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
 					Type: &ast.TypeName{Name: "ismn"},
 				},
 			},
@@ -41,7 +65,31 @@ func Isn() *catalog.Schema {
 					Type: &ast.TypeName{Name: "ean13"},
 				},
 				{
-					Type: &ast.TypeName{Name: "isbn"},
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "btean13cmp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "btean13cmp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -59,49 +107,13 @@ func Isn() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "integer"},
 		},
 		{
-			Name: "btean13cmp",
+			Name: "btisbn13cmp",
 			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "btean13cmp",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "btean13cmp",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
 				{
 					Type: &ast.TypeName{Name: "isbn13"},
 				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "btean13cmp",
-			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -126,18 +138,6 @@ func Isn() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "btisbn13cmp",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -185,18 +185,6 @@ func Isn() *catalog.Schema {
 					Type: &ast.TypeName{Name: "ismn13"},
 				},
 				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "btismn13cmp",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-				{
 					Type: &ast.TypeName{Name: "ean13"},
 				},
 			},
@@ -209,6 +197,18 @@ func Isn() *catalog.Schema {
 					Type: &ast.TypeName{Name: "ismn13"},
 				},
 				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "btismn13cmp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
 					Type: &ast.TypeName{Name: "ismn13"},
 				},
 			},
@@ -221,6 +221,18 @@ func Isn() *catalog.Schema {
 					Type: &ast.TypeName{Name: "ismn"},
 				},
 				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "btismncmp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+				{
 					Type: &ast.TypeName{Name: "ismn"},
 				},
 			},
@@ -239,18 +251,6 @@ func Isn() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "integer"},
 		},
 		{
-			Name: "btismncmp",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
 			Name: "btissn13cmp",
 			Args: []*catalog.Argument{
 				{
@@ -293,31 +293,31 @@ func Isn() *catalog.Schema {
 					Type: &ast.TypeName{Name: "issn"},
 				},
 				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "btissncmp",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "btissncmp",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-				{
 					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "btissncmp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "btissncmp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -359,7 +359,7 @@ func Isn() *catalog.Schema {
 			Name: "ean13_out",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ismn13"},
+					Type: &ast.TypeName{Name: "ean13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "cstring"},
@@ -377,7 +377,7 @@ func Isn() *catalog.Schema {
 			Name: "ean13_out",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "issn13"},
+					Type: &ast.TypeName{Name: "ismn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "cstring"},
@@ -386,7 +386,7 @@ func Isn() *catalog.Schema {
 			Name: "ean13_out",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ean13"},
+					Type: &ast.TypeName{Name: "issn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "cstring"},
@@ -467,34 +467,7 @@ func Isn() *catalog.Schema {
 			Name: "is_valid",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "is_valid",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "is_valid",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "is_valid",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -512,6 +485,15 @@ func Isn() *catalog.Schema {
 			Name: "is_valid",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "is_valid",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "ismn"},
 				},
 			},
@@ -521,7 +503,25 @@ func Isn() *catalog.Schema {
 			Name: "is_valid",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "is_valid",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "is_valid",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -611,24 +611,6 @@ func Isn() *catalog.Schema {
 			Name: "isn_out",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "cstring"},
-		},
-		{
-			Name: "isn_out",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "upc"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "cstring"},
-		},
-		{
-			Name: "isn_out",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "isbn"},
 				},
 			},
@@ -639,6 +621,24 @@ func Isn() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "ismn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "cstring"},
+		},
+		{
+			Name: "isn_out",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "cstring"},
+		},
+		{
+			Name: "isn_out",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "upc"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "cstring"},
@@ -664,6 +664,90 @@ func Isn() *catalog.Schema {
 					Type: &ast.TypeName{Name: "ean13"},
 				},
 				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isneq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isneq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isneq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isneq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isneq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isneq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isneq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
 					Type: &ast.TypeName{Name: "upc"},
 				},
 			},
@@ -673,115 +757,7 @@ func Isn() *catalog.Schema {
 			Name: "isneq",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isneq",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isneq",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isneq",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isneq",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
 					Type: &ast.TypeName{Name: "isbn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isneq",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isneq",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isneq",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isneq",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isneq",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
 				},
 				{
 					Type: &ast.TypeName{Name: "ean13"},
@@ -817,11 +793,23 @@ func Isn() *catalog.Schema {
 			Name: "isneq",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isneq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+				{
 					Type: &ast.TypeName{Name: "isbn"},
 				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
@@ -829,10 +817,10 @@ func Isn() *catalog.Schema {
 			Name: "isneq",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ismn13"},
+					Type: &ast.TypeName{Name: "isbn13"},
 				},
 				{
-					Type: &ast.TypeName{Name: "ismn13"},
+					Type: &ast.TypeName{Name: "isbn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -840,20 +828,8 @@ func Isn() *catalog.Schema {
 		{
 			Name: "isneq",
 			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
 				{
 					Type: &ast.TypeName{Name: "ismn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isneq",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
 				},
 				{
 					Type: &ast.TypeName{Name: "ean13"},
@@ -889,11 +865,23 @@ func Isn() *catalog.Schema {
 			Name: "isneq",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isneq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
 					Type: &ast.TypeName{Name: "ismn"},
 				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
@@ -901,58 +889,10 @@ func Isn() *catalog.Schema {
 			Name: "isneq",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "issn13"},
+					Type: &ast.TypeName{Name: "ismn13"},
 				},
 				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isneq",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isneq",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isneq",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isneq",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn13"},
+					Type: &ast.TypeName{Name: "ismn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -973,10 +913,58 @@ func Isn() *catalog.Schema {
 			Name: "isneq",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "upc"},
+					Type: &ast.TypeName{Name: "issn"},
 				},
 				{
-					Type: &ast.TypeName{Name: "upc"},
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isneq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isneq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isneq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isneq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -994,10 +982,46 @@ func Isn() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
+			Name: "isneq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "upc"},
+				},
+				{
+					Type: &ast.TypeName{Name: "upc"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
 			Name: "isnge",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnge",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
 					Type: &ast.TypeName{Name: "isbn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnge",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
 				},
 				{
 					Type: &ast.TypeName{Name: "isbn13"},
@@ -1021,34 +1045,10 @@ func Isn() *catalog.Schema {
 			Name: "isnge",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnge",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "ean13"},
 				},
 				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnge",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
+					Type: &ast.TypeName{Name: "ismn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -1069,58 +1069,10 @@ func Isn() *catalog.Schema {
 			Name: "isnge",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnge",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnge",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnge",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "ean13"},
 				},
 				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnge",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn"},
+					Type: &ast.TypeName{Name: "issn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -1141,6 +1093,42 @@ func Isn() *catalog.Schema {
 			Name: "isnge",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnge",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnge",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnge",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "isbn13"},
 				},
 				{
@@ -1153,30 +1141,6 @@ func Isn() *catalog.Schema {
 			Name: "isnge",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnge",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnge",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "isbn13"},
 				},
 				{
@@ -1201,10 +1165,58 @@ func Isn() *catalog.Schema {
 			Name: "isnge",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ean13"},
+					Type: &ast.TypeName{Name: "ismn"},
 				},
 				{
-					Type: &ast.TypeName{Name: "issn13"},
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnge",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnge",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnge",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnge",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -1228,67 +1240,19 @@ func Isn() *catalog.Schema {
 					Type: &ast.TypeName{Name: "issn"},
 				},
 				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnge",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "issn"},
 				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnge",
-			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnge",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnge",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "upc"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnge",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnge",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn"},
+					Type: &ast.TypeName{Name: "issn"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -1312,7 +1276,43 @@ func Isn() *catalog.Schema {
 					Type: &ast.TypeName{Name: "issn13"},
 				},
 				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnge",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
 					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnge",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnge",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "upc"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -1333,139 +1333,7 @@ func Isn() *catalog.Schema {
 			Name: "isngt",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-				{
 					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
 				},
 				{
 					Type: &ast.TypeName{Name: "ean13"},
@@ -1489,23 +1357,11 @@ func Isn() *catalog.Schema {
 			Name: "isngt",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
 					Type: &ast.TypeName{Name: "isbn13"},
 				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
@@ -1525,19 +1381,7 @@ func Isn() *catalog.Schema {
 			Name: "isngt",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-				{
 					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn"},
 				},
 				{
 					Type: &ast.TypeName{Name: "ismn13"},
@@ -1553,6 +1397,18 @@ func Isn() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -1573,70 +1429,10 @@ func Isn() *catalog.Schema {
 			Name: "isngt",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-				{
 					Type: &ast.TypeName{Name: "isbn"},
 				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "upc"},
-				},
 				{
 					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isngt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "upc"},
-				},
-				{
-					Type: &ast.TypeName{Name: "upc"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -1657,6 +1453,222 @@ func Isn() *catalog.Schema {
 			Name: "isngt",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "upc"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isngt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "upc"},
+				},
+				{
+					Type: &ast.TypeName{Name: "upc"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "ean13"},
 				},
 				{
@@ -1669,10 +1681,82 @@ func Isn() *catalog.Schema {
 			Name: "isnle",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "issn13"},
+					Type: &ast.TypeName{Name: "ean13"},
 				},
 				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "upc"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -1693,22 +1777,10 @@ func Isn() *catalog.Schema {
 			Name: "isnle",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ismn13"},
+					Type: &ast.TypeName{Name: "isbn"},
 				},
 				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnle",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn"},
+					Type: &ast.TypeName{Name: "isbn"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -1717,7 +1789,19 @@ func Isn() *catalog.Schema {
 			Name: "isnle",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ismn13"},
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
 				},
 				{
 					Type: &ast.TypeName{Name: "ean13"},
@@ -1729,22 +1813,10 @@ func Isn() *catalog.Schema {
 			Name: "isnle",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ismn"},
+					Type: &ast.TypeName{Name: "isbn13"},
 				},
 				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnle",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
+					Type: &ast.TypeName{Name: "isbn"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -1753,7 +1825,7 @@ func Isn() *catalog.Schema {
 			Name: "isnle",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ean13"},
+					Type: &ast.TypeName{Name: "isbn13"},
 				},
 				{
 					Type: &ast.TypeName{Name: "isbn13"},
@@ -1777,22 +1849,10 @@ func Isn() *catalog.Schema {
 			Name: "isnle",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "issn13"},
+					Type: &ast.TypeName{Name: "ismn"},
 				},
 				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnle",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn"},
+					Type: &ast.TypeName{Name: "ismn"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -1801,10 +1861,10 @@ func Isn() *catalog.Schema {
 			Name: "isnle",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "issn"},
+					Type: &ast.TypeName{Name: "ismn"},
 				},
 				{
-					Type: &ast.TypeName{Name: "issn"},
+					Type: &ast.TypeName{Name: "ismn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -1813,7 +1873,7 @@ func Isn() *catalog.Schema {
 			Name: "isnle",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ean13"},
+					Type: &ast.TypeName{Name: "ismn13"},
 				},
 				{
 					Type: &ast.TypeName{Name: "ean13"},
@@ -1825,6 +1885,54 @@ func Isn() *catalog.Schema {
 			Name: "isnle",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "issn"},
 				},
 				{
@@ -1837,7 +1945,43 @@ func Isn() *catalog.Schema {
 			Name: "isnle",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
 					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnle",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "upc"},
 				},
 				{
 					Type: &ast.TypeName{Name: "ean13"},
@@ -1858,10 +2002,10 @@ func Isn() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "isnle",
+			Name: "isnlt",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "upc"},
+					Type: &ast.TypeName{Name: "ean13"},
 				},
 				{
 					Type: &ast.TypeName{Name: "ean13"},
@@ -1870,10 +2014,10 @@ func Isn() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "isnle",
+			Name: "isnlt",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "isbn13"},
+					Type: &ast.TypeName{Name: "ean13"},
 				},
 				{
 					Type: &ast.TypeName{Name: "isbn"},
@@ -1882,43 +2026,19 @@ func Isn() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "isnle",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnle",
+			Name: "isnlt",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "ean13"},
 				},
 				{
-					Type: &ast.TypeName{Name: "upc"},
+					Type: &ast.TypeName{Name: "isbn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "isnle",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnle",
+			Name: "isnlt",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "ean13"},
@@ -1930,31 +2050,7 @@ func Isn() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "isnle",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnle",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnle",
+			Name: "isnlt",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "ean13"},
@@ -1966,181 +2062,13 @@ func Isn() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "isnle",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnle",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnle",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
 			Name: "isnlt",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-				{
 					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn"},
 				},
 				{
 					Type: &ast.TypeName{Name: "issn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "upc"},
-				},
-				{
-					Type: &ast.TypeName{Name: "upc"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -2153,42 +2081,6 @@ func Isn() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -2209,10 +2101,46 @@ func Isn() *catalog.Schema {
 			Name: "isnlt",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ean13"},
+					Type: &ast.TypeName{Name: "isbn"},
 				},
 				{
-					Type: &ast.TypeName{Name: "ismn13"},
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnlt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnlt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnlt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -2233,10 +2161,58 @@ func Isn() *catalog.Schema {
 			Name: "isnlt",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "issn"},
+					Type: &ast.TypeName{Name: "isbn13"},
 				},
 				{
-					Type: &ast.TypeName{Name: "issn13"},
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnlt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnlt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnlt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnlt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -2249,6 +2225,90 @@ func Isn() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "ismn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnlt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnlt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnlt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnlt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnlt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnlt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnlt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -2269,70 +2329,10 @@ func Isn() *catalog.Schema {
 			Name: "isnlt",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ismn13"},
+					Type: &ast.TypeName{Name: "upc"},
 				},
 				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnlt",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn"},
+					Type: &ast.TypeName{Name: "upc"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -2341,7 +2341,43 @@ func Isn() *catalog.Schema {
 			Name: "isnne",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ismn"},
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
 				},
 				{
 					Type: &ast.TypeName{Name: "ismn"},
@@ -2353,7 +2389,43 @@ func Isn() *catalog.Schema {
 			Name: "isnne",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "upc"},
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ean13"},
 				},
 				{
 					Type: &ast.TypeName{Name: "upc"},
@@ -2377,7 +2449,163 @@ func Isn() *catalog.Schema {
 			Name: "isnne",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "issn13"},
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn"},
 				},
 				{
 					Type: &ast.TypeName{Name: "issn13"},
@@ -2389,10 +2617,34 @@ func Isn() *catalog.Schema {
 			Name: "isnne",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ean13"},
+					Type: &ast.TypeName{Name: "issn13"},
 				},
 				{
 					Type: &ast.TypeName{Name: "ean13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "isnne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "issn13"},
+				},
+				{
+					Type: &ast.TypeName{Name: "issn13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -2413,262 +2665,10 @@ func Isn() *catalog.Schema {
 			Name: "isnne",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
+					Type: &ast.TypeName{Name: "upc"},
 				},
 				{
 					Type: &ast.TypeName{Name: "upc"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "isbn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "isbn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "isnne",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ean13"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -2713,15 +2713,6 @@ func Isn() *catalog.Schema {
 			Name: "make_valid",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "ismn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "ismn13"},
-		},
-		{
-			Name: "make_valid",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "ean13"},
 				},
 			},
@@ -2740,10 +2731,28 @@ func Isn() *catalog.Schema {
 			Name: "make_valid",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "isbn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "isbn13"},
+		},
+		{
+			Name: "make_valid",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "ismn"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "ismn"},
+		},
+		{
+			Name: "make_valid",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ismn13"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "ismn13"},
 		},
 		{
 			Name: "make_valid",
@@ -2758,10 +2767,10 @@ func Isn() *catalog.Schema {
 			Name: "make_valid",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "isbn13"},
+					Type: &ast.TypeName{Name: "issn13"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "isbn13"},
+			ReturnType: &ast.TypeName{Name: "issn13"},
 		},
 		{
 			Name: "make_valid",
@@ -2771,15 +2780,6 @@ func Isn() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "upc"},
-		},
-		{
-			Name: "make_valid",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "issn13"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "issn13"},
 		},
 		{
 			Name: "upc",

--- a/internal/engine/postgresql/contrib/ltree.go
+++ b/internal/engine/postgresql/contrib/ltree.go
@@ -187,9 +187,6 @@ func Ltree() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "ltree"},
 				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
 		},
@@ -202,12 +199,150 @@ func Ltree() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "ltree"},
 				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
 		},
 		{
 			Name: "lca",
 			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "ltree"},
+		},
+		{
+			Name: "lca",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "ltree"},
+		},
+		{
+			Name: "lca",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "ltree"},
+		},
+		{
+			Name: "lca",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "ltree"},
+		},
+		{
+			Name: "lca",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "ltree"},
+		},
+		{
+			Name: "lca",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "ltree"},
+		},
+		{
+			Name: "lca",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
 				{
 					Type: &ast.TypeName{Name: "ltree"},
 				},
@@ -222,141 +357,6 @@ func Ltree() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "ltree[]"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "ltree"},
-		},
-		{
-			Name: "lca",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "ltree"},
-		},
-		{
-			Name: "lca",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "ltree"},
-		},
-		{
-			Name: "lca",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "ltree"},
-		},
-		{
-			Name: "lca",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "ltree"},
-		},
-		{
-			Name: "lca",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "ltree"},
-		},
-		{
-			Name: "lca",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
-				},
-				{
-					Type: &ast.TypeName{Name: "ltree"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "ltree"},
@@ -378,6 +378,15 @@ func Ltree() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "cstring"},
+		},
+		{
+			Name: "lquery_send",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "lquery"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bytea"},
 		},
 		{
 			Name: "lt_q_regex",
@@ -605,6 +614,15 @@ func Ltree() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
+			Name: "ltree_send",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ltree"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bytea"},
+		},
+		{
 			Name: "ltree_textadd",
 			Args: []*catalog.Argument{
 				{
@@ -657,6 +675,15 @@ func Ltree() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "ltxtq_send",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "ltxtquery"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bytea"},
 		},
 		{
 			Name: "nlevel",

--- a/internal/engine/postgresql/contrib/pageinspect.go
+++ b/internal/engine/postgresql/contrib/pageinspect.go
@@ -104,10 +104,6 @@ func Pageinspect() *catalog.Schema {
 					Name: "t_bits",
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Name: "do_detoast",
-					Type: &ast.TypeName{Name: "boolean"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "bytea[]"},
 		},
@@ -133,6 +129,10 @@ func Pageinspect() *catalog.Schema {
 				{
 					Name: "t_bits",
 					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Name: "do_detoast",
+					Type: &ast.TypeName{Name: "boolean"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bytea[]"},

--- a/internal/engine/postgresql/contrib/pageinspect.go
+++ b/internal/engine/postgresql/contrib/pageinspect.go
@@ -11,6 +11,30 @@ func Pageinspect() *catalog.Schema {
 	s := &catalog.Schema{Name: "pg_catalog"}
 	s.Funcs = []*catalog.Function{
 		{
+			Name: "brin_metapage_info",
+			Args: []*catalog.Argument{
+				{
+					Name: "page",
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "brin_page_items",
+			Args: []*catalog.Argument{
+				{
+					Name: "page",
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+				{
+					Name: "index_oid",
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "brin_page_type",
 			Args: []*catalog.Argument{
 				{
@@ -19,6 +43,64 @@ func Pageinspect() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "brin_revmap_data",
+			Args: []*catalog.Argument{
+				{
+					Name: "page",
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "tid"},
+		},
+		{
+			Name: "bt_metap",
+			Args: []*catalog.Argument{
+				{
+					Name: "relname",
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "bt_page_items",
+			Args: []*catalog.Argument{
+				{
+					Name: "page",
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "bt_page_items",
+			Args: []*catalog.Argument{
+				{
+					Name: "relname",
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Name: "blkno",
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "bt_page_stats",
+			Args: []*catalog.Argument{
+				{
+					Name: "relname",
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Name: "blkno",
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "fsm_page_contents",
@@ -58,6 +140,80 @@ func Pageinspect() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "bytea"},
 		},
 		{
+			Name: "gin_leafpage_items",
+			Args: []*catalog.Argument{
+				{
+					Name: "page",
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "gin_metapage_info",
+			Args: []*catalog.Argument{
+				{
+					Name: "page",
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "gin_page_opaque_info",
+			Args: []*catalog.Argument{
+				{
+					Name: "page",
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "hash_bitmap_info",
+			Args: []*catalog.Argument{
+				{
+					Name: "index_oid",
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+				{
+					Name: "blkno",
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "hash_metapage_info",
+			Args: []*catalog.Argument{
+				{
+					Name: "page",
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "hash_page_items",
+			Args: []*catalog.Argument{
+				{
+					Name: "page",
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "hash_page_stats",
+			Args: []*catalog.Argument{
+				{
+					Name: "page",
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "hash_page_type",
 			Args: []*catalog.Argument{
 				{
@@ -66,6 +222,62 @@ func Pageinspect() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "heap_page_item_attrs",
+			Args: []*catalog.Argument{
+				{
+					Name: "page",
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+				{
+					Name: "rel_oid",
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "heap_page_item_attrs",
+			Args: []*catalog.Argument{
+				{
+					Name: "page",
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+				{
+					Name: "rel_oid",
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+				{
+					Name: "do_detoast",
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "heap_page_items",
+			Args: []*catalog.Argument{
+				{
+					Name: "page",
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "heap_tuple_infomask_flags",
+			Args: []*catalog.Argument{
+				{
+					Name: "t_infomask",
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Name: "t_infomask2",
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "page_checksum",
@@ -80,6 +292,16 @@ func Pageinspect() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "smallint"},
+		},
+		{
+			Name: "page_header",
+			Args: []*catalog.Argument{
+				{
+					Name: "page",
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "tuple_data_split",

--- a/internal/engine/postgresql/contrib/pg_stat_statements.go
+++ b/internal/engine/postgresql/contrib/pg_stat_statements.go
@@ -11,6 +11,16 @@ func PgStatStatements() *catalog.Schema {
 	s := &catalog.Schema{Name: "pg_catalog"}
 	s.Funcs = []*catalog.Function{
 		{
+			Name: "pg_stat_statements",
+			Args: []*catalog.Argument{
+				{
+					Name: "showtext",
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "pg_stat_statements_reset",
 			Args: []*catalog.Argument{
 				{

--- a/internal/engine/postgresql/contrib/pg_visibility.go
+++ b/internal/engine/postgresql/contrib/pg_visibility.go
@@ -11,6 +11,24 @@ func PgVisibility() *catalog.Schema {
 	s := &catalog.Schema{Name: "pg_catalog"}
 	s.Funcs = []*catalog.Function{
 		{
+			Name: "pg_check_frozen",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "tid"},
+		},
+		{
+			Name: "pg_check_visible",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "tid"},
+		},
+		{
 			Name: "pg_truncate_visibility_map",
 			Args: []*catalog.Argument{
 				{
@@ -18,6 +36,59 @@ func PgVisibility() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "void"},
+		},
+		{
+			Name: "pg_visibility",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_visibility",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+				{
+					Name: "blkno",
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_visibility_map",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_visibility_map",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+				{
+					Name: "blkno",
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_visibility_map_summary",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 	}
 	return s

--- a/internal/engine/postgresql/contrib/pgcrypto.go
+++ b/internal/engine/postgresql/contrib/pgcrypto.go
@@ -92,7 +92,7 @@ func Pgcrypto() *catalog.Schema {
 			Name: "digest",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bytea"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -104,7 +104,7 @@ func Pgcrypto() *catalog.Schema {
 			Name: "digest",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "bytea"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},

--- a/internal/engine/postgresql/contrib/pgcrypto.go
+++ b/internal/engine/postgresql/contrib/pgcrypto.go
@@ -206,6 +206,15 @@ func Pgcrypto() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "bytea"},
 		},
 		{
+			Name: "pgp_armor_headers",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "pgp_key_id",
 			Args: []*catalog.Argument{
 				{

--- a/internal/engine/postgresql/contrib/pgcrypto.go
+++ b/internal/engine/postgresql/contrib/pgcrypto.go
@@ -16,12 +16,6 @@ func Pgcrypto() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "bytea"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text[]"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text[]"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
@@ -30,6 +24,12 @@ func Pgcrypto() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "bytea"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text[]"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text[]"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -92,7 +92,7 @@ func Pgcrypto() *catalog.Schema {
 			Name: "digest",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "bytea"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -104,7 +104,7 @@ func Pgcrypto() *catalog.Schema {
 			Name: "digest",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bytea"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -155,11 +155,6 @@ func Pgcrypto() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "bytea"},
 		},
 		{
-			Name:       "gen_random_uuid",
-			Args:       []*catalog.Argument{},
-			ReturnType: &ast.TypeName{Name: "uuid"},
-		},
-		{
 			Name: "gen_salt",
 			Args: []*catalog.Argument{
 				{
@@ -184,10 +179,10 @@ func Pgcrypto() *catalog.Schema {
 			Name: "hmac",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "bytea"},
 				},
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "bytea"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -199,10 +194,10 @@ func Pgcrypto() *catalog.Schema {
 			Name: "hmac",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bytea"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
-					Type: &ast.TypeName{Name: "bytea"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -243,9 +238,6 @@ func Pgcrypto() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
@@ -261,6 +253,9 @@ func Pgcrypto() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
@@ -273,24 +268,6 @@ func Pgcrypto() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "bytea"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bytea"},
-		},
-		{
-			Name: "pgp_pub_decrypt_bytea",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "bytea"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bytea"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "bytea"},
 		},
@@ -310,13 +287,16 @@ func Pgcrypto() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "bytea"},
 		},
 		{
-			Name: "pgp_pub_encrypt",
+			Name: "pgp_pub_decrypt_bytea",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "bytea"},
 				},
 				{
 					Type: &ast.TypeName{Name: "bytea"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -332,6 +312,21 @@ func Pgcrypto() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "bytea"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bytea"},
+		},
+		{
+			Name: "pgp_pub_encrypt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bytea"},
@@ -372,9 +367,6 @@ func Pgcrypto() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
@@ -383,6 +375,9 @@ func Pgcrypto() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "bytea"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -426,9 +421,6 @@ func Pgcrypto() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "bytea"},
 		},
@@ -441,6 +433,9 @@ func Pgcrypto() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
 			},
 			ReturnType: &ast.TypeName{Name: "bytea"},
 		},
@@ -453,9 +448,6 @@ func Pgcrypto() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "bytea"},
 		},
@@ -464,6 +456,9 @@ func Pgcrypto() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "bytea"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},

--- a/internal/engine/postgresql/contrib/pgrowlocks.go
+++ b/internal/engine/postgresql/contrib/pgrowlocks.go
@@ -7,30 +7,18 @@ import (
 	"github.com/kyleconroy/sqlc/internal/sql/catalog"
 )
 
-func PgFreespacemap() *catalog.Schema {
+func Pgrowlocks() *catalog.Schema {
 	s := &catalog.Schema{Name: "pg_catalog"}
 	s.Funcs = []*catalog.Function{
 		{
-			Name: "pg_freespace",
+			Name: "pgrowlocks",
 			Args: []*catalog.Argument{
 				{
-					Name: "rel",
-					Type: &ast.TypeName{Name: "regclass"},
+					Name: "relname",
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "record"},
-		},
-		{
-			Name: "pg_freespace",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "regclass"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "smallint"},
 		},
 	}
 	return s

--- a/internal/engine/postgresql/contrib/pgstattuple.go
+++ b/internal/engine/postgresql/contrib/pgstattuple.go
@@ -30,6 +30,76 @@ func Pgstattuple() *catalog.Schema {
 			},
 			ReturnType: &ast.TypeName{Name: "bigint"},
 		},
+		{
+			Name: "pgstatginindex",
+			Args: []*catalog.Argument{
+				{
+					Name: "relname",
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pgstathashindex",
+			Args: []*catalog.Argument{
+				{
+					Name: "relname",
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pgstatindex",
+			Args: []*catalog.Argument{
+				{
+					Name: "relname",
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pgstatindex",
+			Args: []*catalog.Argument{
+				{
+					Name: "relname",
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pgstattuple",
+			Args: []*catalog.Argument{
+				{
+					Name: "reloid",
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pgstattuple",
+			Args: []*catalog.Argument{
+				{
+					Name: "relname",
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pgstattuple_approx",
+			Args: []*catalog.Argument{
+				{
+					Name: "reloid",
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
 	}
 	return s
 }

--- a/internal/engine/postgresql/contrib/pgstattuple.go
+++ b/internal/engine/postgresql/contrib/pgstattuple.go
@@ -15,7 +15,7 @@ func Pgstattuple() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Name: "relname",
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "regclass"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bigint"},
@@ -25,7 +25,7 @@ func Pgstattuple() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Name: "relname",
-					Type: &ast.TypeName{Name: "regclass"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bigint"},

--- a/internal/engine/postgresql/contrib/sslinfo.go
+++ b/internal/engine/postgresql/contrib/sslinfo.go
@@ -40,6 +40,11 @@ func Sslinfo() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
+			Name:       "ssl_extension_info",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name:       "ssl_is_used",
 			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "boolean"},

--- a/internal/engine/postgresql/contrib/tablefunc.go
+++ b/internal/engine/postgresql/contrib/tablefunc.go
@@ -112,9 +112,6 @@ func Tablefunc() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "record"},
 		},
@@ -123,6 +120,9 @@ func Tablefunc() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "record"},

--- a/internal/engine/postgresql/contrib/xml2.go
+++ b/internal/engine/postgresql/contrib/xml2.go
@@ -49,9 +49,6 @@ func Xml2() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
@@ -64,21 +61,6 @@ func Xml2() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "xpath_nodeset",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -100,6 +82,24 @@ func Xml2() *catalog.Schema {
 		{
 			Name: "xpath_nodeset",
 			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "xpath_nodeset",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -166,15 +166,15 @@ func Xml2() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "xslt_process",
 			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},

--- a/internal/engine/postgresql/extension.go
+++ b/internal/engine/postgresql/extension.go
@@ -51,6 +51,8 @@ func loadExtension(name string) *catalog.Schema {
 		return contrib.PgFreespacemap()
 	case "pg_prewarm":
 		return contrib.PgPrewarm()
+	case "pgrowlocks":
+		return contrib.Pgrowlocks()
 	case "pg_stat_statements":
 		return contrib.PgStatStatements()
 	case "pgstattuple":

--- a/internal/engine/postgresql/pg_catalog.go
+++ b/internal/engine/postgresql/pg_catalog.go
@@ -167,6 +167,16 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "aclitem[]"},
 		},
 		{
+			Name: "aclexplode",
+			Args: []*catalog.Argument{
+				{
+					Name: "acl",
+					Type: &ast.TypeName{Name: "aclitem[]"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "aclinsert",
 			Args: []*catalog.Argument{
 				{
@@ -4141,6 +4151,29 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
+			Name: "concat",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "any"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "concat_ws",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "any"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
 			Name: "convert",
 			Args: []*catalog.Argument{
 				{
@@ -4304,6 +4337,16 @@ func genPGCatalog() *catalog.Schema {
 		{
 			Name:       "cume_dist",
 			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "cume_dist",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "any"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
 			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
@@ -5100,6 +5143,16 @@ func genPGCatalog() *catalog.Schema {
 		{
 			Name:       "dense_rank",
 			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name: "dense_rank",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "any"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
 			ReturnType: &ast.TypeName{Name: "bigint"},
 		},
 		{
@@ -6769,6 +6822,19 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "format",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "any"},
+					Mode: ast.FuncParamVariadic,
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -11891,6 +11957,26 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
+			Name: "json_array_elements",
+			Args: []*catalog.Argument{
+				{
+					Name: "from_json",
+					Type: &ast.TypeName{Name: "json"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "json"},
+		},
+		{
+			Name: "json_array_elements_text",
+			Args: []*catalog.Argument{
+				{
+					Name: "from_json",
+					Type: &ast.TypeName{Name: "json"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
 			Name: "json_array_length",
 			Args: []*catalog.Argument{
 				{
@@ -11905,9 +11991,79 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "json"},
 		},
 		{
+			Name: "json_build_array",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "any"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "json"},
+		},
+		{
 			Name:       "json_build_object",
 			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "json"},
+		},
+		{
+			Name: "json_build_object",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "any"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "json"},
+		},
+		{
+			Name: "json_each",
+			Args: []*catalog.Argument{
+				{
+					Name: "from_json",
+					Type: &ast.TypeName{Name: "json"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "json_each_text",
+			Args: []*catalog.Argument{
+				{
+					Name: "from_json",
+					Type: &ast.TypeName{Name: "json"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "json_extract_path",
+			Args: []*catalog.Argument{
+				{
+					Name: "from_json",
+					Type: &ast.TypeName{Name: "json"},
+				},
+				{
+					Name: "path_elems",
+					Type: &ast.TypeName{Name: "text[]"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "json"},
+		},
+		{
+			Name: "json_extract_path_text",
+			Args: []*catalog.Argument{
+				{
+					Name: "from_json",
+					Type: &ast.TypeName{Name: "json"},
+				},
+				{
+					Name: "path_elems",
+					Type: &ast.TypeName{Name: "text[]"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "json_in",
@@ -12145,6 +12301,26 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
+			Name: "jsonb_array_elements",
+			Args: []*catalog.Argument{
+				{
+					Name: "from_json",
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "jsonb"},
+		},
+		{
+			Name: "jsonb_array_elements_text",
+			Args: []*catalog.Argument{
+				{
+					Name: "from_json",
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
 			Name: "jsonb_array_length",
 			Args: []*catalog.Argument{
 				{
@@ -12159,8 +12335,28 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "jsonb"},
 		},
 		{
+			Name: "jsonb_build_array",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "any"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "jsonb"},
+		},
+		{
 			Name:       "jsonb_build_object",
 			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "jsonb"},
+		},
+		{
+			Name: "jsonb_build_object",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "any"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
 			ReturnType: &ast.TypeName{Name: "jsonb"},
 		},
 		{
@@ -12236,6 +12432,21 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "jsonb"},
 		},
 		{
+			Name: "jsonb_delete",
+			Args: []*catalog.Argument{
+				{
+					Name: "from_json",
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name: "path_elems",
+					Type: &ast.TypeName{Name: "text[]"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "jsonb"},
+		},
+		{
 			Name: "jsonb_delete_path",
 			Args: []*catalog.Argument{
 				{
@@ -12246,6 +12457,26 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "jsonb"},
+		},
+		{
+			Name: "jsonb_each",
+			Args: []*catalog.Argument{
+				{
+					Name: "from_json",
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "jsonb_each_text",
+			Args: []*catalog.Argument{
+				{
+					Name: "from_json",
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "jsonb_eq",
@@ -12294,6 +12525,36 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "jsonb_extract_path",
+			Args: []*catalog.Argument{
+				{
+					Name: "from_json",
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name: "path_elems",
+					Type: &ast.TypeName{Name: "text[]"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "jsonb"},
+		},
+		{
+			Name: "jsonb_extract_path_text",
+			Args: []*catalog.Argument{
+				{
+					Name: "from_json",
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name: "path_elems",
+					Type: &ast.TypeName{Name: "text[]"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "jsonb_ge",
@@ -15588,6 +15849,26 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "integer"},
 		},
 		{
+			Name: "num_nonnulls",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "any"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "num_nulls",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "any"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
 			Name: "numeric",
 			Args: []*catalog.Argument{
 				{
@@ -16988,6 +17269,16 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
+			Name: "percent_rank",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "any"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
 			Name: "percentile_cont",
 			Args: []*catalog.Argument{
 				{
@@ -17191,6 +17482,16 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "void"},
 		},
 		{
+			Name:       "pg_available_extension_versions",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_available_extensions",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name:       "pg_backend_pid",
 			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -17289,6 +17590,31 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
 		},
 		{
+			Name:       "pg_config",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_control_checkpoint",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_control_init",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_control_recovery",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_control_system",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "pg_conversion_is_visible",
 			Args: []*catalog.Argument{
 				{
@@ -17296,6 +17622,131 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "pg_copy_logical_replication_slot",
+			Args: []*catalog.Argument{
+				{
+					Name: "src_slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name: "dst_slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_copy_logical_replication_slot",
+			Args: []*catalog.Argument{
+				{
+					Name: "src_slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name: "dst_slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name: "temporary",
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_copy_logical_replication_slot",
+			Args: []*catalog.Argument{
+				{
+					Name: "src_slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name: "dst_slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name: "temporary",
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+				{
+					Name: "plugin",
+					Type: &ast.TypeName{Name: "name"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_copy_physical_replication_slot",
+			Args: []*catalog.Argument{
+				{
+					Name: "src_slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name: "dst_slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_copy_physical_replication_slot",
+			Args: []*catalog.Argument{
+				{
+					Name: "src_slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name: "dst_slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name: "temporary",
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_create_logical_replication_slot",
+			Args: []*catalog.Argument{
+				{
+					Name: "slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name: "plugin",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name:       "temporary",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_create_physical_replication_slot",
+			Args: []*catalog.Argument{
+				{
+					Name: "slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name:       "immediately_reserve",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "boolean"},
+				},
+				{
+					Name:       "temporary",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "pg_create_restore_point",
@@ -17349,6 +17800,11 @@ func genPGCatalog() *catalog.Schema {
 			Name:       "pg_current_xact_id_if_assigned",
 			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "xid8"},
+		},
+		{
+			Name:       "pg_cursor",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "pg_database_size",
@@ -17465,6 +17921,21 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "name"},
 		},
 		{
+			Name:       "pg_event_trigger_ddl_commands",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_event_trigger_dropped_objects",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_event_trigger_table_rewrite_oid",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "oid"},
+		},
+		{
 			Name:       "pg_event_trigger_table_rewrite_reason",
 			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -17485,6 +17956,16 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "void"},
+		},
+		{
+			Name: "pg_extension_update_paths",
+			Args: []*catalog.Argument{
+				{
+					Name: "name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "pg_file_rename",
@@ -17688,6 +18169,39 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
+			Name:       "pg_get_keywords",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_get_multixact_members",
+			Args: []*catalog.Argument{
+				{
+					Name: "multixid",
+					Type: &ast.TypeName{Name: "xid"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_get_object_address",
+			Args: []*catalog.Argument{
+				{
+					Name: "type",
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Name: "object_names",
+					Type: &ast.TypeName{Name: "text[]"},
+				},
+				{
+					Name: "object_args",
+					Type: &ast.TypeName{Name: "text[]"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "pg_get_partition_constraintdef",
 			Args: []*catalog.Argument{
 				{
@@ -17706,6 +18220,16 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
+			Name: "pg_get_publication_tables",
+			Args: []*catalog.Argument{
+				{
+					Name: "pubname",
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "oid"},
+		},
+		{
 			Name: "pg_get_replica_identity_index",
 			Args: []*catalog.Argument{
 				{
@@ -17713,6 +18237,11 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "regclass"},
+		},
+		{
+			Name:       "pg_get_replication_slots",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "pg_get_ruledef",
@@ -17746,6 +18275,11 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name:       "pg_get_shmem_allocations",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "pg_get_statisticsobjdef",
@@ -17925,6 +18459,47 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
+			Name:       "pg_hba_file_rules",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_identify_object",
+			Args: []*catalog.Argument{
+				{
+					Name: "classid",
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Name: "objid",
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Name: "objsubid",
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_identify_object_as_address",
+			Args: []*catalog.Argument{
+				{
+					Name: "classid",
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Name: "objid",
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Name: "objsubid",
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "pg_import_system_collations",
 			Args: []*catalog.Argument{
 				{
@@ -18035,6 +18610,11 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
+			Name:       "pg_last_committed_xact",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name:       "pg_last_wal_receive_lsn",
 			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "pg_lsn"},
@@ -18053,6 +18633,11 @@ func genPGCatalog() *catalog.Schema {
 			Name:       "pg_listening_channels",
 			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name:       "pg_lock_status",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name:       "pg_logdir_ls",
@@ -18090,6 +18675,107 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "pg_lsn"},
 		},
 		{
+			Name: "pg_logical_slot_get_binary_changes",
+			Args: []*catalog.Argument{
+				{
+					Name: "slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name: "upto_lsn",
+					Type: &ast.TypeName{Name: "pg_lsn"},
+				},
+				{
+					Name: "upto_nchanges",
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Name:       "options",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "text[]"},
+					Mode:       ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_logical_slot_get_changes",
+			Args: []*catalog.Argument{
+				{
+					Name: "slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name: "upto_lsn",
+					Type: &ast.TypeName{Name: "pg_lsn"},
+				},
+				{
+					Name: "upto_nchanges",
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Name:       "options",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "text[]"},
+					Mode:       ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_logical_slot_peek_binary_changes",
+			Args: []*catalog.Argument{
+				{
+					Name: "slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name: "upto_lsn",
+					Type: &ast.TypeName{Name: "pg_lsn"},
+				},
+				{
+					Name: "upto_nchanges",
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Name:       "options",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "text[]"},
+					Mode:       ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_logical_slot_peek_changes",
+			Args: []*catalog.Argument{
+				{
+					Name: "slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name: "upto_lsn",
+					Type: &ast.TypeName{Name: "pg_lsn"},
+				},
+				{
+					Name: "upto_nchanges",
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Name:       "options",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "text[]"},
+					Mode:       ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_ls_archive_statusdir",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "pg_ls_dir",
 			Args: []*catalog.Argument{
 				{
@@ -18112,6 +18798,31 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name:       "pg_ls_logdir",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_ls_tmpdir",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_ls_tmpdir",
+			Args: []*catalog.Argument{
+				{
+					Name: "tablespace",
+					Type: &ast.TypeName{Name: "oid"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_ls_waldir",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "pg_lsn_cmp",
@@ -18291,6 +19002,16 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "pg_mcv_list"},
 		},
 		{
+			Name: "pg_mcv_list_items",
+			Args: []*catalog.Argument{
+				{
+					Name: "mcv_list",
+					Type: &ast.TypeName{Name: "pg_mcv_list"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "pg_mcv_list_out",
 			Args: []*catalog.Argument{
 				{
@@ -18427,6 +19148,26 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
+			Name: "pg_options_to_table",
+			Args: []*catalog.Argument{
+				{
+					Name: "options_array",
+					Type: &ast.TypeName{Name: "text[]"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_partition_ancestors",
+			Args: []*catalog.Argument{
+				{
+					Name: "partitionid",
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "regclass"},
+		},
+		{
 			Name: "pg_partition_root",
 			Args: []*catalog.Argument{
 				{
@@ -18436,9 +19177,29 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "regclass"},
 		},
 		{
+			Name: "pg_partition_tree",
+			Args: []*catalog.Argument{
+				{
+					Name: "rootrelid",
+					Type: &ast.TypeName{Name: "regclass"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name:       "pg_postmaster_start_time",
 			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
+		},
+		{
+			Name:       "pg_prepared_statement",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_prepared_xact",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "pg_promote",
@@ -18717,6 +19478,20 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "void"},
 		},
 		{
+			Name: "pg_replication_slot_advance",
+			Args: []*catalog.Argument{
+				{
+					Name: "slot_name",
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Name: "upto_lsn",
+					Type: &ast.TypeName{Name: "pg_lsn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name:       "pg_rotate_logfile",
 			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -18743,6 +19518,31 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name: "pg_sequence_parameters",
+			Args: []*catalog.Argument{
+				{
+					Name: "sequence_oid",
+					Type: &ast.TypeName{Name: "oid"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_show_all_file_settings",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_show_all_settings",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_show_replication_origin_status",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "pg_size_bytes",
@@ -18878,6 +19678,40 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "void"},
 		},
 		{
+			Name: "pg_stat_file",
+			Args: []*catalog.Argument{
+				{
+					Name: "filename",
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_stat_file",
+			Args: []*catalog.Argument{
+				{
+					Name: "filename",
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Name: "missing_ok",
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "pg_stat_get_activity",
+			Args: []*catalog.Argument{
+				{
+					Name: "pid",
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "pg_stat_get_analyze_count",
 			Args: []*catalog.Argument{
 				{
@@ -18885,6 +19719,11 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name:       "pg_stat_get_archiver",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "pg_stat_get_autoanalyze_count",
@@ -19406,9 +20245,34 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "bigint"},
 		},
 		{
+			Name: "pg_stat_get_progress_info",
+			Args: []*catalog.Argument{
+				{
+					Name: "cmdtype",
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_stat_get_slru",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name:       "pg_stat_get_snapshot_timestamp",
 			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
+		},
+		{
+			Name: "pg_stat_get_subscription",
+			Args: []*catalog.Argument{
+				{
+					Name: "subid",
+					Type: &ast.TypeName{Name: "oid"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "pg_stat_get_tuples_deleted",
@@ -19472,6 +20336,16 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name:       "pg_stat_get_wal_receiver",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_stat_get_wal_senders",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "pg_stat_get_xact_blocks_fetched",
@@ -19637,6 +20511,21 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "pg_lsn"},
 		},
 		{
+			Name: "pg_stop_backup",
+			Args: []*catalog.Argument{
+				{
+					Name: "exclusive",
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+				{
+					Name:       "wait_for_archive",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name:       "pg_switch_wal",
 			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "pg_lsn"},
@@ -19703,6 +20592,16 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name:       "pg_timezone_abbrevs",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name:       "pg_timezone_names",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "pg_total_relation_size",
@@ -19898,6 +20797,16 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "pg_walfile_name_offset",
+			Args: []*catalog.Argument{
+				{
+					Name: "lsn",
+					Type: &ast.TypeName{Name: "pg_lsn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "pg_xact_commit_timestamp",
@@ -21021,6 +21930,16 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "bigint"},
 		},
 		{
+			Name: "rank",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "any"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
 			Name: "record_eq",
 			Args: []*catalog.Argument{
 				{
@@ -21921,6 +22840,25 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "satisfies_hash_partition",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "any"},
+					Mode: ast.FuncParamVariadic,
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
 			Name: "scale",
@@ -25410,6 +26348,30 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
+			Name: "ts_debug",
+			Args: []*catalog.Argument{
+				{
+					Name: "config",
+					Type: &ast.TypeName{Name: "regconfig"},
+				},
+				{
+					Name: "document",
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "ts_debug",
+			Args: []*catalog.Argument{
+				{
+					Name: "document",
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "ts_delete",
 			Args: []*catalog.Argument{
 				{
@@ -25686,6 +26648,34 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
+			Name: "ts_parse",
+			Args: []*catalog.Argument{
+				{
+					Name: "parser_oid",
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Name: "txt",
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "ts_parse",
+			Args: []*catalog.Argument{
+				{
+					Name: "parser_name",
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Name: "txt",
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
 			Name: "ts_rank",
 			Args: []*catalog.Argument{
 				{
@@ -25831,6 +26821,50 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "tsquery"},
+		},
+		{
+			Name: "ts_stat",
+			Args: []*catalog.Argument{
+				{
+					Name: "query",
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "ts_stat",
+			Args: []*catalog.Argument{
+				{
+					Name: "query",
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Name: "weights",
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "ts_token_type",
+			Args: []*catalog.Argument{
+				{
+					Name: "parser_oid",
+					Type: &ast.TypeName{Name: "oid"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
+		},
+		{
+			Name: "ts_token_type",
+			Args: []*catalog.Argument{
+				{
+					Name: "parser_name",
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "tsm_handler_in",
@@ -26395,6 +27429,16 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "anyelement"},
+		},
+		{
+			Name: "unnest",
+			Args: []*catalog.Argument{
+				{
+					Name: "tsvector",
+					Type: &ast.TypeName{Name: "tsvector"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "record"},
 		},
 		{
 			Name: "upper",

--- a/internal/engine/postgresql/pg_catalog.go
+++ b/internal/engine/postgresql/pg_catalog.go
@@ -4151,16 +4151,6 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
-			Name: "concat",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "any"},
-					Mode: ast.FuncParamVariadic,
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
 			Name: "concat_ws",
 			Args: []*catalog.Argument{
 				{
@@ -6896,60 +6886,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "generate_series",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bigint"},
-		},
-		{
-			Name: "generate_series",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bigint"},
-		},
-		{
-			Name: "generate_series",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "generate_series",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "generate_series",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "numeric"},
 				},
 				{
@@ -6957,6 +6893,60 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "generate_series",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name: "generate_series",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name: "generate_series",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "generate_series",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
 		},
 		{
 			Name: "generate_series",
@@ -13924,19 +13914,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "lower",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "anyrange"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "anyelement"},
+			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "lower",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "anyrange"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "text"},
+			ReturnType: &ast.TypeName{Name: "anyelement"},
 		},
 		{
 			Name: "lower_inc",

--- a/internal/engine/postgresql/pg_catalog.go
+++ b/internal/engine/postgresql/pg_catalog.go
@@ -15199,12 +15199,8 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "smallint"},
 		},
 		{
-			Name: "mode",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "anyelement"},
-				},
-			},
+			Name:       "mode",
+			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "anyelement"},
 		},
 		{
@@ -17284,9 +17280,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "double precision"},
 				},
-				{
-					Type: &ast.TypeName{Name: "double precision"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
@@ -17295,9 +17288,6 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "double precision[]"},
-				},
-				{
-					Type: &ast.TypeName{Name: "double precision"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "double precision[]"},
@@ -17308,9 +17298,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "double precision"},
 				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "interval"},
 		},
@@ -17319,9 +17306,6 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "double precision[]"},
-				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "interval[]"},
@@ -17332,9 +17316,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "double precision[]"},
 				},
-				{
-					Type: &ast.TypeName{Name: "anyelement"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "anyarray"},
 		},
@@ -17343,9 +17324,6 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "double precision"},
-				},
-				{
-					Type: &ast.TypeName{Name: "anyelement"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "anyelement"},

--- a/internal/engine/postgresql/pg_catalog.go
+++ b/internal/engine/postgresql/pg_catalog.go
@@ -74,7 +74,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "abbrev",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "inet"},
+					Type: &ast.TypeName{Name: "cidr"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -83,10 +83,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "abbrev",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "cidr"},
+					Type: &ast.TypeName{Name: "inet"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "abs",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
 		},
 		{
 			Name: "abs",
@@ -110,15 +119,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "abs",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "smallint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "smallint"},
-		},
-		{
-			Name: "abs",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "numeric"},
 				},
 			},
@@ -128,19 +128,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "abs",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bigint"},
+					Type: &ast.TypeName{Name: "real"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "bigint"},
+			ReturnType: &ast.TypeName{Name: "real"},
 		},
 		{
 			Name: "abs",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "real"},
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "real"},
+			ReturnType: &ast.TypeName{Name: "smallint"},
 		},
 		{
 			Name: "aclcontains",
@@ -251,36 +251,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "age",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "interval"},
-		},
-		{
-			Name: "age",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "interval"},
-		},
-		{
-			Name: "age",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "interval"},
-		},
-		{
-			Name: "age",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "xid"},
 				},
 			},
@@ -292,8 +262,38 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "timestamp without time zone"},
 				},
+			},
+			ReturnType: &ast.TypeName{Name: "interval"},
+		},
+		{
+			Name: "age",
+			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "interval"},
+		},
+		{
+			Name: "age",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "interval"},
+		},
+		{
+			Name: "age",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "interval"},
@@ -351,6 +351,93 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bytea"},
+		},
+		{
+			Name: "anycompatible_in",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "cstring"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "anycompatible"},
+		},
+		{
+			Name: "anycompatible_out",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "anycompatible"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "cstring"},
+		},
+		{
+			Name: "anycompatiblearray_in",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "cstring"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "anycompatiblearray"},
+		},
+		{
+			Name: "anycompatiblearray_out",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "anycompatiblearray"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "cstring"},
+		},
+		{
+			Name: "anycompatiblearray_send",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "anycompatiblearray"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bytea"},
+		},
+		{
+			Name: "anycompatiblenonarray_in",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "cstring"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "anycompatiblenonarray"},
+		},
+		{
+			Name: "anycompatiblenonarray_out",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "anycompatiblenonarray"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "cstring"},
+		},
+		{
+			Name: "anycompatiblerange_in",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "cstring"},
+				},
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "anycompatiblerange"},
+		},
+		{
+			Name: "anycompatiblerange_out",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "anycompatiblerange"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "cstring"},
 		},
 		{
 			Name: "anyelement_in",
@@ -446,6 +533,15 @@ func genPGCatalog() *catalog.Schema {
 			Name: "area",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "box"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "area",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "circle"},
 				},
 			},
@@ -456,15 +552,6 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "path"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
-		},
-		{
-			Name: "area",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "box"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "double precision"},
@@ -541,9 +628,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "integer[]"},
 				},
-				{
-					Type: &ast.TypeName{Name: "integer[]"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "anyarray"},
 		},
@@ -552,6 +636,9 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "anyelement"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer[]"},
 				},
 				{
 					Type: &ast.TypeName{Name: "integer[]"},
@@ -697,9 +784,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "anyelement"},
 				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
 		},
@@ -711,6 +795,9 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "anyelement"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -793,9 +880,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "anyarray"},
 				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "json"},
 		},
@@ -805,6 +889,9 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "anyarray"},
 				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
 			},
 			ReturnType: &ast.TypeName{Name: "json"},
 		},
@@ -813,9 +900,6 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "anyarray"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -828,6 +912,9 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "anyarray"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -983,10 +1070,28 @@ func genPGCatalog() *catalog.Schema {
 			Name: "avg",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "double precision"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "avg",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "real"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "avg",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "interval"},
 		},
 		{
 			Name: "avg",
@@ -1001,19 +1106,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "avg",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "double precision"},
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
-		},
-		{
-			Name: "avg",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "interval"},
+			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
 			Name: "avg",
@@ -1032,15 +1128,6 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "avg",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "real"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
 			Name: "binary_upgrade_create_empty_extension",
@@ -1181,10 +1268,13 @@ func genPGCatalog() *catalog.Schema {
 			Name: "bit",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "bit"},
 				},
 				{
 					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bit"},
@@ -1193,13 +1283,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "bit",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bit"},
-				},
-				{
 					Type: &ast.TypeName{Name: "integer"},
 				},
 				{
-					Type: &ast.TypeName{Name: "boolean"},
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bit"},
@@ -1217,10 +1304,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "bit_and",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "smallint"},
+					Type: &ast.TypeName{Name: "bit"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "smallint"},
+			ReturnType: &ast.TypeName{Name: "bit"},
 		},
 		{
 			Name: "bit_and",
@@ -1235,10 +1322,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "bit_and",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bit"},
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "bit"},
+			ReturnType: &ast.TypeName{Name: "smallint"},
 		},
 		{
 			Name: "bit_in",
@@ -1286,19 +1373,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "bit_or",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "smallint"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "smallint"},
-		},
-		{
-			Name: "bit_or",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
+			ReturnType: &ast.TypeName{Name: "bigint"},
 		},
 		{
 			Name: "bit_or",
@@ -1313,10 +1391,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "bit_or",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bigint"},
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "bigint"},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "bit_or",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "smallint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "smallint"},
 		},
 		{
 			Name: "bit_out",
@@ -1523,7 +1610,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "bool",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "jsonb"},
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -1532,7 +1619,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "bool",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "jsonb"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -1694,37 +1781,37 @@ func genPGCatalog() *catalog.Schema {
 			Name: "box",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "polygon"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "box"},
-		},
-		{
-			Name: "box",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "point"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "box"},
-		},
-		{
-			Name: "box",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "point"},
-				},
-				{
-					Type: &ast.TypeName{Name: "point"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "box"},
-		},
-		{
-			Name: "box",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "circle"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "box"},
+		},
+		{
+			Name: "box",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "point"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "box"},
+		},
+		{
+			Name: "box",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "point"},
+				},
+				{
+					Type: &ast.TypeName{Name: "point"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "box"},
+		},
+		{
+			Name: "box",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "polygon"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "box"},
@@ -2081,6 +2168,15 @@ func genPGCatalog() *catalog.Schema {
 			Name: "bpchar",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "char"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "character"},
+		},
+		{
+			Name: "bpchar",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "character"},
 				},
 				{
@@ -2097,15 +2193,6 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "name"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "character"},
-		},
-		{
-			Name: "bpchar",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "char"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "character"},
@@ -2504,6 +2591,15 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "integer"},
 		},
 		{
+			Name: "btequalimage",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
 			Name: "btfloat48cmp",
 			Args: []*catalog.Argument{
 				{
@@ -2735,27 +2831,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "btrim",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "btrim",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "btrim",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "bytea"},
 				},
 				{
@@ -2763,6 +2838,27 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bytea"},
+		},
+		{
+			Name: "btrim",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "btrim",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "bttext_pattern_cmp",
@@ -2811,6 +2907,15 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "btvarstrequalimage",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
 			Name: "byteacat",
@@ -3281,19 +3386,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "ceil",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
+					Type: &ast.TypeName{Name: "double precision"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
+			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
 			Name: "ceil",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "double precision"},
+					Type: &ast.TypeName{Name: "numeric"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
+			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
 			Name: "ceiling",
@@ -3335,7 +3440,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "char",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "char"},
@@ -3344,7 +3449,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "char",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "char"},
@@ -3572,10 +3677,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "circle",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "point"},
-				},
-				{
-					Type: &ast.TypeName{Name: "double precision"},
+					Type: &ast.TypeName{Name: "box"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "circle"},
@@ -3584,7 +3686,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "circle",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "box"},
+					Type: &ast.TypeName{Name: "point"},
+				},
+				{
+					Type: &ast.TypeName{Name: "double precision"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "circle"},
@@ -4132,17 +4237,17 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
+			Name:       "count",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
 			Name: "count",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "any"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "bigint"},
-		},
-		{
-			Name:       "count",
-			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "bigint"},
 		},
 		{
@@ -4231,9 +4336,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
@@ -4242,6 +4344,9 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -4390,7 +4495,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "date",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "date"},
@@ -4399,7 +4504,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "date",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "date"},
@@ -4729,31 +4834,7 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "text"},
 				},
 				{
-					Type: &ast.TypeName{Name: "time with time zone"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
-		},
-		{
-			Name: "date_part",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
-		},
-		{
-			Name: "date_part",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "time without time zone"},
+					Type: &ast.TypeName{Name: "date"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "double precision"},
@@ -4777,7 +4858,7 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "text"},
 				},
 				{
-					Type: &ast.TypeName{Name: "date"},
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "double precision"},
@@ -4790,6 +4871,30 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "date_part",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "time without time zone"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "date_part",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "time with time zone"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "double precision"},
@@ -4846,6 +4951,18 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "text"},
 				},
 				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "interval"},
+		},
+		{
+			Name: "date_trunc",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
 					Type: &ast.TypeName{Name: "timestamp without time zone"},
 				},
 			},
@@ -4877,18 +4994,6 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
-		},
-		{
-			Name: "date_trunc",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "interval"},
 		},
 		{
 			Name: "daterange",
@@ -5025,6 +5130,42 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
+			Name: "dist_bl",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "box"},
+				},
+				{
+					Type: &ast.TypeName{Name: "line"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "dist_bp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "box"},
+				},
+				{
+					Type: &ast.TypeName{Name: "point"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "dist_bs",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "box"},
+				},
+				{
+					Type: &ast.TypeName{Name: "lseg"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
 			Name: "dist_cpoint",
 			Args: []*catalog.Argument{
 				{
@@ -5061,6 +5202,42 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
+			Name: "dist_lp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "line"},
+				},
+				{
+					Type: &ast.TypeName{Name: "point"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "dist_ls",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "line"},
+				},
+				{
+					Type: &ast.TypeName{Name: "lseg"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "dist_pathp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "path"},
+				},
+				{
+					Type: &ast.TypeName{Name: "point"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
 			Name: "dist_pb",
 			Args: []*catalog.Argument{
 				{
@@ -5092,6 +5269,18 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "line"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "dist_polyc",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "polygon"},
+				},
+				{
+					Type: &ast.TypeName{Name: "circle"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "double precision"},
@@ -5164,6 +5353,18 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "line"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "dist_sp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "lseg"},
+				},
+				{
+					Type: &ast.TypeName{Name: "point"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "double precision"},
@@ -5547,24 +5748,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "float4",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "smallint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "real"},
-		},
-		{
-			Name: "float4",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "jsonb"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "real"},
-		},
-		{
-			Name: "float4",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
@@ -5574,7 +5757,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "float4",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
+					Type: &ast.TypeName{Name: "double precision"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "real"},
@@ -5592,7 +5775,25 @@ func genPGCatalog() *catalog.Schema {
 			Name: "float4",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "double precision"},
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "real"},
+		},
+		{
+			Name: "float4",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "real"},
+		},
+		{
+			Name: "float4",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "real"},
@@ -5931,24 +6132,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "float8",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "smallint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
-		},
-		{
-			Name: "float8",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "jsonb"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
-		},
-		{
-			Name: "float8",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
@@ -5967,7 +6150,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "float8",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "real"},
+					Type: &ast.TypeName{Name: "jsonb"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "double precision"},
@@ -5977,6 +6160,24 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "float8",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "real"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "float8",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "double precision"},
@@ -6585,6 +6786,86 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
+			Name: "gcd",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name: "gcd",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "gcd",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name:       "gen_random_uuid",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "uuid"},
+		},
+		{
+			Name: "generate_series",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name: "generate_series",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name: "generate_series",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
 			Name: "generate_series",
 			Args: []*catalog.Argument{
 				{
@@ -6603,16 +6884,28 @@ func genPGCatalog() *catalog.Schema {
 			Name: "generate_series",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
+					Type: &ast.TypeName{Name: "numeric"},
 				},
 				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
+					Type: &ast.TypeName{Name: "numeric"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "generate_series",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
 			Name: "generate_series",
@@ -6633,61 +6926,22 @@ func genPGCatalog() *catalog.Schema {
 			Name: "generate_series",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
 				},
 				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "generate_series",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "numeric"},
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
 				},
 				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-				{
-					Type: &ast.TypeName{Name: "numeric"},
+					Type: &ast.TypeName{Name: "interval"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
+			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
 		},
 		{
-			Name: "generate_series",
+			Name: "generate_subscripts",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bigint"},
-		},
-		{
-			Name: "generate_series",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bigint"},
-		},
-		{
-			Name: "generate_series",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "anyarray"},
 				},
 				{
 					Type: &ast.TypeName{Name: "integer"},
@@ -6711,10 +6965,10 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "integer"},
 		},
 		{
-			Name: "generate_subscripts",
+			Name: "get_bit",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "anyarray"},
+					Type: &ast.TypeName{Name: "bit"},
 				},
 				{
 					Type: &ast.TypeName{Name: "integer"},
@@ -6729,19 +6983,7 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "bytea"},
 				},
 				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "get_bit",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "bit"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -6828,33 +7070,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "has_any_column_privilege",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_any_column_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "name"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_any_column_privilege",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "name"},
 				},
 				{
@@ -6870,7 +7085,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "has_any_column_privilege",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "oid"},
+					Type: &ast.TypeName{Name: "name"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -6900,6 +7115,21 @@ func genPGCatalog() *catalog.Schema {
 			Name: "has_any_column_privilege",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_any_column_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
 					Type: &ast.TypeName{Name: "text"},
 				},
 				{
@@ -6909,13 +7139,10 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "has_column_privilege",
+			Name: "has_any_column_privilege",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "smallint"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -6930,52 +7157,7 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "name"},
 				},
 				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "smallint"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_column_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_column_privilege",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_column_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "smallint"},
@@ -7011,7 +7193,7 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "name"},
 				},
 				{
-					Type: &ast.TypeName{Name: "oid"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "smallint"},
@@ -7026,7 +7208,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "has_column_privilege",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "oid"},
+					Type: &ast.TypeName{Name: "name"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -7047,7 +7229,7 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "oid"},
 				},
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "oid"},
 				},
 				{
 					Type: &ast.TypeName{Name: "smallint"},
@@ -7083,7 +7265,22 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "oid"},
 				},
 				{
+					Type: &ast.TypeName{Name: "smallint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_column_privilege",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "smallint"},
@@ -7098,8 +7295,53 @@ func genPGCatalog() *catalog.Schema {
 			Name: "has_column_privilege",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "name"},
+					Type: &ast.TypeName{Name: "oid"},
 				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_column_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_column_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "smallint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_column_privilege",
+			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -7131,32 +7373,8 @@ func genPGCatalog() *catalog.Schema {
 			Name: "has_database_privilege",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_database_privilege",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "name"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_database_privilege",
-			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -7190,30 +7408,15 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "has_foreign_data_wrapper_privilege",
+			Name: "has_database_privilege",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "oid"},
 				},
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_foreign_data_wrapper_privilege",
-			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -7224,13 +7427,10 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "has_foreign_data_wrapper_privilege",
+			Name: "has_database_privilege",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "name"},
-				},
-				{
-					Type: &ast.TypeName{Name: "oid"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -7245,18 +7445,6 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "name"},
 				},
 				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_foreign_data_wrapper_privilege",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "oid"},
 				},
 				{
@@ -7267,21 +7455,6 @@ func genPGCatalog() *catalog.Schema {
 		},
 		{
 			Name: "has_foreign_data_wrapper_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_function_privilege",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "name"},
@@ -7296,7 +7469,49 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "has_function_privilege",
+			Name: "has_foreign_data_wrapper_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_foreign_data_wrapper_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_foreign_data_wrapper_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_foreign_data_wrapper_privilege",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -7311,34 +7526,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "has_function_privilege",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_function_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_function_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "oid"},
+					Type: &ast.TypeName{Name: "name"},
 				},
 				{
 					Type: &ast.TypeName{Name: "oid"},
@@ -7356,7 +7544,91 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "name"},
 				},
 				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_function_privilege",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_function_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_function_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_function_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_language_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_language_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -7388,24 +7660,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_language_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "name"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
@@ -7417,18 +7671,6 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_language_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "name"},
-				},
-				{
-					Type: &ast.TypeName{Name: "oid"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -7455,30 +7697,6 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "name"},
 				},
 				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_schema_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_schema_privilege",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "oid"},
 				},
 				{
@@ -7494,6 +7712,33 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "name"},
 				},
 				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_schema_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_schema_privilege",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "oid"},
 				},
 				{
@@ -7520,63 +7765,6 @@ func genPGCatalog() *catalog.Schema {
 		{
 			Name: "has_schema_privilege",
 			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_sequence_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_sequence_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_sequence_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_sequence_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -7607,6 +7795,60 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "name"},
 				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_sequence_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_sequence_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_sequence_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_sequence_privilege",
+			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -7653,29 +7895,17 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "oid"},
 				},
 				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_server_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_server_privilege",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "oid"},
 				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_server_privilege",
+			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "oid"},
 				},
@@ -7701,10 +7931,25 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "has_table_privilege",
+			Name: "has_server_privilege",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_table_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Type: &ast.TypeName{Name: "oid"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -7734,6 +7979,9 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "oid"},
 				},
 				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
 					Type: &ast.TypeName{Name: "text"},
 				},
 			},
@@ -7741,6 +7989,45 @@ func genPGCatalog() *catalog.Schema {
 		},
 		{
 			Name: "has_table_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_table_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_table_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_tablespace_privilege",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "name"},
@@ -7755,10 +8042,10 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "has_table_privilege",
+			Name: "has_tablespace_privilege",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "oid"},
+					Type: &ast.TypeName{Name: "name"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -7770,11 +8057,23 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "has_table_privilege",
+			Name: "has_tablespace_privilege",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "oid"},
 				},
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_tablespace_privilege",
+			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "oid"},
 				},
@@ -7812,53 +8111,11 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "has_tablespace_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_tablespace_privilege",
+			Name: "has_type_privilege",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "name"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_tablespace_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "name"},
-				},
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_tablespace_privilege",
-			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "oid"},
 				},
@@ -7887,7 +8144,22 @@ func genPGCatalog() *catalog.Schema {
 			Name: "has_type_privilege",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
 					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "has_type_privilege",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -7914,37 +8186,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "has_type_privilege",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
 					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_type_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "name"},
-				},
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "has_type_privilege",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "oid"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -8403,10 +8645,94 @@ func genPGCatalog() *catalog.Schema {
 			Name: "in_range",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "smallint"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 				{
-					Type: &ast.TypeName{Name: "smallint"},
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "in_range",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "date"},
+				},
+				{
+					Type: &ast.TypeName{Name: "date"},
+				},
+				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "in_range",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "in_range",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "in_range",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
 				},
 				{
 					Type: &ast.TypeName{Name: "integer"},
@@ -8424,13 +8750,76 @@ func genPGCatalog() *catalog.Schema {
 			Name: "in_range",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "time with time zone"},
+					Type: &ast.TypeName{Name: "integer"},
 				},
 				{
-					Type: &ast.TypeName{Name: "time with time zone"},
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "smallint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "in_range",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "interval"},
 				},
 				{
 					Type: &ast.TypeName{Name: "interval"},
+				},
+				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "in_range",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "in_range",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "real"},
+				},
+				{
+					Type: &ast.TypeName{Name: "real"},
+				},
+				{
+					Type: &ast.TypeName{Name: "double precision"},
 				},
 				{
 					Type: &ast.TypeName{Name: "boolean"},
@@ -8466,33 +8855,12 @@ func genPGCatalog() *catalog.Schema {
 			Name: "in_range",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 				{
 					Type: &ast.TypeName{Name: "smallint"},
 				},
 				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "in_range",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
 					Type: &ast.TypeName{Name: "integer"},
 				},
 				{
@@ -8508,34 +8876,13 @@ func genPGCatalog() *catalog.Schema {
 			Name: "in_range",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 				{
-					Type: &ast.TypeName{Name: "numeric"},
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "in_range",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "date"},
-				},
-				{
-					Type: &ast.TypeName{Name: "date"},
-				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 				{
 					Type: &ast.TypeName{Name: "boolean"},
@@ -8592,69 +8939,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "in_range",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "in_range",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "in_range",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "in_range",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "time without time zone"},
 				},
 				{
@@ -8676,55 +8960,13 @@ func genPGCatalog() *catalog.Schema {
 			Name: "in_range",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "real"},
+					Type: &ast.TypeName{Name: "time with time zone"},
 				},
 				{
-					Type: &ast.TypeName{Name: "real"},
+					Type: &ast.TypeName{Name: "time with time zone"},
 				},
 				{
-					Type: &ast.TypeName{Name: "double precision"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "in_range",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "double precision"},
-				},
-				{
-					Type: &ast.TypeName{Name: "double precision"},
-				},
-				{
-					Type: &ast.TypeName{Name: "double precision"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "in_range",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "smallint"},
-				},
-				{
-					Type: &ast.TypeName{Name: "smallint"},
-				},
-				{
-					Type: &ast.TypeName{Name: "smallint"},
+					Type: &ast.TypeName{Name: "interval"},
 				},
 				{
 					Type: &ast.TypeName{Name: "boolean"},
@@ -8906,34 +9148,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "int2",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "smallint"},
-		},
-		{
-			Name: "int2",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "jsonb"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "smallint"},
-		},
-		{
-			Name: "int2",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "smallint"},
-		},
-		{
-			Name: "int2",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "real"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "smallint"},
@@ -8952,6 +9167,33 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "smallint"},
+		},
+		{
+			Name: "int2",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "smallint"},
+		},
+		{
+			Name: "int2",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "smallint"},
+		},
+		{
+			Name: "int2",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "real"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "smallint"},
@@ -9563,52 +9805,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "int4",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "int4",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "smallint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "int4",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "jsonb"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "int4",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "int4",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "double precision"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "int4",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "real"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -9626,6 +9823,15 @@ func genPGCatalog() *catalog.Schema {
 			Name: "int4",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "int4",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "char"},
 				},
 			},
@@ -9635,7 +9841,43 @@ func genPGCatalog() *catalog.Schema {
 			Name: "int4",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bigint"},
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "int4",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "int4",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "int4",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "real"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "int4",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -10162,9 +10404,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "integer"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "int4range"},
 		},
@@ -10176,6 +10415,9 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "int4range"},
@@ -10280,7 +10522,52 @@ func genPGCatalog() *catalog.Schema {
 			Name: "int8",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "bit"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name: "int8",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "double precision"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name: "int8",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name: "int8",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name: "int8",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name: "int8",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bigint"},
@@ -10299,51 +10586,6 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "smallint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bigint"},
-		},
-		{
-			Name: "int8",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "bit"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bigint"},
-		},
-		{
-			Name: "int8",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bigint"},
-		},
-		{
-			Name: "int8",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bigint"},
-		},
-		{
-			Name: "int8",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bigint"},
-		},
-		{
-			Name: "int8",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "jsonb"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bigint"},
@@ -11069,7 +11311,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "interval",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "time without time zone"},
+					Type: &ast.TypeName{Name: "interval"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "interval"},
@@ -11078,10 +11323,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "interval",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "time without time zone"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "interval"},
@@ -11429,6 +11671,18 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "cstring"},
 		},
 		{
+			Name: "is_normalized",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
 			Name: "isclosed",
 			Args: []*catalog.Argument{
 				{
@@ -11450,7 +11704,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "isfinite",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
+					Type: &ast.TypeName{Name: "date"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -11459,7 +11713,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "isfinite",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "date"},
+					Type: &ast.TypeName{Name: "interval"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -11477,7 +11731,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "isfinite",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "interval"},
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -11525,10 +11779,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "isparallel",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "lseg"},
+					Type: &ast.TypeName{Name: "line"},
 				},
 				{
-					Type: &ast.TypeName{Name: "lseg"},
+					Type: &ast.TypeName{Name: "line"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -11537,10 +11791,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "isparallel",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "line"},
+					Type: &ast.TypeName{Name: "lseg"},
 				},
 				{
-					Type: &ast.TypeName{Name: "line"},
+					Type: &ast.TypeName{Name: "lseg"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -11573,10 +11827,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "isvertical",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "point"},
-				},
-				{
-					Type: &ast.TypeName{Name: "point"},
+					Type: &ast.TypeName{Name: "line"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -11594,7 +11845,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "isvertical",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "line"},
+					Type: &ast.TypeName{Name: "point"},
+				},
+				{
+					Type: &ast.TypeName{Name: "point"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -11646,23 +11900,13 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "integer"},
 		},
 		{
-			Name: "json_build_array",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "any"},
-					Mode: ast.FuncParamVariadic,
-				},
-			},
+			Name:       "json_build_array",
+			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "json"},
 		},
 		{
-			Name: "json_build_object",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "any"},
-					Mode: ast.FuncParamVariadic,
-				},
-			},
+			Name:       "json_build_object",
+			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "json"},
 		},
 		{
@@ -11831,9 +12075,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "json_to_tsvector",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "regconfig"},
-				},
-				{
 					Type: &ast.TypeName{Name: "json"},
 				},
 				{
@@ -11845,6 +12086,9 @@ func genPGCatalog() *catalog.Schema {
 		{
 			Name: "json_to_tsvector",
 			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regconfig"},
+				},
 				{
 					Type: &ast.TypeName{Name: "json"},
 				},
@@ -11910,23 +12154,13 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "integer"},
 		},
 		{
-			Name: "jsonb_build_array",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "any"},
-					Mode: ast.FuncParamVariadic,
-				},
-			},
+			Name:       "jsonb_build_array",
+			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "jsonb"},
 		},
 		{
-			Name: "jsonb_build_object",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "any"},
-					Mode: ast.FuncParamVariadic,
-				},
-			},
+			Name:       "jsonb_build_object",
+			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "jsonb"},
 		},
 		{
@@ -12180,15 +12414,15 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text[]"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text[]"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "jsonb"},
 		},
 		{
 			Name: "jsonb_object",
 			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text[]"},
+				},
 				{
 					Type: &ast.TypeName{Name: "text[]"},
 				},
@@ -12290,6 +12524,30 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
+			Name: "jsonb_path_exists_tz",
+			Args: []*catalog.Argument{
+				{
+					Name: "target",
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name: "path",
+					Type: &ast.TypeName{Name: "jsonpath"},
+				},
+				{
+					Name:       "vars",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name:       "silent",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
 			Name: "jsonb_path_match",
 			Args: []*catalog.Argument{
 				{
@@ -12321,6 +12579,30 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "jsonpath"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "jsonb_path_match_tz",
+			Args: []*catalog.Argument{
+				{
+					Name: "target",
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name: "path",
+					Type: &ast.TypeName{Name: "jsonpath"},
+				},
+				{
+					Name:       "vars",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name:       "silent",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "boolean"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -12374,7 +12656,79 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "jsonb"},
 		},
 		{
+			Name: "jsonb_path_query_array_tz",
+			Args: []*catalog.Argument{
+				{
+					Name: "target",
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name: "path",
+					Type: &ast.TypeName{Name: "jsonpath"},
+				},
+				{
+					Name:       "vars",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name:       "silent",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "jsonb"},
+		},
+		{
 			Name: "jsonb_path_query_first",
+			Args: []*catalog.Argument{
+				{
+					Name: "target",
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name: "path",
+					Type: &ast.TypeName{Name: "jsonpath"},
+				},
+				{
+					Name:       "vars",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name:       "silent",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "jsonb"},
+		},
+		{
+			Name: "jsonb_path_query_first_tz",
+			Args: []*catalog.Argument{
+				{
+					Name: "target",
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name: "path",
+					Type: &ast.TypeName{Name: "jsonpath"},
+				},
+				{
+					Name:       "vars",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name:       "silent",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "boolean"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "jsonb"},
+		},
+		{
+			Name: "jsonb_path_query_tz",
 			Args: []*catalog.Argument{
 				{
 					Name: "target",
@@ -12463,6 +12817,34 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "jsonb"},
 		},
 		{
+			Name: "jsonb_set_lax",
+			Args: []*catalog.Argument{
+				{
+					Name: "jsonb_in",
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name: "path",
+					Type: &ast.TypeName{Name: "text[]"},
+				},
+				{
+					Name: "replacement",
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Name:       "create_if_missing",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "boolean"},
+				},
+				{
+					Name:       "null_value_treatment",
+					HasDefault: true,
+					Type:       &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "jsonb"},
+		},
+		{
 			Name: "jsonb_strip_nulls",
 			Args: []*catalog.Argument{
 				{
@@ -12493,9 +12875,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "jsonb_to_tsvector",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "regconfig"},
-				},
-				{
 					Type: &ast.TypeName{Name: "jsonb"},
 				},
 				{
@@ -12507,6 +12886,9 @@ func genPGCatalog() *catalog.Schema {
 		{
 			Name: "jsonb_to_tsvector",
 			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regconfig"},
+				},
 				{
 					Type: &ast.TypeName{Name: "jsonb"},
 				},
@@ -12648,6 +13030,42 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "bigint"},
 		},
 		{
+			Name: "lcm",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name: "lcm",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "lcm",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
 			Name: "lead",
 			Args: []*catalog.Argument{
 				{
@@ -12665,9 +13083,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "integer"},
 				},
-				{
-					Type: &ast.TypeName{Name: "anyelement"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "anyelement"},
 		},
@@ -12679,6 +13094,9 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "anyelement"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "anyelement"},
@@ -12699,10 +13117,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "length",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bit"},
+					Type: &ast.TypeName{Name: "lseg"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "integer"},
+			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
 			Name: "length",
@@ -12717,10 +13135,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "length",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "lseg"},
+					Type: &ast.TypeName{Name: "bit"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "length",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
 		},
 		{
 			Name: "length",
@@ -12730,24 +13157,6 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "name"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "length",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "tsvector"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "length",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "bytea"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -12771,16 +13180,13 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "integer"},
 		},
 		{
-			Name: "like",
+			Name: "length",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "tsvector"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
+			ReturnType: &ast.TypeName{Name: "integer"},
 		},
 		{
 			Name: "like",
@@ -12799,6 +13205,18 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "name"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "like",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -13058,9 +13476,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "oid"},
 		},
@@ -13069,6 +13484,9 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "oid"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "oid"},
@@ -13185,18 +13603,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "log",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "log",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "double precision"},
 				},
 			},
@@ -13212,8 +13618,11 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
-			Name: "log10",
+			Name: "log",
 			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
 				{
 					Type: &ast.TypeName{Name: "numeric"},
 				},
@@ -13228,6 +13637,15 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "log10",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
 			Name: "loread",
@@ -13245,19 +13663,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "lower",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "anyrange"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "text"},
+			ReturnType: &ast.TypeName{Name: "anyelement"},
 		},
 		{
 			Name: "lower",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "anyrange"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "anyelement"},
+			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "lower_inc",
@@ -13320,10 +13738,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "lseg",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "point"},
-				},
-				{
-					Type: &ast.TypeName{Name: "point"},
+					Type: &ast.TypeName{Name: "box"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "lseg"},
@@ -13332,7 +13747,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "lseg",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "box"},
+					Type: &ast.TypeName{Name: "point"},
+				},
+				{
+					Type: &ast.TypeName{Name: "point"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "lseg"},
@@ -13538,15 +13956,15 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "ltrim",
 			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -14002,10 +14420,6 @@ func genPGCatalog() *catalog.Schema {
 					Name: "sec",
 					Type: &ast.TypeName{Name: "double precision"},
 				},
-				{
-					Name: "timezone",
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
 		},
@@ -14035,6 +14449,10 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Name: "sec",
 					Type: &ast.TypeName{Name: "double precision"},
+				},
+				{
+					Name: "timezone",
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
@@ -14070,19 +14488,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "max",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
+					Type: &ast.TypeName{Name: "anyarray"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
-		},
-		{
-			Name: "max",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "inet"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "inet"},
+			ReturnType: &ast.TypeName{Name: "anyarray"},
 		},
 		{
 			Name: "max",
@@ -14097,37 +14506,28 @@ func genPGCatalog() *catalog.Schema {
 			Name: "max",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "integer"},
+			ReturnType: &ast.TypeName{Name: "bigint"},
 		},
 		{
 			Name: "max",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "smallint"},
+					Type: &ast.TypeName{Name: "character"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "smallint"},
+			ReturnType: &ast.TypeName{Name: "character"},
 		},
 		{
 			Name: "max",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "oid"},
+					Type: &ast.TypeName{Name: "date"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "oid"},
-		},
-		{
-			Name: "max",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "real"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "real"},
+			ReturnType: &ast.TypeName{Name: "date"},
 		},
 		{
 			Name: "max",
@@ -14142,10 +14542,118 @@ func genPGCatalog() *catalog.Schema {
 			Name: "max",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "date"},
+					Type: &ast.TypeName{Name: "inet"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "date"},
+			ReturnType: &ast.TypeName{Name: "inet"},
+		},
+		{
+			Name: "max",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "max",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "interval"},
+		},
+		{
+			Name: "max",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "money"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "money"},
+		},
+		{
+			Name: "max",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "max",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "oid"},
+		},
+		{
+			Name: "max",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "pg_lsn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "pg_lsn"},
+		},
+		{
+			Name: "max",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "real"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "real"},
+		},
+		{
+			Name: "max",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "smallint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "smallint"},
+		},
+		{
+			Name: "max",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "max",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "tid"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "tid"},
+		},
+		{
+			Name: "max",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "timestamp without time zone"},
+		},
+		{
+			Name: "max",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
 		},
 		{
 			Name: "max",
@@ -14164,87 +14672,6 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "time with time zone"},
-		},
-		{
-			Name: "max",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "money"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "money"},
-		},
-		{
-			Name: "max",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "timestamp without time zone"},
-		},
-		{
-			Name: "max",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "interval"},
-		},
-		{
-			Name: "max",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "max",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "max",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "anyarray"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "anyarray"},
-		},
-		{
-			Name: "max",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "character"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "character"},
-		},
-		{
-			Name: "max",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "tid"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "tid"},
-		},
-		{
-			Name: "max",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bigint"},
 		},
 		{
 			Name: "md5",
@@ -14268,37 +14695,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "min",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
+					Type: &ast.TypeName{Name: "anyarray"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
+			ReturnType: &ast.TypeName{Name: "anyarray"},
 		},
 		{
 			Name: "min",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "interval"},
+					Type: &ast.TypeName{Name: "anyenum"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "interval"},
-		},
-		{
-			Name: "min",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "character"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "character"},
-		},
-		{
-			Name: "min",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "smallint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "smallint"},
+			ReturnType: &ast.TypeName{Name: "anyenum"},
 		},
 		{
 			Name: "min",
@@ -14313,37 +14722,28 @@ func genPGCatalog() *catalog.Schema {
 			Name: "min",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "oid"},
+					Type: &ast.TypeName{Name: "character"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "oid"},
+			ReturnType: &ast.TypeName{Name: "character"},
 		},
 		{
 			Name: "min",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "date"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "text"},
+			ReturnType: &ast.TypeName{Name: "date"},
 		},
 		{
 			Name: "min",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "time without time zone"},
+					Type: &ast.TypeName{Name: "double precision"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "time without time zone"},
-		},
-		{
-			Name: "min",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "time with time zone"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "time with time zone"},
+			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
 			Name: "min",
@@ -14353,6 +14753,24 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "inet"},
+		},
+		{
+			Name: "min",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "min",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "interval"},
 		},
 		{
 			Name: "min",
@@ -14376,10 +14794,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "min",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
+					Type: &ast.TypeName{Name: "oid"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "timestamp without time zone"},
+			ReturnType: &ast.TypeName{Name: "oid"},
+		},
+		{
+			Name: "min",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "pg_lsn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "pg_lsn"},
 		},
 		{
 			Name: "min",
@@ -14394,37 +14821,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "min",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "anyarray"},
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "anyarray"},
+			ReturnType: &ast.TypeName{Name: "smallint"},
 		},
 		{
 			Name: "min",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "anyenum"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "anyenum"},
-		},
-		{
-			Name: "min",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "double precision"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
-		},
-		{
-			Name: "min",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
+			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "min",
@@ -14439,19 +14848,43 @@ func genPGCatalog() *catalog.Schema {
 			Name: "min",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "date"},
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "date"},
+			ReturnType: &ast.TypeName{Name: "timestamp without time zone"},
 		},
 		{
-			Name: "mod",
+			Name: "min",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
 				},
+			},
+			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
+		},
+		{
+			Name: "min",
+			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "time without time zone"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "time without time zone"},
+		},
+		{
+			Name: "min",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "time with time zone"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "time with time zone"},
+		},
+		{
+			Name: "min_scale",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -14472,13 +14905,13 @@ func genPGCatalog() *catalog.Schema {
 			Name: "mod",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "smallint"},
+					Type: &ast.TypeName{Name: "integer"},
 				},
 				{
-					Type: &ast.TypeName{Name: "smallint"},
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "smallint"},
+			ReturnType: &ast.TypeName{Name: "integer"},
 		},
 		{
 			Name: "mod",
@@ -14493,8 +14926,24 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
-			Name:       "mode",
-			Args:       []*catalog.Argument{},
+			Name: "mod",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "smallint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "smallint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "smallint"},
+		},
+		{
+			Name: "mode",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "anyelement"},
+				},
+			},
 			ReturnType: &ast.TypeName{Name: "anyelement"},
 		},
 		{
@@ -14510,7 +14959,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "money",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "money"},
@@ -14519,7 +14968,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "money",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "numeric"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "money"},
@@ -14549,6 +14998,15 @@ func genPGCatalog() *catalog.Schema {
 			Name: "name",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "character"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "name"},
+		},
+		{
+			Name: "name",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "character varying"},
 				},
 			},
@@ -14559,15 +15017,6 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "name"},
-		},
-		{
-			Name: "name",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "character"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "name"},
@@ -15047,13 +15496,25 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "bigint"},
 		},
 		{
-			Name: "notlike",
+			Name: "normalize",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "notlike",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bytea"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -15074,10 +15535,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "notlike",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bytea"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
-					Type: &ast.TypeName{Name: "bytea"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -15130,7 +15591,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "numeric",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
@@ -15140,6 +15601,33 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "double precision"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "numeric",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "numeric",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "numeric",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "money"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
@@ -15160,16 +15648,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "numeric",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "numeric",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "money"},
+					Type: &ast.TypeName{Name: "real"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
@@ -15179,24 +15658,6 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "smallint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "numeric",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "jsonb"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "numeric",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "real"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
@@ -15546,9 +16007,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "numeric"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "numrange"},
 		},
@@ -15560,6 +16018,9 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "numeric"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numrange"},
@@ -15582,9 +16043,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "oid"},
 				},
-				{
-					Type: &ast.TypeName{Name: "name"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
@@ -15593,6 +16051,9 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "name"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -15610,7 +16071,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "octet_length",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "bytea"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -15628,7 +16089,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "octet_length",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bytea"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -15946,22 +16407,148 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "opaque_in",
+			Name: "overlaps",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "cstring"},
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "interval"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "opaque"},
+			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "opaque_out",
+			Name: "overlaps",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "opaque"},
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "cstring"},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "overlaps",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "overlaps",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "overlaps",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "overlaps",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "overlaps",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "overlaps",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
 			Name: "overlaps",
@@ -15985,154 +16572,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "overlaps",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "overlaps",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "overlaps",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "overlaps",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "overlaps",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "overlaps",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "overlaps",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "overlaps",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "overlaps",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "time without time zone"},
 				},
 				{
-					Type: &ast.TypeName{Name: "time without time zone"},
+					Type: &ast.TypeName{Name: "interval"},
 				},
 				{
 					Type: &ast.TypeName{Name: "time without time zone"},
@@ -16168,7 +16611,7 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "time without time zone"},
 				},
 				{
-					Type: &ast.TypeName{Name: "interval"},
+					Type: &ast.TypeName{Name: "time without time zone"},
 				},
 				{
 					Type: &ast.TypeName{Name: "time without time zone"},
@@ -16196,42 +16639,6 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "overlay",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "overlay",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "bytea"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bytea"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bytea"},
 		},
 		{
 			Name: "overlay",
@@ -16247,21 +16654,6 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bit"},
-		},
-		{
-			Name: "overlay",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "overlay",
@@ -16295,6 +16687,57 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bytea"},
+		},
+		{
+			Name: "overlay",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bytea"},
+		},
+		{
+			Name: "overlay",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "overlay",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "parse_ident",
@@ -16548,7 +16991,22 @@ func genPGCatalog() *catalog.Schema {
 			Name: "percentile_cont",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "percentile_cont",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "double precision[]"},
+				},
+				{
+					Type: &ast.TypeName{Name: "double precision"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "double precision[]"},
@@ -16559,17 +17017,23 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "double precision"},
 				},
-			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
-		},
-		{
-			Name: "percentile_disc",
-			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "double precision"},
+					Type: &ast.TypeName{Name: "interval"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "anyelement"},
+			ReturnType: &ast.TypeName{Name: "interval"},
+		},
+		{
+			Name: "percentile_cont",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "double precision[]"},
+				},
+				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "interval[]"},
 		},
 		{
 			Name: "percentile_disc",
@@ -16577,17 +17041,29 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "double precision[]"},
 				},
+				{
+					Type: &ast.TypeName{Name: "anyelement"},
+				},
 			},
 			ReturnType: &ast.TypeName{Name: "anyarray"},
+		},
+		{
+			Name: "percentile_disc",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+				{
+					Type: &ast.TypeName{Name: "anyelement"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "anyelement"},
 		},
 		{
 			Name: "pg_advisory_lock",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "void"},
@@ -16596,7 +17072,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "pg_advisory_lock",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bigint"},
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "void"},
@@ -16626,10 +17105,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "pg_advisory_unlock",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -16638,7 +17114,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "pg_advisory_unlock",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bigint"},
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -16673,10 +17152,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "pg_advisory_xact_lock",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "void"},
@@ -16685,15 +17161,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "pg_advisory_xact_lock",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "void"},
-		},
-		{
-			Name: "pg_advisory_xact_lock_shared",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "integer"},
 				},
 				{
@@ -16707,6 +17174,18 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "bigint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "void"},
+		},
+		{
+			Name: "pg_advisory_xact_lock_shared",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "void"},
@@ -16828,6 +17307,11 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "pg_lsn"},
 		},
 		{
+			Name:       "pg_current_logfile",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
 			Name: "pg_current_logfile",
 			Args: []*catalog.Argument{
 				{
@@ -16837,9 +17321,9 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
-			Name:       "pg_current_logfile",
+			Name:       "pg_current_snapshot",
 			Args:       []*catalog.Argument{},
-			ReturnType: &ast.TypeName{Name: "text"},
+			ReturnType: &ast.TypeName{Name: "pg_snapshot"},
 		},
 		{
 			Name:       "pg_current_wal_flush_lsn",
@@ -16855,6 +17339,16 @@ func genPGCatalog() *catalog.Schema {
 			Name:       "pg_current_wal_lsn",
 			Args:       []*catalog.Argument{},
 			ReturnType: &ast.TypeName{Name: "pg_lsn"},
+		},
+		{
+			Name:       "pg_current_xact_id",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "xid8"},
+		},
+		{
+			Name:       "pg_current_xact_id_if_assigned",
+			Args:       []*catalog.Argument{},
+			ReturnType: &ast.TypeName{Name: "xid8"},
 		},
 		{
 			Name: "pg_database_size",
@@ -17001,9 +17495,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
@@ -17016,8 +17507,20 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "pg_file_sync",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "void"},
 		},
 		{
 			Name: "pg_file_unlink",
@@ -17094,9 +17597,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "oid"},
 				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
@@ -17108,6 +17608,9 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -17166,12 +17669,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "oid"},
 				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
@@ -17180,6 +17677,12 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -17217,9 +17720,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "oid"},
 				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
@@ -17228,6 +17728,9 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -17287,10 +17790,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "pg_get_viewdef",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
+					Type: &ast.TypeName{Name: "oid"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -17323,7 +17823,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "pg_get_viewdef",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "oid"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -17334,6 +17834,9 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
@@ -17344,18 +17847,6 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "name"},
 				},
 				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "pg_has_role",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
-				{
 					Type: &ast.TypeName{Name: "name"},
 				},
 				{
@@ -17386,6 +17877,18 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "name"},
 				},
 				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "pg_has_role",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
 					Type: &ast.TypeName{Name: "name"},
 				},
 				{
@@ -17401,6 +17904,9 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "oid"},
 				},
 				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+				{
 					Type: &ast.TypeName{Name: "text"},
 				},
 			},
@@ -17409,9 +17915,6 @@ func genPGCatalog() *catalog.Schema {
 		{
 			Name: "pg_has_role",
 			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "oid"},
-				},
 				{
 					Type: &ast.TypeName{Name: "oid"},
 				},
@@ -17566,7 +18069,7 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "text"},
 				},
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "bytea"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "pg_lsn"},
@@ -17581,7 +18084,7 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "text"},
 				},
 				{
-					Type: &ast.TypeName{Name: "bytea"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "pg_lsn"},
@@ -17592,12 +18095,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
@@ -17606,6 +18103,12 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -17689,6 +18192,18 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "pg_lsn"},
 		},
 		{
+			Name: "pg_lsn_larger",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "pg_lsn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "pg_lsn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "pg_lsn"},
+		},
+		{
 			Name: "pg_lsn_le",
 			Args: []*catalog.Argument{
 				{
@@ -17753,6 +18268,18 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bytea"},
+		},
+		{
+			Name: "pg_lsn_smaller",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "pg_lsn"},
+				},
+				{
+					Type: &ast.TypeName{Name: "pg_lsn"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "pg_lsn"},
 		},
 		{
 			Name: "pg_mcv_list_in",
@@ -17935,6 +18462,15 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
+			},
+			ReturnType: &ast.TypeName{Name: "bytea"},
+		},
+		{
+			Name: "pg_read_binary_file",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
 				{
 					Type: &ast.TypeName{Name: "bigint"},
 				},
@@ -17963,13 +18499,28 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "bytea"},
 		},
 		{
-			Name: "pg_read_binary_file",
+			Name: "pg_read_file",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "bytea"},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "pg_read_file",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "pg_read_file",
@@ -17985,30 +18536,6 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "boolean"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "pg_read_file",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "pg_read_file",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -18270,6 +18797,60 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "void"},
+		},
+		{
+			Name: "pg_snapshot_in",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "cstring"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "pg_snapshot"},
+		},
+		{
+			Name: "pg_snapshot_out",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "pg_snapshot"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "cstring"},
+		},
+		{
+			Name: "pg_snapshot_send",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "pg_snapshot"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bytea"},
+		},
+		{
+			Name: "pg_snapshot_xip",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "pg_snapshot"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "xid8"},
+		},
+		{
+			Name: "pg_snapshot_xmax",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "pg_snapshot"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "xid8"},
+		},
+		{
+			Name: "pg_snapshot_xmin",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "pg_snapshot"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "xid8"},
 		},
 		{
 			Name: "pg_start_backup",
@@ -18753,6 +19334,15 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
+			Name: "pg_stat_get_ins_since_vacuum",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "oid"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
 			Name: "pg_stat_get_last_analyze_time",
 			Args: []*catalog.Argument{
 				{
@@ -19024,6 +19614,15 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "void"},
 		},
 		{
+			Name: "pg_stat_reset_slru",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "void"},
+		},
+		{
 			Name: "pg_statistics_obj_is_visible",
 			Args: []*catalog.Argument{
 				{
@@ -19082,7 +19681,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "pg_tablespace_size",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "oid"},
+					Type: &ast.TypeName{Name: "name"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bigint"},
@@ -19091,7 +19690,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "pg_tablespace_size",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "name"},
+					Type: &ast.TypeName{Name: "oid"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bigint"},
@@ -19123,10 +19722,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "pg_try_advisory_lock",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -19135,15 +19731,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "pg_try_advisory_lock",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "boolean"},
-		},
-		{
-			Name: "pg_try_advisory_lock_shared",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "integer"},
 				},
 				{
@@ -19162,7 +19749,7 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "pg_try_advisory_xact_lock",
+			Name: "pg_try_advisory_lock_shared",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "integer"},
@@ -19183,7 +19770,7 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "boolean"},
 		},
 		{
-			Name: "pg_try_advisory_xact_lock_shared",
+			Name: "pg_try_advisory_xact_lock",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "integer"},
@@ -19199,6 +19786,18 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "bigint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "pg_try_advisory_xact_lock_shared",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "boolean"},
@@ -19258,6 +19857,18 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "regtype"},
 		},
 		{
+			Name: "pg_visible_in_snapshot",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+				{
+					Type: &ast.TypeName{Name: "pg_snapshot"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
 			Name: "pg_wal_lsn_diff",
 			Args: []*catalog.Argument{
 				{
@@ -19296,6 +19907,15 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
+		},
+		{
+			Name: "pg_xact_status",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "phraseto_tsquery",
@@ -19362,36 +19982,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "point",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "circle"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "point"},
-		},
-		{
-			Name: "point",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "path"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "point"},
-		},
-		{
-			Name: "point",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "double precision"},
-				},
-				{
-					Type: &ast.TypeName{Name: "double precision"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "point"},
-		},
-		{
-			Name: "point",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "box"},
 				},
 			},
@@ -19401,7 +19991,37 @@ func genPGCatalog() *catalog.Schema {
 			Name: "point",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "circle"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "point"},
+		},
+		{
+			Name: "point",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "point"},
+		},
+		{
+			Name: "point",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "lseg"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "point"},
+		},
+		{
+			Name: "point",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "path"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "point"},
@@ -19815,7 +20435,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "polygon",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "path"},
+					Type: &ast.TypeName{Name: "box"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "polygon"},
@@ -19845,7 +20465,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "polygon",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "box"},
+					Type: &ast.TypeName{Name: "path"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "polygon"},
@@ -19863,6 +20483,18 @@ func genPGCatalog() *catalog.Schema {
 			Name: "position",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "bit"},
+				},
+				{
+					Type: &ast.TypeName{Name: "bit"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "position",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "bytea"},
 				},
 				{
@@ -19879,18 +20511,6 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "position",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "bit"},
-				},
-				{
-					Type: &ast.TypeName{Name: "bit"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
@@ -19911,18 +20531,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "pow",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "pow",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "double precision"},
 				},
 				{
@@ -19930,6 +20538,18 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "pow",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
 			Name: "power",
@@ -20614,6 +21234,33 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "bytea"},
 		},
 		{
+			Name: "regcollationin",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "cstring"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "regcollation"},
+		},
+		{
+			Name: "regcollationout",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regcollation"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "cstring"},
+		},
+		{
+			Name: "regcollationsend",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regcollation"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bytea"},
+		},
+		{
 			Name: "regconfigin",
 			Args: []*catalog.Argument{
 				{
@@ -20676,9 +21323,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text[]"},
 		},
@@ -20691,18 +21335,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-			},
-			ReturnType: &ast.TypeName{Name: "text[]"},
-		},
-		{
-			Name: "regexp_matches",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -20712,6 +21344,21 @@ func genPGCatalog() *catalog.Schema {
 		{
 			Name: "regexp_matches",
 			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text[]"},
+		},
+		{
+			Name: "regexp_matches",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -20790,15 +21437,15 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "regexp_split_to_table",
 			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -21157,6 +21804,24 @@ func genPGCatalog() *catalog.Schema {
 			Name: "round",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "round",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "round",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "numeric"},
 				},
 				{
@@ -21164,24 +21829,6 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "round",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "round",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "double precision"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
 			Name:       "row_number",
@@ -21212,9 +21859,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "record"},
 				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "json"},
 		},
@@ -21224,6 +21868,9 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "record"},
 				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
+				},
 			},
 			ReturnType: &ast.TypeName{Name: "json"},
 		},
@@ -21260,15 +21907,15 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "rtrim",
 			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -21377,7 +22024,7 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "bytea"},
 				},
 				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 				{
 					Type: &ast.TypeName{Name: "integer"},
@@ -21484,9 +22131,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "char"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text[]"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "tsvector"},
 		},
@@ -21498,6 +22142,9 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "char"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text[]"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "tsvector"},
@@ -21545,13 +22192,13 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "cstring"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "opaque"},
+			ReturnType: &ast.TypeName{Name: "void"},
 		},
 		{
 			Name: "shell_out",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "opaque"},
+					Type: &ast.TypeName{Name: "void"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "cstring"},
@@ -21572,22 +22219,43 @@ func genPGCatalog() *catalog.Schema {
 			Name: "sign",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "sign",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "double precision"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
+			Name: "sign",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
 			Name: "similar_escape",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "similar_to_escape",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "similar_to_escape",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -21665,19 +22333,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "sqrt",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
+					Type: &ast.TypeName{Name: "double precision"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
+			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
 			Name: "sqrt",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "double precision"},
+					Type: &ast.TypeName{Name: "numeric"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
+			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
 			Name: "starts_with",
@@ -21700,15 +22368,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "stddev",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "smallint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "stddev",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "double precision"},
 				},
 			},
@@ -21718,10 +22377,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "stddev",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
+					Type: &ast.TypeName{Name: "real"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
+			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
 			Name: "stddev",
@@ -21745,16 +22404,16 @@ func genPGCatalog() *catalog.Schema {
 			Name: "stddev",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "real"},
+					Type: &ast.TypeName{Name: "numeric"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
+			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
-			Name: "stddev_pop",
+			Name: "stddev",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
@@ -21772,15 +22431,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "stddev_pop",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "stddev_pop",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "real"},
 				},
 			},
@@ -21790,7 +22440,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "stddev_pop",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "smallint"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
@@ -21805,28 +22455,19 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
-			Name: "stddev_samp",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "smallint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "stddev_samp",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "stddev_samp",
+			Name: "stddev_pop",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "stddev_pop",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
@@ -21853,7 +22494,34 @@ func genPGCatalog() *catalog.Schema {
 			Name: "stddev_samp",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "stddev_samp",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "stddev_samp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "stddev_samp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
@@ -21966,9 +22634,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "integer"},
 				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
@@ -21981,84 +22646,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "integer"},
 				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "substring",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "substring",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "substring",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "bytea"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bytea"},
-		},
-		{
-			Name: "substring",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "bytea"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bytea"},
-		},
-		{
-			Name: "substring",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "substring",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
 				{
 					Type: &ast.TypeName{Name: "integer"},
 				},
@@ -22091,6 +22678,87 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "bit"},
+		},
+		{
+			Name: "substring",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bytea"},
+		},
+		{
+			Name: "substring",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "bytea"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bytea"},
+		},
+		{
+			Name: "substring",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "substring",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "substring",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "substring",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "sum",
@@ -22105,10 +22773,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "sum",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
+			ReturnType: &ast.TypeName{Name: "bigint"},
+		},
+		{
+			Name: "sum",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
 			Name: "sum",
@@ -22132,10 +22809,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "sum",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "double precision"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "sum",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
 			Name: "sum",
@@ -22145,24 +22831,6 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "real"},
-		},
-		{
-			Name: "sum",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "smallint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "bigint"},
-		},
-		{
-			Name: "sum",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
 			Name:       "suppress_redundant_updates_trigger",
@@ -22284,25 +22952,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "text",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "name"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "text",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "character"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "text",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "xml"},
+					Type: &ast.TypeName{Name: "boolean"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -22320,7 +22970,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "text",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "boolean"},
+					Type: &ast.TypeName{Name: "character"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -22330,6 +22980,24 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "inet"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "text",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "name"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "text",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "xml"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "text"},
@@ -22833,6 +23501,24 @@ func genPGCatalog() *catalog.Schema {
 			Name: "time",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "interval"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "time without time zone"},
+		},
+		{
+			Name: "time",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "time without time zone"},
+		},
+		{
+			Name: "time",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "timestamp with time zone"},
 				},
 			},
@@ -22854,25 +23540,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "time",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "time without time zone"},
-		},
-		{
-			Name: "time",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "time with time zone"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "time without time zone"},
-		},
-		{
-			Name: "time",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "time without time zone"},
@@ -23096,7 +23764,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "timestamp",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
+					Type: &ast.TypeName{Name: "date"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "timestamp without time zone"},
@@ -23106,6 +23774,9 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "date"},
+				},
+				{
+					Type: &ast.TypeName{Name: "time without time zone"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "timestamp without time zone"},
@@ -23126,10 +23797,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "timestamp",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "date"},
-				},
-				{
-					Type: &ast.TypeName{Name: "time without time zone"},
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "timestamp without time zone"},
@@ -23524,9 +24192,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "date"},
 				},
-				{
-					Type: &ast.TypeName{Name: "time with time zone"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
 		},
@@ -23534,10 +24199,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "timestamptz",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
+					Type: &ast.TypeName{Name: "date"},
 				},
 				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "time without time zone"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
@@ -23547,6 +24212,9 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "date"},
+				},
+				{
+					Type: &ast.TypeName{Name: "time with time zone"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
@@ -23564,10 +24232,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "timestamptz",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "date"},
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
 				},
 				{
-					Type: &ast.TypeName{Name: "time without time zone"},
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
@@ -23966,10 +24634,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "timetz",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "time with time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
+					Type: &ast.TypeName{Name: "time without time zone"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "time with time zone"},
@@ -23978,7 +24643,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "timetz",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "time without time zone"},
+					Type: &ast.TypeName{Name: "time with time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "time with time zone"},
@@ -24206,18 +24874,6 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "interval"},
 				},
 				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
-		},
-		{
-			Name: "timezone",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "interval"},
-				},
-				{
 					Type: &ast.TypeName{Name: "timestamp with time zone"},
 				},
 			},
@@ -24239,7 +24895,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "timezone",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "interval"},
 				},
 				{
 					Type: &ast.TypeName{Name: "timestamp without time zone"},
@@ -24254,10 +24910,10 @@ func genPGCatalog() *catalog.Schema {
 					Type: &ast.TypeName{Name: "text"},
 				},
 				{
-					Type: &ast.TypeName{Name: "time with time zone"},
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "time with time zone"},
+			ReturnType: &ast.TypeName{Name: "timestamp with time zone"},
 		},
 		{
 			Name: "timezone",
@@ -24270,6 +24926,27 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "time with time zone"},
+		},
+		{
+			Name: "timezone",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+				{
+					Type: &ast.TypeName{Name: "time with time zone"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "time with time zone"},
+		},
+		{
+			Name: "to_ascii",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "to_ascii",
@@ -24296,8 +24973,11 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
-			Name: "to_ascii",
+			Name: "to_char",
 			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "bigint"},
+				},
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -24308,19 +24988,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "to_char",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "timestamp without time zone"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "to_char",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "real"},
+					Type: &ast.TypeName{Name: "double precision"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -24333,18 +25001,6 @@ func genPGCatalog() *catalog.Schema {
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "to_char",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "timestamp with time zone"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -24380,7 +25036,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "to_char",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "double precision"},
+					Type: &ast.TypeName{Name: "real"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -24392,7 +25048,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "to_char",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bigint"},
+					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "to_char",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "timestamp with time zone"},
 				},
 				{
 					Type: &ast.TypeName{Name: "text"},
@@ -24468,6 +25136,15 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "regclass"},
+		},
+		{
+			Name: "to_regcollation",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "regcollation"},
 		},
 		{
 			Name: "to_regnamespace",
@@ -24587,39 +25264,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "to_tsvector",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "tsvector"},
-		},
-		{
-			Name: "to_tsvector",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "regconfig"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "tsvector"},
-		},
-		{
-			Name: "to_tsvector",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "jsonb"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "tsvector"},
-		},
-		{
-			Name: "to_tsvector",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "regconfig"},
-				},
-				{
 					Type: &ast.TypeName{Name: "jsonb"},
 				},
 			},
@@ -24633,6 +25277,39 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "json"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "tsvector"},
+		},
+		{
+			Name: "to_tsvector",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regconfig"},
+				},
+				{
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "tsvector"},
+		},
+		{
+			Name: "to_tsvector",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regconfig"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "tsvector"},
+		},
+		{
+			Name: "to_tsvector",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "tsvector"},
@@ -24676,13 +25353,22 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "cstring"},
 		},
 		{
-			Name: "trunc",
+			Name: "trim_scale",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "numeric"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "trunc",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
 			Name: "trunc",
@@ -24708,9 +25394,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "numeric"},
 				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
@@ -24718,10 +25401,13 @@ func genPGCatalog() *catalog.Schema {
 			Name: "trunc",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "double precision"},
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
+			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
 			Name: "ts_delete",
@@ -24775,6 +25461,81 @@ func genPGCatalog() *catalog.Schema {
 			Name: "ts_headline",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "json"},
+				},
+				{
+					Type: &ast.TypeName{Name: "tsquery"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "json"},
+		},
+		{
+			Name: "ts_headline",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regconfig"},
+				},
+				{
+					Type: &ast.TypeName{Name: "json"},
+				},
+				{
+					Type: &ast.TypeName{Name: "tsquery"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "json"},
+		},
+		{
+			Name: "ts_headline",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "regconfig"},
+				},
+				{
+					Type: &ast.TypeName{Name: "json"},
+				},
+				{
+					Type: &ast.TypeName{Name: "tsquery"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "json"},
+		},
+		{
+			Name: "ts_headline",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Type: &ast.TypeName{Name: "tsquery"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "jsonb"},
+		},
+		{
+			Name: "ts_headline",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "jsonb"},
+				},
+				{
+					Type: &ast.TypeName{Name: "tsquery"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "jsonb"},
+		},
+		{
+			Name: "ts_headline",
+			Args: []*catalog.Argument{
+				{
 					Type: &ast.TypeName{Name: "regconfig"},
 				},
 				{
@@ -24792,96 +25553,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "regconfig"},
 				},
-				{
-					Type: &ast.TypeName{Name: "jsonb"},
-				},
-				{
-					Type: &ast.TypeName{Name: "tsquery"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "jsonb"},
-		},
-		{
-			Name: "ts_headline",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "tsquery"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "ts_headline",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-				{
-					Type: &ast.TypeName{Name: "tsquery"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "text"},
-		},
-		{
-			Name: "ts_headline",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "regconfig"},
-				},
-				{
-					Type: &ast.TypeName{Name: "json"},
-				},
-				{
-					Type: &ast.TypeName{Name: "tsquery"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "json"},
-		},
-		{
-			Name: "ts_headline",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "regconfig"},
-				},
-				{
-					Type: &ast.TypeName{Name: "json"},
-				},
-				{
-					Type: &ast.TypeName{Name: "tsquery"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "json"},
-		},
-		{
-			Name: "ts_headline",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "json"},
-				},
-				{
-					Type: &ast.TypeName{Name: "tsquery"},
-				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "json"},
-		},
-		{
-			Name: "ts_headline",
-			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "jsonb"},
 				},
@@ -24913,20 +25584,35 @@ func genPGCatalog() *catalog.Schema {
 			Name: "ts_headline",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "jsonb"},
+					Type: &ast.TypeName{Name: "regconfig"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 				{
 					Type: &ast.TypeName{Name: "tsquery"},
 				},
+				{
+					Type: &ast.TypeName{Name: "text"},
+				},
 			},
-			ReturnType: &ast.TypeName{Name: "jsonb"},
+			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "ts_headline",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "regconfig"},
+					Type: &ast.TypeName{Name: "text"},
 				},
+				{
+					Type: &ast.TypeName{Name: "tsquery"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "text"},
+		},
+		{
+			Name: "ts_headline",
+			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -25011,24 +25697,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "tsquery"},
 				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "real"},
-		},
-		{
-			Name: "ts_rank",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "tsvector"},
-				},
-				{
-					Type: &ast.TypeName{Name: "tsquery"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "real"},
 		},
@@ -25044,6 +25712,9 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "tsquery"},
 				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
 			},
 			ReturnType: &ast.TypeName{Name: "real"},
 		},
@@ -25060,19 +25731,7 @@ func genPGCatalog() *catalog.Schema {
 			ReturnType: &ast.TypeName{Name: "real"},
 		},
 		{
-			Name: "ts_rank_cd",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "tsvector"},
-				},
-				{
-					Type: &ast.TypeName{Name: "tsquery"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "real"},
-		},
-		{
-			Name: "ts_rank_cd",
+			Name: "ts_rank",
 			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "tsvector"},
@@ -25107,6 +25766,33 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "real[]"},
 				},
+				{
+					Type: &ast.TypeName{Name: "tsvector"},
+				},
+				{
+					Type: &ast.TypeName{Name: "tsquery"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "real"},
+		},
+		{
+			Name: "ts_rank_cd",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "tsvector"},
+				},
+				{
+					Type: &ast.TypeName{Name: "tsquery"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "real"},
+		},
+		{
+			Name: "ts_rank_cd",
+			Args: []*catalog.Argument{
 				{
 					Type: &ast.TypeName{Name: "tsvector"},
 				},
@@ -25314,9 +26000,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "tsquery"},
 				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "tsquery"},
 		},
@@ -25328,6 +26011,9 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "tsquery"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "tsquery"},
@@ -25368,9 +26054,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "timestamp without time zone"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "tsrange"},
 		},
@@ -25382,6 +26065,9 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "timestamp without time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "tsrange"},
@@ -25407,9 +26093,6 @@ func genPGCatalog() *catalog.Schema {
 				{
 					Type: &ast.TypeName{Name: "timestamp with time zone"},
 				},
-				{
-					Type: &ast.TypeName{Name: "text"},
-				},
 			},
 			ReturnType: &ast.TypeName{Name: "tstzrange"},
 		},
@@ -25421,6 +26104,9 @@ func genPGCatalog() *catalog.Schema {
 				},
 				{
 					Type: &ast.TypeName{Name: "timestamp with time zone"},
+				},
+				{
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "tstzrange"},
@@ -25714,19 +26400,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "upper",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "text"},
+					Type: &ast.TypeName{Name: "anyrange"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "text"},
+			ReturnType: &ast.TypeName{Name: "anyelement"},
 		},
 		{
 			Name: "upper",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "anyrange"},
+					Type: &ast.TypeName{Name: "text"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "anyelement"},
+			ReturnType: &ast.TypeName{Name: "text"},
 		},
 		{
 			Name: "upper_inc",
@@ -25882,24 +26568,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "var_pop",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "var_pop",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "var_pop",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "double precision"},
 				},
 			},
@@ -25918,7 +26586,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "var_pop",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "smallint"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
@@ -25927,10 +26595,37 @@ func genPGCatalog() *catalog.Schema {
 			Name: "var_pop",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bigint"},
+					Type: &ast.TypeName{Name: "integer"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "var_pop",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "var_pop",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "smallint"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "numeric"},
+		},
+		{
+			Name: "var_samp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
 			Name: "var_samp",
@@ -25945,7 +26640,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "var_samp",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "smallint"},
+					Type: &ast.TypeName{Name: "bigint"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
@@ -25963,15 +26658,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "var_samp",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "bigint"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
-		},
-		{
-			Name: "var_samp",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "numeric"},
 				},
 			},
@@ -25981,10 +26667,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "var_samp",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "double precision"},
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
+			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
 			Name: "varbit",
@@ -26140,7 +26826,13 @@ func genPGCatalog() *catalog.Schema {
 			Name: "varchar",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "name"},
+					Type: &ast.TypeName{Name: "character varying"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+				{
+					Type: &ast.TypeName{Name: "boolean"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "character varying"},
@@ -26149,13 +26841,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "varchar",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "character varying"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-				{
-					Type: &ast.TypeName{Name: "boolean"},
+					Type: &ast.TypeName{Name: "name"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "character varying"},
@@ -26215,10 +26901,19 @@ func genPGCatalog() *catalog.Schema {
 			Name: "variance",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "numeric"},
+					Type: &ast.TypeName{Name: "double precision"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "numeric"},
+			ReturnType: &ast.TypeName{Name: "double precision"},
+		},
+		{
+			Name: "variance",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "real"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "double precision"},
 		},
 		{
 			Name: "variance",
@@ -26242,7 +26937,7 @@ func genPGCatalog() *catalog.Schema {
 			Name: "variance",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "smallint"},
+					Type: &ast.TypeName{Name: "numeric"},
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "numeric"},
@@ -26251,19 +26946,10 @@ func genPGCatalog() *catalog.Schema {
 			Name: "variance",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "real"},
+					Type: &ast.TypeName{Name: "smallint"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
-		},
-		{
-			Name: "variance",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "double precision"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "double precision"},
+			ReturnType: &ast.TypeName{Name: "numeric"},
 		},
 		{
 			Name:       "version",
@@ -26301,6 +26987,9 @@ func genPGCatalog() *catalog.Schema {
 			Name: "websearch_to_tsquery",
 			Args: []*catalog.Argument{
 				{
+					Type: &ast.TypeName{Name: "regconfig"},
+				},
+				{
 					Type: &ast.TypeName{Name: "text"},
 				},
 			},
@@ -26309,9 +26998,6 @@ func genPGCatalog() *catalog.Schema {
 		{
 			Name: "websearch_to_tsquery",
 			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "regconfig"},
-				},
 				{
 					Type: &ast.TypeName{Name: "text"},
 				},
@@ -26331,42 +27017,6 @@ func genPGCatalog() *catalog.Schema {
 			Name: "width_bucket",
 			Args: []*catalog.Argument{
 				{
-					Type: &ast.TypeName{Name: "double precision"},
-				},
-				{
-					Type: &ast.TypeName{Name: "double precision"},
-				},
-				{
-					Type: &ast.TypeName{Name: "double precision"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "width_bucket",
-			Args: []*catalog.Argument{
-				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-				{
-					Type: &ast.TypeName{Name: "numeric"},
-				},
-				{
-					Type: &ast.TypeName{Name: "integer"},
-				},
-			},
-			ReturnType: &ast.TypeName{Name: "integer"},
-		},
-		{
-			Name: "width_bucket",
-			Args: []*catalog.Argument{
-				{
 					Type: &ast.TypeName{Name: "anyelement"},
 				},
 				{
@@ -26374,6 +27024,162 @@ func genPGCatalog() *catalog.Schema {
 				},
 			},
 			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "width_bucket",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+				{
+					Type: &ast.TypeName{Name: "double precision"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "width_bucket",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+				{
+					Type: &ast.TypeName{Name: "numeric"},
+				},
+				{
+					Type: &ast.TypeName{Name: "integer"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "xid",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "xid"},
+		},
+		{
+			Name: "xid8cmp",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "integer"},
+		},
+		{
+			Name: "xid8eq",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "xid8ge",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "xid8gt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "xid8in",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "cstring"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "xid8"},
+		},
+		{
+			Name: "xid8le",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "xid8lt",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "xid8ne",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "boolean"},
+		},
+		{
+			Name: "xid8out",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "cstring"},
+		},
+		{
+			Name: "xid8send",
+			Args: []*catalog.Argument{
+				{
+					Type: &ast.TypeName{Name: "xid8"},
+				},
+			},
+			ReturnType: &ast.TypeName{Name: "bytea"},
 		},
 		{
 			Name: "xideq",

--- a/internal/tools/sqlc-pg-gen/main.go
+++ b/internal/tools/sqlc-pg-gen/main.go
@@ -29,7 +29,8 @@ LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
 WHERE n.nspname OPERATOR(pg_catalog.~) '^(pg_catalog)$'
   AND p.proargmodes IS NULL
   AND pg_function_is_visible(p.oid)
-ORDER BY 1;
+-- simply order all columns to keep subsequent runs stable
+ORDER BY 1, 2, 3, 4;
 `
 
 // https://dba.stackexchange.com/questions/255412/how-to-select-functions-that-belong-in-a-given-extension-in-postgresql
@@ -54,7 +55,8 @@ FROM pg_catalog.pg_proc p
 JOIN extension_funcs ef ON ef.oid = p.oid
 WHERE p.proargmodes IS NULL
   AND pg_function_is_visible(p.oid)
-ORDER BY 1;
+-- simply order all columns to keep subsequent runs stable
+ORDER BY 1, 2, 3, 4;
 `
 
 const catalogTmpl = `

--- a/internal/tools/sqlc-pg-gen/main.go
+++ b/internal/tools/sqlc-pg-gen/main.go
@@ -25,7 +25,6 @@ SELECT p.proname as name,
 FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
 WHERE n.nspname OPERATOR(pg_catalog.~) '^(pg_catalog)$'
-  AND p.proargmodes IS NULL
   AND pg_function_is_visible(p.oid)
 -- simply order all columns to keep subsequent runs stable
 ORDER BY 1, 2, 3, 4, 5;
@@ -52,8 +51,7 @@ SELECT p.proname as name,
   p.proargmodes::text[]
 FROM pg_catalog.pg_proc p
 JOIN extension_funcs ef ON ef.oid = p.oid
-WHERE p.proargmodes IS NULL
-  AND pg_function_is_visible(p.oid)
+WHERE pg_function_is_visible(p.oid)
 -- simply order all columns to keep subsequent runs stable
 ORDER BY 1, 2, 3, 4, 5;
 `

--- a/internal/tools/sqlc-pg-gen/main.go
+++ b/internal/tools/sqlc-pg-gen/main.go
@@ -166,6 +166,20 @@ func (p *Proc) Args() []Arg {
 		})
 	}
 
+	// Some manual changes until https://github.com/kyleconroy/sqlc/pull/1748
+	// can be completely implmented
+	if p.Name == "mode" {
+		return nil
+	}
+
+	if p.Name == "percentile_cont" && len(args) == 2 {
+		args = args[:1]
+	}
+
+	if p.Name == "percentile_disc" && len(args) == 2 {
+		args = args[:1]
+	}
+
 	return args
 }
 


### PR DESCRIPTION
This is sort of a yak-shaving task for https://github.com/kyleconroy/sqlc/pull/1748

Problem: there seem to have been some manual edits to pg_catalog.go over the course of time.  This makes it hard (almost impossible actually) to do any change there with any confidence.

Solution: Do some detective work on the manual edits performed, and incorporate them into pg-gen.  Once that is done the work on #1748 will be a lot easier.

Here are the 2 manual edits as far as I can tell:
https://github.com/kyleconroy/sqlc/commit/95131550616d8d06c9a484e948e91a6a7ed7b3cc (pg_catalog functions with variadic signatures - this is completely solved by this PR)

And

https://github.com/kyleconroy/sqlc/commit/846c6298ca0a53ab0cf176d16b4da56c52345d3c (manual edits to pg_catalog that I _believe_ will be fixed "right way" once "direct args" vs "aggregated args" are separated in #1748 ).

Commits in order tell a story, probably best to review that way.

