### PR TITLE
docs(config.md): add `sqlite` as engine option

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -29,7 +29,7 @@ sql:
 Each mapping in the `sql` collection has the following keys:
 
 - `engine`:
-  - Either `postgresql` or `mysql`.
+  - One of `postgresql`, `mysql` or `sqlite`.
 - `schema`:
   - Directory of SQL migrations or path to single SQL file; or a list of paths.
 - `queries`:


### PR DESCRIPTION
I noticed the sqlite option wasn't added to the configuration docs. 