### PR TITLE
fix: initialize generated code outside function

### DIFF
--- a/internal/tools/sqlc-pg-gen/main.go
+++ b/internal/tools/sqlc-pg-gen/main.go
@@ -51,31 +51,33 @@ import (
 	"github.com/kyleconroy/sqlc/internal/sql/catalog"
 )
 
+var funcs{{.GenFnName}} = []*catalog.Function {
+    {{- range .Procs}}
+	{
+		Name: "{{.Name}}",
+		Args: []*catalog.Argument{
+			{{range .Args}}{
+			{{- if .Name}}
+			Name: "{{.Name}}",
+			{{- end}}
+			{{- if .HasDefault}}
+			HasDefault: true,
+			{{- end}}
+			Type: &ast.TypeName{Name: "{{.TypeName}}"},
+			{{- if ne .Mode "i" }}
+			Mode: {{ .GoMode }},
+			{{- end}}
+			},
+			{{end}}
+		},
+		ReturnType: &ast.TypeName{Name: "{{.ReturnTypeName}}"},
+	},
+	{{- end}}
+}
+
 func {{.GenFnName}}() *catalog.Schema {
 	s := &catalog.Schema{Name: "{{ .SchemaName }}"}
-	s.Funcs = []*catalog.Function{
-	    {{- range .Procs}}
-		{
-			Name: "{{.Name}}",
-			Args: []*catalog.Argument{
-				{{range .Args}}{
-				{{- if .Name}}
-				Name: "{{.Name}}",
-				{{- end}}
-				{{- if .HasDefault}}
-				HasDefault: true,
-				{{- end}}
-				Type: &ast.TypeName{Name: "{{.TypeName}}"},
-				{{- if ne .Mode "i" }}
-				Mode: {{ .GoMode }},
-				{{- end}}
-				},
-				{{end}}
-			},
-			ReturnType: &ast.TypeName{Name: "{{.ReturnTypeName}}"},
-		},
-		{{- end}}
-	}
+	s.Funcs = funcs{{.GenFnName}}
 	{{- if .Relations }}
 	s.Tables = []*catalog.Table {
 	    {{- range .Relations }}


### PR DESCRIPTION
This fixes the compile/debug problem.
I need help re-generating pg_catalog.go etc. because when I call sqlc-pg-gen on my machine, the resulting file is a bit shorter and at least one endtoend test fails.

Refs: #1849 