### PR TITLE
codegen: surface batch validation errors

### DIFF
--- a/internal/sql/validate/cmd.go
+++ b/internal/sql/validate/cmd.go
@@ -45,7 +45,10 @@ func validateCopyfrom(n ast.Node) error {
 }
 
 func validateBatch(n ast.Node) error {
-	nums, _, _ := ParamRef(n)
+	nums, _, err := ParamRef(n)
+	if err != nil {
+		return err
+	}
 	if len(nums) == 0 {
 		return errors.New(":batch* commands require parameters")
 	}

--- a/internal/sql/validate/param_ref.go
+++ b/internal/sql/validate/param_ref.go
@@ -27,7 +27,7 @@ func ParamRef(n ast.Node) (map[int]bool, bool, error) {
 		}
 	}), n)
 	if dollar && nodollar {
-		return nil, false, errors.New("Can not mix $1 format with ? format")
+		return nil, false, errors.New("can not mix $1 format with ? format")
 	}
 
 	seen := map[int]bool{}


### PR DESCRIPTION
As a result of #1841 (letting named params contribute to param count), the call to `ParamRef` will actually fail for queries with mixed usage of numbered and named parameters. 

This PR mainly ensures that when the failure occurs, the error surfaced to the user makes it obvious what the issue is. Previously, the error would say `:batch* commands require parameters` when the actual error is that the parameters are being mixed.

Now it says `path/to/query.sql:1:1: could not determine data type of parameter $1` or
`path/to/query.sql:15:1: can not mix $1 format with ? format`

With this change, I believe mixed parameters are still allowed for non-batch queries, and I'm not sure if I should change that (please let me know through review).

#1625 