### PR TITLE
*: clean up some tiny things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,16 @@ install:
 test:
 	go test ./...
 
+vet:
+	go vet ./...
+
 test-examples:
 	go test --tags=examples ./...
 
 build-endtoend:
 	cd ./internal/endtoend/testdata && go build ./...
 
-test-ci: test-examples build-endtoend
+test-ci: test-examples build-endtoend vet
 
 regen: sqlc-dev sqlc-gen-json
 	go run ./scripts/regenerate/

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -52,13 +52,15 @@ func Do(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int 
 	}
 	defer cleanup()
 
-	if err := rootCmd.ExecuteContext(ctx); err == nil {
-		return 0
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		if exitError, ok := err.(*exec.ExitError); ok {
+			return exitError.ExitCode()
+		} else {
+			return 1
+		}
 	}
-	if exitError, ok := err.(*exec.ExitError); ok {
-		return exitError.ExitCode()
-	}
-	return 1
+	return 0
 }
 
 var version string

--- a/internal/cmd/diff.go
+++ b/internal/cmd/diff.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/cubicdaiya/gonp"
-	"github.com/kyleconroy/sqlc/internal/debug"
 )
 
 func Diff(ctx context.Context, e Env, dir, name string, stderr io.Writer) error {
@@ -19,9 +18,7 @@ func Diff(ctx context.Context, e Env, dir, name string, stderr io.Writer) error 
 	if err != nil {
 		return err
 	}
-	if debug.Traced {
-		defer trace.StartRegion(ctx, "checkfiles").End()
-	}
+	defer trace.StartRegion(ctx, "checkfiles").End()
 	var errored bool
 
 	keys := make([]string, 0, len(output))

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -193,17 +193,12 @@ func Generate(ctx context.Context, e Env, dir, filename string, stderr io.Writer
 			name = sql.Plugin.Plugin
 		}
 
-		var packageRegion *trace.Region
-		if debug.Traced {
-			packageRegion = trace.StartRegion(ctx, "package")
-			trace.Logf(ctx, "", "name=%s dir=%s plugin=%s", name, dir, lang)
-		}
+		packageRegion := trace.StartRegion(ctx, "package")
+		trace.Logf(ctx, "", "name=%s dir=%s plugin=%s", name, dir, lang)
 
 		result, failed := parse(ctx, name, dir, sql.SQL, combo, parseOpts, stderr)
 		if failed {
-			if packageRegion != nil {
-				packageRegion.End()
-			}
+			packageRegion.End()
 			errored = true
 			break
 		}
@@ -213,9 +208,7 @@ func Generate(ctx context.Context, e Env, dir, filename string, stderr io.Writer
 			fmt.Fprintf(stderr, "# package %s\n", name)
 			fmt.Fprintf(stderr, "error generating code: %s\n", err)
 			errored = true
-			if packageRegion != nil {
-				packageRegion.End()
-			}
+			packageRegion.End()
 			continue
 		}
 
@@ -227,9 +220,7 @@ func Generate(ctx context.Context, e Env, dir, filename string, stderr io.Writer
 			filename := filepath.Join(dir, out, n)
 			output[filename] = source
 		}
-		if packageRegion != nil {
-			packageRegion.End()
-		}
+		packageRegion.End()
 	}
 
 	if errored {
@@ -239,9 +230,7 @@ func Generate(ctx context.Context, e Env, dir, filename string, stderr io.Writer
 }
 
 func parse(ctx context.Context, name, dir string, sql config.SQL, combo config.CombinedSettings, parserOpts opts.Parser, stderr io.Writer) (*compiler.Result, bool) {
-	if debug.Traced {
-		defer trace.StartRegion(ctx, "parse").End()
-	}
+	defer trace.StartRegion(ctx, "parse").End()
 	c := compiler.NewCompiler(sql, combo)
 	if err := c.ParseCatalog(sql.Schema); err != nil {
 		fmt.Fprintf(stderr, "# package %s\n", name)
@@ -272,10 +261,7 @@ func parse(ctx context.Context, name, dir string, sql config.SQL, combo config.C
 }
 
 func codegen(ctx context.Context, combo config.CombinedSettings, sql outPair, result *compiler.Result) (string, *plugin.CodeGenResponse, error) {
-	var region *trace.Region
-	if debug.Traced {
-		region = trace.StartRegion(ctx, "codegen")
-	}
+	defer trace.StartRegion(ctx, "codegen").End()
 	req := codeGenRequest(result, combo)
 	var handler ext.Handler
 	var out string
@@ -319,8 +305,5 @@ func codegen(ctx context.Context, combo config.CombinedSettings, sql outPair, re
 		return "", nil, fmt.Errorf("missing language backend")
 	}
 	resp, err := handler.Generate(ctx, req)
-	if region != nil {
-		region.End()
-	}
 	return out, resp, err
 }

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -71,7 +71,7 @@ func buildStructs(req *plugin.CodeGenRequest) []Struct {
 				})
 			}
 			s := Struct{
-				Table:   plugin.Identifier{Schema: schema.Name, Name: table.Rel.Name},
+				Table:   &plugin.Identifier{Schema: schema.Name, Name: table.Rel.Name},
 				Name:    StructName(structName, req.Settings),
 				Comment: table.Comment,
 			}
@@ -214,7 +214,7 @@ func buildQueries(req *plugin.CodeGenRequest, structs []Struct) ([]Query, error)
 					c := query.Columns[i]
 					sameName := f.Name == StructName(columnName(c, i), req.Settings)
 					sameType := f.Type == goType(req, c)
-					sameTable := sdk.SameTableName(c.Table, &s.Table, req.Catalog.DefaultSchema)
+					sameTable := sdk.SameTableName(c.Table, s.Table, req.Catalog.DefaultSchema)
 					if !sameName || !sameType || !sameTable {
 						same = false
 					}

--- a/internal/codegen/golang/struct.go
+++ b/internal/codegen/golang/struct.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Struct struct {
-	Table   plugin.Identifier
+	Table   *plugin.Identifier
 	Name    string
 	Fields  []Field
 	Comment string

--- a/internal/codegen/json/gen.go
+++ b/internal/codegen/json/gen.go
@@ -11,13 +11,13 @@ import (
 	"github.com/kyleconroy/sqlc/internal/plugin"
 )
 
-func parseOptions(req *plugin.CodeGenRequest) (plugin.JSONCode, error) {
+func parseOptions(req *plugin.CodeGenRequest) (*plugin.JSONCode, error) {
 	if req.Settings == nil {
-		return plugin.JSONCode{}, nil
+		return new(plugin.JSONCode), nil
 	}
 	if req.Settings.Codegen != nil {
 		if len(req.Settings.Codegen.Options) != 0 {
-			var options plugin.JSONCode
+			var options *plugin.JSONCode
 			dec := ejson.NewDecoder(bytes.NewReader(req.Settings.Codegen.Options))
 			dec.DisallowUnknownFields()
 			if err := dec.Decode(&options); err != nil {
@@ -27,9 +27,9 @@ func parseOptions(req *plugin.CodeGenRequest) (plugin.JSONCode, error) {
 		}
 	}
 	if req.Settings.Json != nil {
-		return *req.Settings.Json, nil
+		return req.Settings.Json, nil
 	}
-	return plugin.JSONCode{}, nil
+	return new(plugin.JSONCode), nil
 }
 
 func Generate(ctx context.Context, req *plugin.CodeGenRequest) (*plugin.CodeGenResponse, error) {

--- a/internal/debug/dump.go
+++ b/internal/debug/dump.go
@@ -9,14 +9,12 @@ import (
 )
 
 var Active bool
-var Traced bool
 var Debug opts.Debug
 
 func init() {
 	Active = os.Getenv("SQLCDEBUG") != ""
 	if Active {
 		Debug = opts.DebugFromEnv()
-		Traced = Debug.Trace != ""
 	}
 }
 

--- a/internal/tracer/trace.go
+++ b/internal/tracer/trace.go
@@ -9,18 +9,17 @@ import (
 	"github.com/kyleconroy/sqlc/internal/debug"
 )
 
-func Start(base context.Context) (context.Context, func(), error) {
-	if !debug.Traced {
-		return base, func() {}, nil
-	}
-
+// Start starts Go's runtime tracing facility.
+// Traces will be written to the file named by [debug.Debug.Trace].
+// It also starts a new [*trace.Task] that will be stopped when the cleanup is called.
+func Start(base context.Context) (_ context.Context, cleanup func(), _ error) {
 	f, err := os.Create(debug.Debug.Trace)
 	if err != nil {
-		return base, func() {}, fmt.Errorf("failed to create trace output file: %v", err)
+		return base, cleanup, fmt.Errorf("failed to create trace output file: %v", err)
 	}
 
 	if err := trace.Start(f); err != nil {
-		return base, func() {}, fmt.Errorf("failed to start trace: %v", err)
+		return base, cleanup, fmt.Errorf("failed to start trace: %v", err)
 	}
 
 	ctx, task := trace.NewTask(base, "sqlc")


### PR DESCRIPTION
Howdy!

In the course of learning this code, I found a few tiny changes
that I hope you might find useful! I'm happy to split these into
separate pull requests. Or, please feel free to close this if you
don't want drive-by changes like these.

Thank you!

---

- internal/cmd: fix an exit code buglet

It seems the previous code intended to interpret the error from
rootCmd.ExecuteContext() as an *exec.ExitError. That's not the way
it worked in practice, though. Instead, the typecheck on
err.(*exec.ExitError) used the error from the call to tracer.Start().
This is due to the scoping rules of if statements.

With this commit, cmd.Do() now attempts to interpret the command
execution error as an *exec.ExitError. It also prints the error
message to stderr, since the caller in ./cmd/sqlc.main doesn't do
that.

See: https://go.dev/ref/spec#Blocks

- internal/debug: remove Traced global

Previously, some callers of trace.StartRegion() guarded on the
global debug.Traced variable. This guard is unneeded because
runtime/trace.StartRegion() will return a no-op region if tracing
has not been started. That means we can centralize the decision of
whether we want tracing to cmd.Do(). Since we then only have one
reference to debug.Traced, we can just delete it, since it seems
it was a shorthand for (debug.Debug.Trace != "").

See: https://cs.opensource.google/go/go/+/refs/tags/go1.19.3:src/runtime/trace/annotation.go;l=153-155

- internal/codegen: don't copy protobuf locks

This patch silences the output of "go vet ./...", which used to say this:

	# github.com/kyleconroy/sqlc/internal/codegen/json
	internal/codegen/json/gen.go:24:12: return copies lock value: github.com/kyleconroy/sqlc/internal/plugin.JSONCode contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex
	internal/codegen/json/gen.go:26:11: return copies lock value: github.com/kyleconroy/sqlc/internal/plugin.JSONCode contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex
	internal/codegen/json/gen.go:30:10: return copies lock value: github.com/kyleconroy/sqlc/internal/plugin.JSONCode contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex
	# github.com/kyleconroy/sqlc/internal/codegen/golang
	internal/codegen/golang/imports.go:68:9: range var strct copies lock: github.com/kyleconroy/sqlc/internal/codegen/golang.Struct contains github.com/kyleconroy/sqlc/internal/plugin.Identifier contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex
	internal/codegen/golang/result.go:94:30: call of append copies lock value: github.com/kyleconroy/sqlc/internal/codegen/golang.Struct contains github.com/kyleconroy/sqlc/internal/plugin.Identifier contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex
	internal/codegen/golang/result.go:208:11: range var s copies lock: github.com/kyleconroy/sqlc/internal/codegen/golang.Struct contains github.com/kyleconroy/sqlc/internal/plugin.Identifier contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex

Also, add go vet to CI.

- internal/cmd: use *cobra.Command.RunE everywhere

Errors are handled by the root command's execution, so we don't
need to os.Exit() in any child commands.