### PR TITLE
cmd/sqlc: Remove --experimental flag

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
 
-	"github.com/kyleconroy/sqlc/internal/codegen/golang"
 	"github.com/kyleconroy/sqlc/internal/config"
 	"github.com/kyleconroy/sqlc/internal/debug"
 	"github.com/kyleconroy/sqlc/internal/info"
@@ -31,7 +30,7 @@ func init() {
 func Do(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int {
 	rootCmd := &cobra.Command{Use: "sqlc", SilenceUsage: true}
 	rootCmd.PersistentFlags().StringP("file", "f", "", "specify an alternate config file (default: sqlc.yaml)")
-	rootCmd.PersistentFlags().BoolP("experimental", "x", false, "enable experimental features (default: false)")
+	rootCmd.PersistentFlags().BoolP("experimental", "x", false, "DEPRECATED: enable experimental features (default: false)")
 
 	rootCmd.AddCommand(checkCmd)
 	rootCmd.AddCommand(diffCmd)
@@ -106,26 +105,17 @@ var initCmd = &cobra.Command{
 }
 
 type Env struct {
-	ExperimentalFeatures bool
-	DryRun               bool
+	DryRun bool
 }
 
 func ParseEnv(c *cobra.Command) Env {
-	x := c.Flag("experimental")
 	dr := c.Flag("dry-run")
 	return Env{
-		ExperimentalFeatures: x != nil && x.Changed,
-		DryRun:               dr != nil && dr.Changed,
+		DryRun: dr != nil && dr.Changed,
 	}
 }
 
 func (e *Env) Validate(cfg *config.Config) error {
-	for _, sql := range cfg.SQL {
-		if sql.Gen.Go != nil && sql.Gen.Go.SQLPackage == golang.SQLPackagePGXV5 && !e.ExperimentalFeatures {
-			return fmt.Errorf("'pgx/v5' golang sql package requires enabled '--experimental' flag")
-		}
-	}
-
 	return nil
 }
 

--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -39,7 +39,7 @@ func TestExamples(t *testing.T) {
 			t.Parallel()
 			path := filepath.Join(examples, tc)
 			var stderr bytes.Buffer
-			output, err := cmd.Generate(ctx, cmd.Env{ExperimentalFeatures: true}, path, "", &stderr)
+			output, err := cmd.Generate(ctx, cmd.Env{}, path, "", &stderr)
 			if err != nil {
 				t.Fatalf("sqlc generate failed: %s", stderr.String())
 			}
@@ -67,7 +67,7 @@ func BenchmarkExamples(b *testing.B) {
 			path := filepath.Join(examples, tc)
 			for i := 0; i < b.N; i++ {
 				var stderr bytes.Buffer
-				cmd.Generate(ctx, cmd.Env{ExperimentalFeatures: true}, path, "", &stderr)
+				cmd.Generate(ctx, cmd.Env{}, path, "", &stderr)
 			}
 		})
 	}
@@ -112,9 +112,9 @@ func TestReplay(t *testing.T) {
 
 			switch args.Command {
 			case "diff":
-				err = cmd.Diff(ctx, cmd.Env{ExperimentalFeatures: true}, path, "", &stderr)
+				err = cmd.Diff(ctx, cmd.Env{}, path, "", &stderr)
 			case "generate":
-				output, err = cmd.Generate(ctx, cmd.Env{ExperimentalFeatures: true}, path, "", &stderr)
+				output, err = cmd.Generate(ctx, cmd.Env{}, path, "", &stderr)
 				if err == nil {
 					cmpDirectory(t, path, output)
 				}
@@ -254,7 +254,7 @@ func BenchmarkReplay(b *testing.B) {
 			path, _ := filepath.Abs(tc)
 			for i := 0; i < b.N; i++ {
 				var stderr bytes.Buffer
-				cmd.Generate(ctx, cmd.Env{ExperimentalFeatures: true}, path, "", &stderr)
+				cmd.Generate(ctx, cmd.Env{}, path, "", &stderr)
 			}
 		})
 	}


### PR DESCRIPTION
For backwards compatability, the flag still exists but is a no-op. If we need feature flagging in the future, we'll develop a more robust system than what this flag provided.