### PR TITLE
fix: batch imports filter queries, update cmds having ret type

### DIFF
--- a/examples/batch/postgresql/models.go
+++ b/examples/batch/postgresql/models.go
@@ -8,6 +8,8 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"time"
+
+	"github.com/jackc/pgtype"
 )
 
 type BookType string
@@ -53,8 +55,9 @@ func (ns NullBookType) Value() (driver.Value, error) {
 }
 
 type Author struct {
-	AuthorID int32  `json:"author_id"`
-	Name     string `json:"name"`
+	AuthorID  int32        `json:"author_id"`
+	Name      string       `json:"name"`
+	Biography pgtype.JSONB `json:"biography"`
 }
 
 type Book struct {

--- a/examples/batch/postgresql/querier.go
+++ b/examples/batch/postgresql/querier.go
@@ -6,6 +6,8 @@ package batch
 
 import (
 	"context"
+
+	"github.com/jackc/pgconn"
 )
 
 type Querier interface {
@@ -13,6 +15,7 @@ type Querier interface {
 	CreateAuthor(ctx context.Context, name string) (Author, error)
 	CreateBook(ctx context.Context, arg []CreateBookParams) *CreateBookBatchResults
 	DeleteBook(ctx context.Context, bookID []int32) *DeleteBookBatchResults
+	DeleteBookExecResult(ctx context.Context, bookID int32) (pgconn.CommandTag, error)
 	GetAuthor(ctx context.Context, authorID int32) (Author, error)
 	UpdateBook(ctx context.Context, arg []UpdateBookParams) *UpdateBookBatchResults
 }

--- a/examples/batch/postgresql/querier.go
+++ b/examples/batch/postgresql/querier.go
@@ -17,6 +17,7 @@ type Querier interface {
 	DeleteBook(ctx context.Context, bookID []int32) *DeleteBookBatchResults
 	DeleteBookExecResult(ctx context.Context, bookID int32) (pgconn.CommandTag, error)
 	GetAuthor(ctx context.Context, authorID int32) (Author, error)
+	GetBiography(ctx context.Context, authorID []int32) *GetBiographyBatchResults
 	UpdateBook(ctx context.Context, arg []UpdateBookParams) *UpdateBookBatchResults
 }
 

--- a/examples/batch/postgresql/query.sql
+++ b/examples/batch/postgresql/query.sql
@@ -42,3 +42,7 @@ RETURNING *;
 UPDATE books
 SET title = $1, tags = $2
 WHERE book_id = $3;
+
+-- name: GetBiography :batchone
+SELECT biography FROM authors
+WHERE author_id = $1;

--- a/examples/batch/postgresql/query.sql
+++ b/examples/batch/postgresql/query.sql
@@ -2,6 +2,10 @@
 SELECT * FROM authors
 WHERE author_id = $1;
 
+-- name: DeleteBookExecResult :execresult
+DELETE FROM books
+WHERE book_id = $1;
+
 -- name: DeleteBook :batchexec
 DELETE FROM books
 WHERE book_id = $1;

--- a/examples/batch/postgresql/query.sql.go
+++ b/examples/batch/postgresql/query.sql.go
@@ -13,13 +13,13 @@ import (
 
 const createAuthor = `-- name: CreateAuthor :one
 INSERT INTO authors (name) VALUES ($1)
-RETURNING author_id, name
+RETURNING author_id, name, biography
 `
 
 func (q *Queries) CreateAuthor(ctx context.Context, name string) (Author, error) {
 	row := q.db.QueryRow(ctx, createAuthor, name)
 	var i Author
-	err := row.Scan(&i.AuthorID, &i.Name)
+	err := row.Scan(&i.AuthorID, &i.Name, &i.Biography)
 	return i, err
 }
 
@@ -33,13 +33,13 @@ func (q *Queries) DeleteBookExecResult(ctx context.Context, bookID int32) (pgcon
 }
 
 const getAuthor = `-- name: GetAuthor :one
-SELECT author_id, name FROM authors
+SELECT author_id, name, biography FROM authors
 WHERE author_id = $1
 `
 
 func (q *Queries) GetAuthor(ctx context.Context, authorID int32) (Author, error) {
 	row := q.db.QueryRow(ctx, getAuthor, authorID)
 	var i Author
-	err := row.Scan(&i.AuthorID, &i.Name)
+	err := row.Scan(&i.AuthorID, &i.Name, &i.Biography)
 	return i, err
 }

--- a/examples/batch/postgresql/query.sql.go
+++ b/examples/batch/postgresql/query.sql.go
@@ -7,6 +7,8 @@ package batch
 
 import (
 	"context"
+
+	"github.com/jackc/pgconn"
 )
 
 const createAuthor = `-- name: CreateAuthor :one
@@ -19,6 +21,15 @@ func (q *Queries) CreateAuthor(ctx context.Context, name string) (Author, error)
 	var i Author
 	err := row.Scan(&i.AuthorID, &i.Name)
 	return i, err
+}
+
+const deleteBookExecResult = `-- name: DeleteBookExecResult :execresult
+DELETE FROM books
+WHERE book_id = $1
+`
+
+func (q *Queries) DeleteBookExecResult(ctx context.Context, bookID int32) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, deleteBookExecResult, bookID)
 }
 
 const getAuthor = `-- name: GetAuthor :one

--- a/examples/batch/postgresql/schema.sql
+++ b/examples/batch/postgresql/schema.sql
@@ -1,6 +1,7 @@
 CREATE TABLE authors (
           author_id SERIAL PRIMARY KEY,
-          name text NOT NULL DEFAULT ''
+          name text NOT NULL DEFAULT '',
+          biography JSONB
 );
 
 CREATE TYPE book_type AS ENUM (

--- a/internal/codegen/golang/imports.go
+++ b/internal/codegen/golang/imports.go
@@ -409,15 +409,12 @@ func (i *importer) copyfromImports() fileImports {
 func (i *importer) batchImports(filename string) fileImports {
 	batchQueries := make([]Query, 0, len(i.Queries))
 	for _, q := range i.Queries {
-		if q.Cmd == metadata.CmdBatchExec || q.Cmd == metadata.CmdBatchMany || q.Cmd == metadata.CmdBatchOne {
+		if usesBatch([]Query{q}) {
 			batchQueries = append(batchQueries, q)
 		}
 	}
 	std, pkg := buildImports(i.Settings, batchQueries, func(name string) bool {
-		for _, q := range i.Queries {
-			if !usesBatch([]Query{q}) {
-				continue
-			}
+		for _, q := range batchQueries {
 			if q.hasRetType() {
 				if q.Ret.EmitStruct() {
 					for _, f := range q.Ret.Struct.Fields {

--- a/internal/codegen/golang/imports.go
+++ b/internal/codegen/golang/imports.go
@@ -239,6 +239,9 @@ func (i *importer) interfaceImports() fileImports {
 	std, pkg := buildImports(i.Settings, i.Queries, func(name string) bool {
 		for _, q := range i.Queries {
 			if q.hasRetType() {
+				if usesBatch([]Query{q}) {
+					continue
+				}
 				if strings.HasPrefix(q.Ret.Type(), name) {
 					return true
 				}

--- a/internal/codegen/golang/imports.go
+++ b/internal/codegen/golang/imports.go
@@ -407,7 +407,13 @@ func (i *importer) copyfromImports() fileImports {
 }
 
 func (i *importer) batchImports(filename string) fileImports {
-	std, pkg := buildImports(i.Settings, i.Queries, func(name string) bool {
+	batchQueries := make([]Query, 0, len(i.Queries))
+	for _, q := range i.Queries {
+		if q.Cmd == metadata.CmdBatchExec || q.Cmd == metadata.CmdBatchMany || q.Cmd == metadata.CmdBatchOne {
+			batchQueries = append(batchQueries, q)
+		}
+	}
+	std, pkg := buildImports(i.Settings, batchQueries, func(name string) bool {
 		for _, q := range i.Queries {
 			if !usesBatch([]Query{q}) {
 				continue

--- a/internal/codegen/golang/query.go
+++ b/internal/codegen/golang/query.go
@@ -165,7 +165,8 @@ type Query struct {
 }
 
 func (q Query) hasRetType() bool {
-	scanned := q.Cmd == metadata.CmdOne || q.Cmd == metadata.CmdMany
+	scanned := q.Cmd == metadata.CmdOne || q.Cmd == metadata.CmdMany ||
+		q.Cmd == metadata.CmdBatchMany || q.Cmd == metadata.CmdBatchOne
 	return scanned && !q.Ret.isEmpty()
 }
 


### PR DESCRIPTION
The original code was using all queries to build the batch imports, so the `batch.go` file was including extraneous imports that were not needed.

And also include batch cmd commands as having return types, which was preventing the build imports code for batch queries to never return true for return types.

Fixes #1682
Fixes #1792