### PR TITLE
Propagate env to process plugin and support command args

### DIFF
--- a/internal/endtoend/testdata/process_plugin_sqlc_gen_json/sqlc.json
+++ b/internal/endtoend/testdata/process_plugin_sqlc_gen_json/sqlc.json
@@ -21,7 +21,7 @@
     {
       "name": "jsonb",
       "process": {
-        "cmd": "sqlc-gen-json"
+        "cmd": "go run ../../cmd/sqlc-gen-json"
       }
     }
   ]


### PR DESCRIPTION
This is a strawman's proposal that I noticed while working on #2068 and feel free to reject it. Unit tests wouldn't pass because they expect installation of `sqlc-gen-json` on the running machine. I guess it's best if tests can be run without any external dependencies outside the codebase. Luckily, `go run` is basically guaranteed to work fine and could be an appropriate alternative.

I started by adding support for splitting args out of the cmd string. Then I also noticed that the user's environment is not propagated to the process when run - I think generally users would expect the environment to be available when an external process is run as the plugin may have dependencies on it, and it would otherwise be impossible to run the plugin. Though if not propagating was intentional, then that's fine too and definitely this PR can be closed.