### PR TITLE
Remove unnecessary `AUTOINCREMENT` from example

### DIFF
--- a/docs/tutorials/getting-started-sqlite.md
+++ b/docs/tutorials/getting-started-sqlite.md
@@ -32,7 +32,7 @@ create a file named `schema.sql` with the following contents:
 
 ```sql
 CREATE TABLE authors (
-  id   INTEGER PRIMARY KEY AUTOINCREMENT,
+  id   INTEGER PRIMARY KEY,
   name text    NOT NULL,
   bio  text
 );


### PR DESCRIPTION
Firstly, thanks for the great project.

According to [the sqlite documentation](https://www.sqlite.org/autoinc.html), the `AUTOINCREMENT` keyword shouldn't be used in normal cases:

> The AUTOINCREMENT keyword imposes extra CPU, memory, disk space, and disk I/O overhead and should be avoided if not strictly needed. **It is usually not needed**.

> On an INSERT, if the ROWID or INTEGER PRIMARY KEY column is not explicitly given a value, then it will be filled automatically with an unused integer, usually one more than the largest ROWID currently in use. **This is true regardless of whether or not the AUTOINCREMENT keyword is used**.