### PR TITLE
docs: Update samples for HOW-TO GUIDES

### DIFF
--- a/docs/howto/delete.md
+++ b/docs/howto/delete.md
@@ -19,7 +19,7 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) error
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 }
 
 func New(db DBTX) *Queries {

--- a/docs/howto/insert.md
+++ b/docs/howto/insert.md
@@ -19,7 +19,7 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) error
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 }
 
 func New(db DBTX) *Queries {
@@ -79,8 +79,8 @@ type Author struct {
 }
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) error
-	QueryRowContext(context.Context, string, ...interface{}) error
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
 func New(db DBTX) *Queries {

--- a/docs/howto/prepared_query.md
+++ b/docs/howto/prepared_query.md
@@ -19,10 +19,11 @@ package db
 import (
 	"context"
 	"database/sql"
+	"fmt"
 )
 
 type Record struct {
-	ID int
+	ID int32
 }
 
 type DBTX interface {
@@ -38,7 +39,7 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	q := Queries{db: db}
 	var err error
 	if q.getRecordStmt, err = db.PrepareContext(ctx, getRecord); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error preparing query GetRecord: %w", err)
 	}
 	return &q, nil
 }
@@ -73,11 +74,10 @@ SELECT id FROM records
 WHERE id = $1
 `
 
-func (q *Queries) GetRecord(ctx context.Context, id int) (Record, error) {
+func (q *Queries) GetRecord(ctx context.Context, id int32) (int32, error) {
 	row := q.queryRow(ctx, q.getRecordStmt, getRecord, id)
-	var i Record
-	err := row.Scan(&i.ID)
-	return i, err
+	err := row.Scan(&id)
+	return id, err
 }
 ```
 

--- a/docs/howto/update.md
+++ b/docs/howto/update.md
@@ -26,7 +26,7 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) error
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 }
 
 func New(db DBTX) *Queries {
@@ -52,6 +52,12 @@ func (q *Queries) UpdateAuthorBios(ctx context.Context, bio string) error {
 If your query has more than one parameter, your Go method will accept a
 `Params` struct.
 
+```sql
+-- name: UpdateAuthor :exec
+UPDATE authors SET bio = $2
+WHERE id = $1;
+```
+
 ```go
 package db
 
@@ -61,7 +67,7 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) error
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 }
 
 func New(db DBTX) *Queries {


### PR DESCRIPTION
Some of the sample code in "HOW-TO GUIDES" was outdated and has been updated.

`ExecContext()` signatures, for example.