### PR TITLE
fix: version support in error message

### DIFF
--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -27,7 +27,7 @@ import (
 )
 
 const errMessageNoVersion = `The configuration file must have a version number.
-Set the version to 1 at the top of sqlc.json:
+Set the version to 1 or 2 at the top of sqlc.json:
 
 {
   "version": "1"
@@ -36,7 +36,7 @@ Set the version to 1 at the top of sqlc.json:
 `
 
 const errMessageUnknownVersion = `The configuration file has an invalid version number.
-The only supported version is "1".
+The supported version can only be "1" or "2".
 `
 
 const errMessageNoPackages = `No packages are configured`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,21 +10,6 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-const errMessageNoVersion = `The configuration file must have a version number.
-Set the version to 1 at the top of sqlc.json:
-
-{
-  "version": "1"
-  ...
-}
-`
-
-const errMessageUnknownVersion = `The configuration file has an invalid version number.
-The only supported version is "1".
-`
-
-const errMessageNoPackages = `No packages are configured`
-
 type versionSetting struct {
 	Number string `json:"version" yaml:"version"`
 }


### PR DESCRIPTION
Currently when use version "3" for testing, it returns:
```
The configuration file has an invalid version number.
The only supported version is "1".
```

while `version "2"` is also supported.