### PR TITLE
fix: NullEnums.Value() breaks SQL-Execution (#1880)

### DIFF
--- a/internal/codegen/golang/templates/template.tmpl
+++ b/internal/codegen/golang/templates/template.tmpl
@@ -107,7 +107,7 @@ func (ns Null{{.Name}}) Value() (driver.Value, error) {
 	if !ns.Valid {
 		return nil, nil
 	}
-	return ns.{{.Name}}, nil
+	return string(ns.{{.Name}}), nil
 }
 
 


### PR DESCRIPTION
I try to fix this issue
https://github.com/kyleconroy/sqlc/issues/1880