### PR TITLE
Fix for issue #2073

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -127,6 +127,15 @@ func TestTypeOverrides(t *testing.T) {
 			"string",
 			true,
 		},
+		{
+			Override{
+				DBType: "timestamp",
+				GoType: GoType{Spec: "time.Time"},
+			},
+			"time",
+			"time.Time",
+			false,
+		},
 	} {
 		tt := test
 		t.Run(tt.override.GoType.Spec, func(t *testing.T) {
@@ -167,7 +176,7 @@ func TestTypeOverrides(t *testing.T) {
 		t.Run(tt.override.GoType.Spec, func(t *testing.T) {
 			err := tt.override.Parse()
 			if err == nil {
-				t.Fatalf("expected pars to fail; got nil")
+				t.Fatalf("expected parse to fail; got nil")
 			}
 			if diff := cmp.Diff(tt.err, err.Error()); diff != "" {
 				t.Errorf("error mismatch;\n%s", diff)

--- a/internal/config/go_type.go
+++ b/internal/config/go_type.go
@@ -135,9 +135,6 @@ func (gt GoType) Parse() (*ParsedGoType, error) {
 		if lastDot == -1 {
 			return nil, fmt.Errorf("Package override `go_type` specifier %q is not the proper format, expected 'package.type', e.g. 'github.com/segmentio/ksuid.KSUID'", input)
 		}
-		if lastSlash == -1 {
-			return nil, fmt.Errorf("Package override `go_type` specifier %q is not the proper format, expected 'package.type', e.g. 'github.com/segmentio/ksuid.KSUID'", input)
-		}
 		typename = input[lastSlash+1:]
 		// a package name beginning with "go-" will give syntax errors in
 		// generated code. We should do the right thing and get the actual


### PR DESCRIPTION
Remove an unnecessary validation check when processing type overrides for Go types. Fixes https://github.com/kyleconroy/sqlc/issues/2073