### PR TITLE
fix: Honor Package level renames in v2 yaml config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -213,13 +213,19 @@ func Combine(conf Config, pkg SQL) CombinedSettings {
 	cs := CombinedSettings{
 		Global:  conf,
 		Package: pkg,
+		Rename:  map[string]string{},
 	}
 	if conf.Gen.Go != nil {
-		cs.Rename = conf.Gen.Go.Rename
+		for k, v := range conf.Gen.Go.Rename {
+			cs.Rename[k] = v
+		}
 		cs.Overrides = append(cs.Overrides, conf.Gen.Go.Overrides...)
 	}
 	if pkg.Gen.Go != nil {
 		cs.Go = *pkg.Gen.Go
+		for k, v := range pkg.Gen.Go.Rename {
+			cs.Rename[k] = v
+		}
 		cs.Overrides = append(cs.Overrides, pkg.Gen.Go.Overrides...)
 	}
 	if pkg.Gen.JSON != nil {

--- a/internal/config/v_two.go
+++ b/internal/config/v_two.go
@@ -79,6 +79,9 @@ func v2ParseConfig(rd io.Reader) (Config, error) {
 					return conf, err
 				}
 			}
+			for k, v := range conf.SQL[j].Gen.Go.Rename {
+				conf.SQL[j].Gen.Go.Rename[k] = v
+			}
 		}
 		if conf.SQL[j].Gen.JSON != nil {
 			if conf.SQL[j].Gen.JSON.Out == "" {


### PR DESCRIPTION
When following the docs for renames for `pkg` scoped renames, the renames were not applying. This is my first look into the sqlc config, but it looked like things were just not plumbed through.

I just adds setting the renames from the yaml parse. In the combine settings I made sure to assign the renames from the pkg (the global was already set). This change does make pkg renames override global ones.


---

For unit testing, I noticed all the `endtoend/testdata` use a v1 config. Instead of adding more vectors to that to also do `v2` directories, what if we just added a `sqlc.v1.yaml` and `sqlc.v2.yaml` to each directory and run it twice? Or something of that nature to test v2 configs? At present this is not tested aside from some manual checking.