### PR TITLE
docs: Add missed configuration option

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -213,6 +213,7 @@ sql:
             import: "a/b/v2"
             package: "b"
             type: "MyType"
+            pointer: true
 ```
 
 When generating code, entries using the `column` key will always have preference over


### PR DESCRIPTION
I found this option in code, but not documented.

https://github.com/kyleconroy/sqlc/blob/20372d7579876f93e361d7fcda79364d638ec818/internal/config/go_type.go#L15-L15