### PR TITLE
Implement cast function parser for MySQL

### DIFF
--- a/internal/compiler/to_column.go
+++ b/internal/compiler/to_column.go
@@ -8,7 +8,7 @@ import (
 )
 
 func isArray(n *ast.TypeName) bool {
-	if n == nil {
+	if n == nil || n.ArrayBounds == nil {
 		return false
 	}
 	return len(n.ArrayBounds.Items) > 0

--- a/internal/engine/dolphin/convert.go
+++ b/internal/engine/dolphin/convert.go
@@ -874,7 +874,10 @@ func (c *cc) convertFrameClause(n *pcast.FrameClause) ast.Node {
 }
 
 func (c *cc) convertFuncCastExpr(n *pcast.FuncCastExpr) ast.Node {
-	return todo(n)
+	return &ast.TypeCast{
+		Arg:      c.convert(n.Expr),
+		TypeName: &ast.TypeName{Name: types.TypeStr(n.Tp.GetType())},
+	}
 }
 
 func (c *cc) convertGetFormatSelectorExpr(n *pcast.GetFormatSelectorExpr) ast.Node {

--- a/internal/sql/astutils/join.go
+++ b/internal/sql/astutils/join.go
@@ -7,7 +7,11 @@ import (
 )
 
 func Join(list *ast.List, sep string) string {
-	items := []string{}
+	if list == nil {
+		return ""
+	}
+
+	var items []string
 	for _, item := range list.Items {
 		if n, ok := item.(*ast.String); ok {
 			items = append(items, n.Str)


### PR DESCRIPTION
### What is this

As the title said, this PR wants to add support for `CAST` function in MySQL.

This PR is based from PR by @ryanpbrewster [here][ryan-pr] (which unfortunately he didn't send here, and only exist in his repository).

### Why is this PR created

Currently `sqlc` unable to infer the correct type from SQL function like `MAX`, `MIN`, `SUM`, etc. For those function, sqlc will return its value as `interface{}`. This behavior can be seen in this [playground].

As workaround, it advised to use `CAST` function to explicitly tell what is the type for that column, as mentioned in #1574.

Unfortunately, currently sqlc only support `CAST` function in PostgreSQL and not in MySQL. Thanks to this, right now MySQL users have to parse the `interface{}` manually, which is not really desirable.

### What does this PR do?

- Implement `convertFuncCast` function for MySQL.
- Add better nil pointer check in some functions that related to `convertFuncCast`.

I haven't write any test because I'm not sure how and where to put it. However, as far as I know the code that handle `ast.TypeCast` for PostgreSQL also don't have any test, so I guess it's fine :man_shrugging: 

### Related issues

- #687, which currently is the oldest MySQL issue that still opened.
- #1622 
- #1866
- #1901
- #1965

[ryan-pr]: https://github.com/ryanpbrewster/sqlc/pull/1
[playground]: https://play.sqlc.dev/p/6fefc08975fcd36229c89b16daad6358d1bcc8ca8db2f79470e4915ce044b806