### PR TITLE
build: Run sqlc-pg-gen via GitHub Actions

### DIFF
--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -24,3 +24,10 @@ jobs:
         go-version: '1.19'
     - run: go build -o sqlc-pg-gen ./internal/tools/sqlc-pg-gen
     - run: ./sqlc-pg-gen
+      env:
+        PG_USER: postgres
+        PG_HOST: localhost
+        PG_DATABASE: postgres
+        PG_PASSWORD: postgres
+        PG_PORT: ${{ job.services.postgres.ports['5432'] }}
+

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -31,5 +31,9 @@ jobs:
         PG_DATABASE: postgres
         PG_PASSWORD: postgres
         PG_PORT: ${{ job.services.postgres.ports['5432'] }}
-    - run: find ./gen
+    - name: Save results
+      uses: actions/upload-artifact@v3
+      with:
+        name: sqlc-pg-gen-results
+        path: gen
 

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -1,0 +1,24 @@
+name: sqlc-pg-gen
+on: workflow_dispatch
+jobs:
+  gen:
+    name: sqlc-pg-gen
+    runs-on: ubuntu-22.04
+    services:
+      postgres:
+        image: postgres:15.0
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+        - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '1.19'
+    - run: go build -o sqlc-pg-gen ./internal/tools/sqlc-pg-gen
+    - run: ./sqlc-pg-gen

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -31,4 +31,5 @@ jobs:
         PG_DATABASE: postgres
         PG_PASSWORD: postgres
         PG_PORT: ${{ job.services.postgres.ports['5432'] }}
+    - run: find ./gen
 

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -1,5 +1,7 @@
 name: sqlc-pg-gen
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  pull_request:
 jobs:
   gen:
     name: sqlc-pg-gen

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -23,7 +23,8 @@ jobs:
       with:
         go-version: '1.19'
     - run: go build -o sqlc-pg-gen ./internal/tools/sqlc-pg-gen
-    - run: ./sqlc-pg-gen
+    - run: mkdir -p gen/contrib
+    - run: ./sqlc-pg-gen gen
       env:
         PG_USER: postgres
         PG_HOST: localhost

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -1,7 +1,6 @@
 name: sqlc-pg-gen
 on:
   workflow_dispatch:
-  pull_request:
 jobs:
   gen:
     name: sqlc-pg-gen

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       postgres:
-        image: postgres:15.0
+        image: postgres:15.0-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/internal/tools/sqlc-pg-gen/main.go
+++ b/internal/tools/sqlc-pg-gen/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
 	"go/format"
 	"log"
@@ -238,6 +239,13 @@ func databaseURL() string {
 }
 
 func run(ctx context.Context) error {
+	flag.Parse()
+
+	dir := flag.Arg(0)
+	if dir == "" {
+		dir = filepath.Join("internal", "engine", "postgresql")
+	}
+
 	tmpl, err := template.New("").Parse(catalogTmpl)
 	if err != nil {
 		return err
@@ -252,12 +260,12 @@ func run(ctx context.Context) error {
 		{
 			Name:      "pg_catalog",
 			GenFnName: "genPGCatalog",
-			DestPath:  filepath.Join("internal", "engine", "postgresql", "pg_catalog.go"),
+			DestPath:  filepath.Join(dir, "pg_catalog.go"),
 		},
 		{
 			Name:      "information_schema",
 			GenFnName: "genInformationSchema",
-			DestPath:  filepath.Join("internal", "engine", "postgresql", "information_schema.go"),
+			DestPath:  filepath.Join(dir, "information_schema.go"),
 		},
 	}
 
@@ -330,7 +338,7 @@ func run(ctx context.Context) error {
 			return false
 		})
 
-		extensionPath := filepath.Join("internal", "engine", "postgresql", "contrib", name+".go")
+		extensionPath := filepath.Join(dir, "contrib", name+".go")
 		err = writeFormattedGo(tmpl, tmplCtx{
 			Pkg:        "contrib",
 			SchemaName: "pg_catalog",
@@ -349,7 +357,7 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	extensionLoaderPath := filepath.Join("internal", "engine", "postgresql", "extension.go")
+	extensionLoaderPath := filepath.Join(dir, "extension.go")
 	err = writeFormattedGo(extensionTmpl, loaded, extensionLoaderPath)
 	if err != nil {
 		return err

--- a/internal/tools/sqlc-pg-gen/main.go
+++ b/internal/tools/sqlc-pg-gen/main.go
@@ -209,12 +209,40 @@ func preserveLegacyCatalogBehavior(allProcs []Proc) []Proc {
 	return procs
 }
 
+func databaseURL() string {
+	dburl := os.Getenv("DATABASE_URL")
+	if dburl != "" {
+		return dburl
+	}
+	pgUser := os.Getenv("PG_USER")
+	pgHost := os.Getenv("PG_HOST")
+	pgPort := os.Getenv("PG_PORT")
+	pgPass := os.Getenv("PG_PASSWORD")
+	pgDB := os.Getenv("PG_DATABASE")
+	if pgUser == "" {
+		pgUser = "postgres"
+	}
+	if pgPass == "" {
+		pgPass = "mysecretpassword"
+	}
+	if pgPort == "" {
+		pgPort = "5432"
+	}
+	if pgHost == "" {
+		pgHost = "127.0.0.1"
+	}
+	if pgDB == "" {
+		pgDB = "dinotest"
+	}
+	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", pgUser, pgPass, pgHost, pgPort, pgDB)
+}
+
 func run(ctx context.Context) error {
 	tmpl, err := template.New("").Parse(catalogTmpl)
 	if err != nil {
 		return err
 	}
-	conn, err := pgx.Connect(ctx, os.Getenv("DATABASE_URL"))
+	conn, err := pgx.Connect(ctx, databaseURL())
 	if err != nil {
 		return err
 	}

--- a/internal/tools/sqlc-pg-gen/main.go
+++ b/internal/tools/sqlc-pg-gen/main.go
@@ -300,8 +300,7 @@ func run(ctx context.Context) error {
 
 		_, err := conn.Exec(ctx, fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS \"%s\"", extension))
 		if err != nil {
-			log.Printf("error creating %s: %s", extension, err)
-			continue
+			return fmt.Errorf("error creating %s: %s", extension, err)
 		}
 
 		rows, err := conn.Query(ctx, extensionFuncs, extension)
@@ -377,16 +376,16 @@ type extensionPair struct {
 var extensions = []string{
 	"adminpack",
 	"amcheck",
-	"auth_delay",
-	"auto_explain",
-	"bloom",
+	// "auth_delay",
+	// "auto_explain",
+	// "bloom",
 	"btree_gin",
 	"btree_gist",
 	"citext",
 	"cube",
 	"dblink",
-	"dict_int",
-	"dict_xsyn",
+	// "dict_int",
+	// "dict_xsyn",
 	"earthdistance",
 	"file_fdw",
 	"fuzzystrmatch",
@@ -397,26 +396,26 @@ var extensions = []string{
 	"lo",
 	"ltree",
 	"pageinspect",
-	"passwordcheck",
+	// "passwordcheck",
 	"pg_buffercache",
-	"pgcrypto",
 	"pg_freespacemap",
 	"pg_prewarm",
-	"pgrowlocks",
 	"pg_stat_statements",
-	"pgstattuple",
 	"pg_trgm",
 	"pg_visibility",
+	"pgcrypto",
+	"pgrowlocks",
+	"pgstattuple",
 	"postgres_fdw",
 	"seg",
-	"sepgsql",
-	"spi",
+	// "sepgsql",
+	// "spi",
 	"sslinfo",
 	"tablefunc",
 	"tcn",
-	"test_decoding",
-	"tsm_system_rows",
-	"tsm_system_time",
+	// "test_decoding",
+	// "tsm_system_rows",
+	// "tsm_system_time",
 	"unaccent",
 	"uuid-ossp",
 	"xml2",


### PR DESCRIPTION
The output of sqlc-pg-gen is difficult to reproduce when run in an inconsistent environment. Add a GitHub workflow to generate the code using a consistent OS (Ubuntu) and PostgreSQL version.