### PR TITLE
Upgrade to Go 1.20

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
-ARG VARIANT=1.19-bullseye
+ARG VARIANT=1.20-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
 
 # [Optional] If your requirements rarely change, uncomment this section to add them to the image.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19'
+        go-version: '1.20'
     - run: go build ./...
 
   darwin-build:
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19'
+        go-version: '1.20'
     - run: go build ./...
 
   build:
@@ -53,7 +53,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19'
+        go-version: '1.20'
 
     - name: gotestsum
       run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19'
+        go-version: '1.20'
     - run: go build -o sqlc-pg-gen ./internal/tools/sqlc-pg-gen
     - run: mkdir -p gen/contrib
     - run: ./sqlc-pg-gen gen

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyleconroy/sqlc
 
-go 1.19
+go 1.20
 
 require (
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220626175859-9abda183db8e


### PR DESCRIPTION
Go 1.20 has now had a point release, so I'm comfortable updating all our tooling to use it.