### PR TITLE
add: float32 support for mysql

### DIFF
--- a/internal/codegen/golang/mysql_type.go
+++ b/internal/codegen/golang/mysql_type.go
@@ -51,6 +51,12 @@ func mysqlType(req *plugin.CodeGenRequest, col *plugin.Column) string {
 		}
 		return "sql.NullString"
 
+	case "float":
+		if notNull {
+			return "float32"
+		}
+		return "sql.NullFloat32"
+
 	case "double", "double precision", "real":
 		if notNull {
 			return "float64"


### PR DESCRIPTION
Add [Generated code for float column in MySQL is of type interface{} instead of float32](https://github.com/kyleconroy/sqlc/issues/2095)