### PR TITLE
fix: clarify error message for PostgreSQL Engine support

### DIFF
--- a/internal/engine/postgresql/parse_disabled.go
+++ b/internal/engine/postgresql/parse_disabled.go
@@ -19,7 +19,7 @@ type Parser struct {
 }
 
 func (p *Parser) Parse(r io.Reader) ([]ast.Statement, error) {
-	return nil, errors.New("the PostgreSQL engine does not support Windows")
+	return nil, errors.New("the PostgreSQL engine is not supported on Windows or any environment where CGO is unavailable")
 }
 
 // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-COMMENTS


### PR DESCRIPTION
### Problem
When trying to build the project under a fresh Ubuntu WSL install, tests would fail with the error "the PostgreSQL engine does not support Windows" - however, the actual reason was that `gcc` was not installed, therefore CGO was not available.  This occurred because postgresql/parse_disabled.go is included when building on windows _OR_ when CGO is not available - however it's possible (as in my case) to be running in a linux environment and still have CGO unavailable. 

### Solution
This PR updates the error message to clarify that both Windows and any environment without CGO is not supported.