### PR TITLE
Update default remote execution hostname

### DIFF
--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -145,7 +145,7 @@ func Generate(ctx context.Context, e Env, dir, filename string, stderr io.Writer
 		return nil, err
 	}
 
-	if conf.Cloud.Hostname != "" && !e.NoRemote {
+	if conf.Cloud.Project != "" && !e.NoRemote {
 		return remoteGenerate(ctx, configPath, conf, dir, stderr)
 	}
 

--- a/internal/remote/rpc.go
+++ b/internal/remote/rpc.go
@@ -11,13 +11,20 @@ import (
 	"github.com/kyleconroy/sqlc/internal/config"
 )
 
+const defaultHostname = "remote.sqlc.dev"
+
 func NewClient(cloudConfig config.Cloud) (GenClient, error) {
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})),
 		grpc.WithPerRPCCredentials(bearer.NewPerRPCCredentials(os.Getenv("SQLC_AUTH_TOKEN"))),
 	}
 
-	conn, err := grpc.Dial(cloudConfig.Hostname+":443", opts...)
+	hostname := cloudConfig.Hostname
+	if hostname == "" {
+		hostname = defaultHostname
+	}
+
+	conn, err := grpc.Dial(hostname+":443", opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When not present in config, set default remote execution hostname to `remote.sqlc.dev`