### PR TITLE
fix: consider UTF-8 encoding

### DIFF
--- a/internal/source/code.go
+++ b/internal/source/code.go
@@ -47,7 +47,8 @@ func LineNumber(source string, head int) (int, int) {
 func Pluck(source string, location, length int) (string, error) {
 	head := location
 	tail := location + length
-	return source[head:tail], nil
+	runes := []rune(source)
+	return string(runes[head:tail]), nil
 }
 
 func Mutate(raw string, a []Edit) (string, error) {
@@ -57,7 +58,7 @@ func Mutate(raw string, a []Edit) (string, error) {
 
 	sort.Slice(a, func(i, j int) bool { return a[i].Location > a[j].Location })
 
-	s := raw
+	s := []rune(raw)
 	for idx, edit := range a {
 		start := edit.Location
 		if start > len(s) || start < 0 {
@@ -78,9 +79,9 @@ func Mutate(raw string, a []Edit) (string, error) {
 			}
 		}
 
-		s = s[:start] + edit.New + s[stop:]
+		s = append(append(s[:start], []rune(edit.New)...), s[stop:]...)
 	}
-	return s, nil
+	return string(s), nil
 }
 
 func StripComments(sql string) (string, []string, error) {


### PR DESCRIPTION
input(query.sql)

```sql
-- name: Pizza :many
SELECT '🍕' as c
where c = '🥞';

-- 🥗
-- name: Salado :exec
SELECT
  '0123456789'
;
```

output

```go
const pizza = `-- name: Pizza :many
SELECT '🍕' as c
where c =
`

const salado = `-- name: Salado :exec
SELECT
  '01234567
`
```

Fixed output

```go
const pizza = `-- name: Pizza :many
SELECT '🍕' as c
where c = '🥞'
`

const salado = `-- name: Salado :exec
SELECT
  '0123456789'
`
```