### PR TITLE
fix: `specifies parameter ":one" without containing a RETURNING clause`

### DIFF
--- a/docs/howto/named_parameters.md
+++ b/docs/howto/named_parameters.md
@@ -75,7 +75,8 @@ UPDATE author
 SET
  name = coalesce(sqlc.narg('name'), name),
  bio = coalesce(sqlc.narg('bio'), bio)
-WHERE id = sqlc.arg('id');
+WHERE id = sqlc.arg('id')
+RETURNING *;
 ```
 
 The following code is generated:


### PR DESCRIPTION
I got an error when I followed the documentation.

```
db/query/user.sql:49:1: query "UpdateUser" specifies parameter ":one" without containing a RETURNING clause
```

db/query/user.sql

```sql
-- name: UpdateUser :one
UPDATE users
SET
  name = coalesce(sqlc.narg('name'), name),
  email = coalesce(sqlc.narg('email'), email),
  role = coalesce(sqlc.narg('role'), role),
  bio = coalesce(sqlc.narg('bio'), bio),
  hashed_password = coalesce(sqlc.narg('hashed_password'), hashed_password)
WHERE id = sqlc.arg('id');
```

I added RETURNING to avoid errors.

sqlc version
1.17.2