### PR TITLE
fix(engine/dolphin): ReturnType in sum catalog fn for mysql schema GO (#1901)

### DIFF
--- a/internal/engine/dolphin/stdlib.go
+++ b/internal/engine/dolphin/stdlib.go
@@ -5202,7 +5202,7 @@ func defaultSchema(name string) *catalog.Schema {
 					Type: &ast.TypeName{Name: "any"},
 				},
 			},
-			ReturnType: &ast.TypeName{Name: "any"},
+			ReturnType: &ast.TypeName{Name: "bigint"},
 		},
 		{
 			Name:       "SYSDATE",


### PR DESCRIPTION
- fix sum ReturnType From `interface` to `bigint` for mysql schema.
- confirmed that it passes the already existing [func_match_types/mysql](https://github.com/kyleconroy/sqlc/tree/main/internal/endtoend/testdata/func_match_types/mysql) test
