### PR TITLE
bin/sqlc: Add SQLCTMPDIR environment variable

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,5 +1,12 @@
 # Environment variables
 
+## SQLCCACHE
+
+The `SQLCCACHE` environment variable dictates where `sqlc` will store cached
+WASM-based plugins and modules. By default `sqlc` follows the [XDG Base
+Directory
+Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+
 ## SQLCDEBUG
 
 The `SQLCDEBUG` variable controls debugging variables within the runtime. It is
@@ -110,3 +117,18 @@ log showing the execution time for each package.
 0.046042779 	 .  5148212 	1 	region writefiles started (duration: 1.718259ms)
 0.047767781 	 .  1725002 	1 	task end
 ```
+
+### processplugins
+
+Setting this value to `0` disables process-based plugins. If a process-based
+plugin is declared in the configuration file, running any `sqlc` command will
+return an error.
+
+`SQLCDEBUG=processplugins=0`
+
+## SQLCTMPDIR
+
+If specified, use the given directory as the base for temporary folders. Only
+applies when using WASM-based codegen plugins. When not specified, this
+defaults to passing an empty string to
+[`os.MkdirTemp`](https://pkg.go.dev/os#MkdirTemp).

--- a/internal/ext/wasm/wasm.go
+++ b/internal/ext/wasm/wasm.go
@@ -236,7 +236,7 @@ func (r *Runner) Generate(ctx context.Context, req *plugin.CodeGenRequest) (*plu
 		return nil, err
 	}
 
-	dir, err := ioutil.TempDir("", "out")
+	dir, err := ioutil.TempDir(os.Getenv("SQLCTMPDIR"), "out")
 	if err != nil {
 		return nil, fmt.Errorf("temp dir: %w", err)
 	}

--- a/internal/ext/wasm/wasm.go
+++ b/internal/ext/wasm/wasm.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -236,7 +235,7 @@ func (r *Runner) Generate(ctx context.Context, req *plugin.CodeGenRequest) (*plu
 		return nil, err
 	}
 
-	dir, err := ioutil.TempDir(os.Getenv("SQLCTMPDIR"), "out")
+	dir, err := os.MkdirTemp(os.Getenv("SQLCTMPDIR"), "out")
 	if err != nil {
 		return nil, fmt.Errorf("temp dir: %w", err)
 	}


### PR DESCRIPTION
If specified, use the given directory as the base for temporary folders. Only applies when using WASM-based codegen plugins.