### PR TITLE
compiler: Move Kotlin parameter logic into codegen

### DIFF
--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -198,9 +198,6 @@ func Generate(ctx context.Context, e Env, dir, filename string, stderr io.Writer
 			lang = "golang"
 
 		case sql.Gen.Kotlin != nil:
-			if sql.Engine == config.EnginePostgreSQL {
-				parseOpts.UsePositionalParameters = true
-			}
 			lang = "kotlin"
 			name = combo.Kotlin.Package
 

--- a/internal/compiler/parse.go
+++ b/internal/compiler/parse.go
@@ -19,18 +19,6 @@ import (
 
 var ErrUnsupportedStatementType = errors.New("parseQuery: unsupported statement type")
 
-func rewriteNumberedParameters(refs []paramRef, raw *ast.RawStmt, sql string) ([]source.Edit, error) {
-	edits := make([]source.Edit, len(refs))
-	for i, ref := range refs {
-		edits[i] = source.Edit{
-			Location: ref.ref.Location - raw.StmtLocation,
-			Old:      fmt.Sprintf("$%d", ref.ref.Number),
-			New:      "?",
-		}
-	}
-	return edits, nil
-}
-
 func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query, error) {
 	if o.Debug.DumpAST {
 		debug.Dump(stmt)

--- a/internal/opts/parser.go
+++ b/internal/opts/parser.go
@@ -1,6 +1,5 @@
 package opts
 
 type Parser struct {
-	UsePositionalParameters bool
-	Debug                   Debug
+	Debug Debug
 }


### PR DESCRIPTION
`UsePositionalParameters` was only used by the Kotlin codegen package. Re-implement that logic inside Kotlin codegen without the compiler knowing about it.