### PR TITLE
add: float support mysql

### DIFF
--- a/internal/codegen/golang/mysql_type.go
+++ b/internal/codegen/golang/mysql_type.go
@@ -51,7 +51,7 @@ func mysqlType(req *plugin.CodeGenRequest, col *plugin.Column) string {
 		}
 		return "sql.NullString"
 
-	case "double", "double precision", "real":
+	case "double", "double precision", "real", "float":
 		if notNull {
 			return "float64"
 		}

--- a/internal/endtoend/testdata/datatype/mysql/go/models.go
+++ b/internal/endtoend/testdata/datatype/mysql/go/models.go
@@ -61,7 +61,7 @@ type DtNumeric struct {
 	G interface{}
 	H sql.NullString
 	I sql.NullString
-	J interface{}
+	J sql.NullFloat64
 	K sql.NullFloat64
 	L sql.NullFloat64
 }
@@ -76,7 +76,7 @@ type DtNumericNotNull struct {
 	G interface{}
 	H string
 	I string
-	J interface{}
+	J float64
 	K float64
 	L float64
 }

--- a/internal/endtoend/testdata/valid_group_by_reference/mysql/go/models.go
+++ b/internal/endtoend/testdata/valid_group_by_reference/mysql/go/models.go
@@ -19,18 +19,18 @@ type WeatherMetric struct {
 	Time            time.Time
 	TimezoneShift   sql.NullInt32
 	CityName        sql.NullString
-	TempC           interface{}
-	FeelsLikeC      interface{}
-	TempMinC        interface{}
-	TempMaxC        interface{}
-	PressureHpa     interface{}
-	HumidityPercent interface{}
-	WindSpeedMs     interface{}
+	TempC           sql.NullFloat64
+	FeelsLikeC      sql.NullFloat64
+	TempMinC        sql.NullFloat64
+	TempMaxC        sql.NullFloat64
+	PressureHpa     sql.NullFloat64
+	HumidityPercent sql.NullFloat64
+	WindSpeedMs     sql.NullFloat64
 	WindDeg         sql.NullInt32
-	Rain1hMm        interface{}
-	Rain3hMm        interface{}
-	Snow1hMm        interface{}
-	Snow3hMm        interface{}
+	Rain1hMm        sql.NullFloat64
+	Rain3hMm        sql.NullFloat64
+	Snow1hMm        sql.NullFloat64
+	Snow3hMm        sql.NullFloat64
 	CloudsPercent   sql.NullInt32
 	WeatherTypeID   sql.NullInt32
 }


### PR DESCRIPTION
add: [Generated code for float column in MySQL is of type interface{} instead of float64](https://github.com/kyleconroy/sqlc/issues/2095)