### PR TITLE
cmd/sqlc: Add option to disable process-based plugins

### DIFF
--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/kyleconroy/sqlc/internal/cmd"
+	"github.com/kyleconroy/sqlc/internal/opts"
 )
 
 func TestExamples(t *testing.T) {
@@ -110,11 +111,14 @@ func TestReplay(t *testing.T) {
 				}
 			}
 
+			env := cmd.Env{
+				Debug: opts.DebugFromString(args.Env["SQLCDEBUG"]),
+			}
 			switch args.Command {
 			case "diff":
-				err = cmd.Diff(ctx, cmd.Env{}, path, "", &stderr)
+				err = cmd.Diff(ctx, env, path, "", &stderr)
 			case "generate":
-				output, err = cmd.Generate(ctx, cmd.Env{}, path, "", &stderr)
+				output, err = cmd.Generate(ctx, env, path, "", &stderr)
 				if err == nil {
 					cmpDirectory(t, path, output)
 				}
@@ -209,8 +213,9 @@ func expectedStderr(t *testing.T, dir string) string {
 }
 
 type exec struct {
-	Command string `json:"command"`
-	Process string `json:"process"`
+	Command string            `json:"command"`
+	Process string            `json:"process"`
+	Env     map[string]string `json:"env"`
 }
 
 func parseExec(t *testing.T, dir string) exec {

--- a/internal/endtoend/testdata/process_plugin_disabled/exec.json
+++ b/internal/endtoend/testdata/process_plugin_disabled/exec.json
@@ -1,0 +1,6 @@
+{
+  "process": "sqlc-gen-json",
+  "env": {
+    "SQLCDEBUG": "processplugins=0"
+  }
+}

--- a/internal/endtoend/testdata/process_plugin_disabled/query.sql
+++ b/internal/endtoend/testdata/process_plugin_disabled/query.sql
@@ -1,0 +1,19 @@
+-- name: GetAuthor :one
+SELECT * FROM authors
+WHERE id = $1 LIMIT 1;
+
+-- name: ListAuthors :many
+SELECT * FROM authors
+ORDER BY name;
+
+-- name: CreateAuthor :one
+INSERT INTO authors (
+          name, bio
+) VALUES (
+  $1, $2
+)
+RETURNING *;
+
+-- name: DeleteAuthor :exec
+DELETE FROM authors
+WHERE id = $1;

--- a/internal/endtoend/testdata/process_plugin_disabled/schema.sql
+++ b/internal/endtoend/testdata/process_plugin_disabled/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE authors (
+          id   BIGSERIAL PRIMARY KEY,
+          name text      NOT NULL,
+          bio  text
+);

--- a/internal/endtoend/testdata/process_plugin_disabled/sqlc.json
+++ b/internal/endtoend/testdata/process_plugin_disabled/sqlc.json
@@ -1,0 +1,28 @@
+{
+  "version": "2",
+  "sql": [
+    {
+      "schema": "schema.sql",
+      "queries": "query.sql",
+      "engine": "postgresql",
+      "codegen": [
+        {
+          "out": "gen",
+          "plugin": "jsonb",
+          "options": {
+            "indent": "  ",
+            "filename": "codegen.json"
+          }
+        }
+      ]
+    }
+  ],
+  "plugins": [
+    {
+      "name": "jsonb",
+      "process": {
+        "cmd": "sqlc-gen-json"
+      }
+    }
+  ]
+}

--- a/internal/endtoend/testdata/process_plugin_disabled/stderr.txt
+++ b/internal/endtoend/testdata/process_plugin_disabled/stderr.txt
@@ -1,0 +1,1 @@
+error validating sqlc.json: plugin: process-based plugins disabled via SQLCDEBUG=processplugins=0

--- a/internal/opts/debug.go
+++ b/internal/opts/debug.go
@@ -13,14 +13,20 @@ import (
 //     trace: setting trace=<path> will output a trace
 
 type Debug struct {
-	DumpAST     bool
-	DumpCatalog bool
-	Trace       string
+	DumpAST        bool
+	DumpCatalog    bool
+	Trace          string
+	ProcessPlugins bool
 }
 
 func DebugFromEnv() Debug {
-	d := Debug{}
-	val := os.Getenv("SQLCDEBUG")
+	return DebugFromString(os.Getenv("SQLCDEBUG"))
+}
+
+func DebugFromString(val string) Debug {
+	d := Debug{
+		ProcessPlugins: true,
+	}
 	if val == "" {
 		return d
 	}
@@ -38,6 +44,8 @@ func DebugFromEnv() Debug {
 			} else {
 				d.Trace = traceName
 			}
+		case pair == "processplugins=0":
+			d.ProcessPlugins = false
 		}
 	}
 	return d


### PR DESCRIPTION
Add a `processplugins=0` option to `SQLCDEBUG`. This type of configuration is modeled Go's own use of `GODEBUG`. See a full explanation of the design here: https://go.googlesource.com/proposal/+/master/design/56986-godebug.md