### PR TITLE
ci: Only report test results on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       working-directory: internal/endtoend/testdata
 
     - name: report
+      if: ${{ github.ref == 'refs/heads/main' }}
       run: ./scripts/report.sh
       env:
         BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}


### PR DESCRIPTION
Turns out that https://github.com/kyleconroy/sqlc/pull/2075 caused all PRs from forks to fail.