### PR TITLE
fix: fix toSnakeCase to handle input in camel case format

### DIFF
--- a/internal/codegen/golang/field.go
+++ b/internal/codegen/golang/field.go
@@ -2,6 +2,7 @@ package golang
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -57,7 +58,14 @@ func SetCaseStyle(name string, style string) string {
 	}
 }
 
+var camelPattern = regexp.MustCompile("[^A-Z][A-Z]+")
+
 func toSnakeCase(s string) string {
+	if !strings.ContainsRune(s, '_') {
+		s = camelPattern.ReplaceAllStringFunc(s, func(x string) string {
+			return x[:1] + "_" + x[1:]
+		})
+	}
 	return strings.ToLower(s)
 }
 

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -335,7 +335,7 @@ func columnsToStruct(req *plugin.CodeGenRequest, name string, columns []goColumn
 		colName := columnName(c.Column, i)
 		tagName := colName
 
-		// overide col/tag with expected model name
+		// override col/tag with expected model name
 		if c.embed != nil {
 			colName = c.embed.modelName
 			tagName = SetCaseStyle(colName, "snake")

--- a/internal/endtoend/testdata/sqlc_embed/postgresql/pgx/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_embed/postgresql/pgx/go/query.sql.go
@@ -118,7 +118,7 @@ INNER JOIN baz.users bu ON users.id = bu.id
 
 type WithCrossSchemaRow struct {
 	User    User    `db:"user" json:"user"`
-	BazUser BazUser `db:"bazuser" json:"bazuser"`
+	BazUser BazUser `db:"baz_user" json:"baz_user"`
 }
 
 func (q *Queries) WithCrossSchema(ctx context.Context) ([]WithCrossSchemaRow, error) {
@@ -152,7 +152,7 @@ SELECT bu.id, bu.name FROM baz.users bu
 `
 
 type WithSchemaRow struct {
-	BazUser BazUser `db:"bazuser" json:"bazuser"`
+	BazUser BazUser `db:"baz_user" json:"baz_user"`
 }
 
 func (q *Queries) WithSchema(ctx context.Context) (WithSchemaRow, error) {


### PR DESCRIPTION
fix #2243 

Previously, SetCaseStyle was used only for column names (snake case), so the `toSnakeCase` function worked correctly with strings.ToLower only.

Convert the model name (camel case) to snake case to get the tag name used in `sqlc.embed`.
This breaks the precondition of the `toSnakeCase` function and it no longer works correctly.

So we fixed the `toSnakeCase` function to work correctly even if the input is camel case.

If the proposed fix approach is incorrect, please let me know and feel free to close this PR