### PR TITLE
fix: named params contribute to batch parameter count

### DIFF
--- a/examples/batch/postgresql/batch.go
+++ b/examples/batch/postgresql/batch.go
@@ -213,6 +213,94 @@ func (b *DeleteBookBatchResults) Close() error {
 	return b.br.Close()
 }
 
+const deleteBookNamedFunc = `-- name: DeleteBookNamedFunc :batchexec
+DELETE FROM books
+WHERE book_id = $1
+`
+
+type DeleteBookNamedFuncBatchResults struct {
+	br     pgx.BatchResults
+	tot    int
+	closed bool
+}
+
+func (q *Queries) DeleteBookNamedFunc(ctx context.Context, bookID []int32) *DeleteBookNamedFuncBatchResults {
+	batch := &pgx.Batch{}
+	for _, a := range bookID {
+		vals := []interface{}{
+			a,
+		}
+		batch.Queue(deleteBookNamedFunc, vals...)
+	}
+	br := q.db.SendBatch(ctx, batch)
+	return &DeleteBookNamedFuncBatchResults{br, len(bookID), false}
+}
+
+func (b *DeleteBookNamedFuncBatchResults) Exec(f func(int, error)) {
+	defer b.br.Close()
+	for t := 0; t < b.tot; t++ {
+		if b.closed {
+			if f != nil {
+				f(t, errors.New("batch already closed"))
+			}
+			continue
+		}
+		_, err := b.br.Exec()
+		if f != nil {
+			f(t, err)
+		}
+	}
+}
+
+func (b *DeleteBookNamedFuncBatchResults) Close() error {
+	b.closed = true
+	return b.br.Close()
+}
+
+const deleteBookNamedSign = `-- name: DeleteBookNamedSign :batchexec
+DELETE FROM books
+WHERE book_id = $1
+`
+
+type DeleteBookNamedSignBatchResults struct {
+	br     pgx.BatchResults
+	tot    int
+	closed bool
+}
+
+func (q *Queries) DeleteBookNamedSign(ctx context.Context, bookID []int32) *DeleteBookNamedSignBatchResults {
+	batch := &pgx.Batch{}
+	for _, a := range bookID {
+		vals := []interface{}{
+			a,
+		}
+		batch.Queue(deleteBookNamedSign, vals...)
+	}
+	br := q.db.SendBatch(ctx, batch)
+	return &DeleteBookNamedSignBatchResults{br, len(bookID), false}
+}
+
+func (b *DeleteBookNamedSignBatchResults) Exec(f func(int, error)) {
+	defer b.br.Close()
+	for t := 0; t < b.tot; t++ {
+		if b.closed {
+			if f != nil {
+				f(t, errors.New("batch already closed"))
+			}
+			continue
+		}
+		_, err := b.br.Exec()
+		if f != nil {
+			f(t, err)
+		}
+	}
+}
+
+func (b *DeleteBookNamedSignBatchResults) Close() error {
+	b.closed = true
+	return b.br.Close()
+}
+
 const getBiography = `-- name: GetBiography :batchone
 SELECT biography FROM authors
 WHERE author_id = $1

--- a/examples/batch/postgresql/querier.go
+++ b/examples/batch/postgresql/querier.go
@@ -16,6 +16,8 @@ type Querier interface {
 	CreateBook(ctx context.Context, arg []CreateBookParams) *CreateBookBatchResults
 	DeleteBook(ctx context.Context, bookID []int32) *DeleteBookBatchResults
 	DeleteBookExecResult(ctx context.Context, bookID int32) (pgconn.CommandTag, error)
+	DeleteBookNamedFunc(ctx context.Context, bookID []int32) *DeleteBookNamedFuncBatchResults
+	DeleteBookNamedSign(ctx context.Context, bookID []int32) *DeleteBookNamedSignBatchResults
 	GetAuthor(ctx context.Context, authorID int32) (Author, error)
 	GetBiography(ctx context.Context, authorID []int32) *GetBiographyBatchResults
 	UpdateBook(ctx context.Context, arg []UpdateBookParams) *UpdateBookBatchResults

--- a/examples/batch/postgresql/query.sql
+++ b/examples/batch/postgresql/query.sql
@@ -10,6 +10,14 @@ WHERE book_id = $1;
 DELETE FROM books
 WHERE book_id = $1;
 
+-- name: DeleteBookNamedFunc :batchexec
+DELETE FROM books
+WHERE book_id = sqlc.arg(book_id);
+
+-- name: DeleteBookNamedSign :batchexec
+DELETE FROM books
+WHERE book_id = @book_id;
+
 -- name: BooksByYear :batchmany
 SELECT * FROM books
 WHERE year = $1;

--- a/internal/compiler/parse.go
+++ b/internal/compiler/parse.go
@@ -80,11 +80,10 @@ func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query,
 	if err != nil {
 		return nil, err
 	}
+	raw, namedParams, edits := rewrite.NamedParameters(c.conf.Engine, raw, numbers, dollar)
 	if err := validate.Cmd(raw.Stmt, name, cmd); err != nil {
 		return nil, err
 	}
-
-	raw, namedParams, edits := rewrite.NamedParameters(c.conf.Engine, raw, numbers, dollar)
 	rvs := rangeVars(raw.Stmt)
 	refs, err := findParameters(raw.Stmt)
 	if err != nil {

--- a/internal/sql/validate/cmd.go
+++ b/internal/sql/validate/cmd.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/kyleconroy/sqlc/internal/metadata"
 	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/kyleconroy/sqlc/internal/sql/astutils"
+	"github.com/kyleconroy/sqlc/internal/sql/named"
 )
 
 func validateCopyfrom(n ast.Node) error {
@@ -45,6 +47,11 @@ func validateCopyfrom(n ast.Node) error {
 }
 
 func validateBatch(n ast.Node) error {
+	namedFunc := astutils.Search(n, named.IsParamFunc)
+	namedSign := astutils.Search(n, named.IsParamSign)
+	if len(namedFunc.Items)+len(namedSign.Items) > 0 {
+		return nil
+	}
 	nums, _, _ := ParamRef(n)
 	if len(nums) == 0 {
 		return errors.New(":batch* commands require parameters")

--- a/internal/sql/validate/cmd.go
+++ b/internal/sql/validate/cmd.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/kyleconroy/sqlc/internal/metadata"
 	"github.com/kyleconroy/sqlc/internal/sql/ast"
-	"github.com/kyleconroy/sqlc/internal/sql/astutils"
-	"github.com/kyleconroy/sqlc/internal/sql/named"
 )
 
 func validateCopyfrom(n ast.Node) error {
@@ -47,11 +45,6 @@ func validateCopyfrom(n ast.Node) error {
 }
 
 func validateBatch(n ast.Node) error {
-	namedFunc := astutils.Search(n, named.IsParamFunc)
-	namedSign := astutils.Search(n, named.IsParamSign)
-	if len(namedFunc.Items)+len(namedSign.Items) > 0 {
-		return nil
-	}
 	nums, _, _ := ParamRef(n)
 	if len(nums) == 0 {
 		return errors.New(":batch* commands require parameters")


### PR DESCRIPTION
The batch validation code was only allowing numbered params contribute to the total parameter count of a query, which prevented batch queries with only named parameters from successfully generating code.

Fixes #1625