### PR TITLE
Changed documentation for json datatype.

### DIFF
--- a/docs/reference/datatypes.md
+++ b/docs/reference/datatypes.md
@@ -160,7 +160,11 @@ CREATE TABLE books (
   "overrides": [
     {
       "column": "books.data",
-      "go_type": "*example.com/db/dto.BookData"
+      "go_type": {
+          "import":"example/db",
+          "package": "dto",
+          "type":"BookData"
+        }
     }
   ]
 }

--- a/docs/reference/datatypes.md
+++ b/docs/reference/datatypes.md
@@ -161,10 +161,10 @@ CREATE TABLE books (
     {
       "column": "books.data",
       "go_type": {
-          "import":"example/db",
-          "package": "dto",
-          "type":"BookData"
-        }
+        "import":"example/db",
+        "package": "dto",
+        "type":"BookData"
+      }
     }
   ]
 }


### PR DESCRIPTION
Changed documentation for JSON-related data as if we go by the previously mentioned docs we won't be able to use fully qualified names in golang.