### PR TITLE
Only enable postgresql support when cgo is enabled as it is required

### DIFF
--- a/internal/engine/postgresql/convert.go
+++ b/internal/engine/postgresql/convert.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && cgo
+// +build !windows,cgo
 
 package postgresql
 
@@ -3120,7 +3120,7 @@ func convertNode(node *pg.Node) ast.Node {
 
 	case *pg.Node_BooleanTest:
 		return convertBooleanTest(n.BooleanTest)
-		
+
 	case *pg.Node_CallStmt:
 		return convertCallStmt(n.CallStmt)
 

--- a/internal/engine/postgresql/parse.go
+++ b/internal/engine/postgresql/parse.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && cgo
+// +build !windows,cgo
 
 package postgresql
 

--- a/internal/engine/postgresql/parse_disabled.go
+++ b/internal/engine/postgresql/parse_disabled.go
@@ -1,5 +1,5 @@
-//go:build windows
-// +build windows
+//go:build windows || !cgo
+// +build windows !cgo
 
 package postgresql
 

--- a/internal/engine/postgresql/utils.go
+++ b/internal/engine/postgresql/utils.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && cgo
+// +build !windows,cgo
 
 package postgresql
 


### PR DESCRIPTION
Fixes #2050

postgresql parser requires cgo to build the native parser library, which can cause build issues such as #1956. Currently there is no way to disable support when it is not needed and the build issues can cause a problem. With this change, `CGO_ENABLED=0` can be used to work with the other parsers and avoid build issues.