### PR TITLE
fix: correct singularization of "waves"

### DIFF
--- a/internal/inflection/singular.go
+++ b/internal/inflection/singular.go
@@ -39,5 +39,9 @@ func Singular(s SingularParams) string {
 	if strings.ToLower(s.Name) == "calories" {
 		return "calorie"
 	}
+	// Manual fix for incorrect handling of "-ves" suffix
+	if strings.ToLower(s.Name) == "waves" {
+		return "wave"
+	}
 	return upstream.Singular(s.Name)
 }


### PR DESCRIPTION
We hit a table where "waves" was singularized to "wafe". Probably caught the rule attempting to set "knives" -> "knife" and "wives" -> "wife".