### PR TITLE
Feat: PostgreSQL capture correct line and column numbers for parse error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0
 	github.com/lib/pq v1.10.9
 	github.com/mattn/go-sqlite3 v1.14.16
-	github.com/pganalyze/pg_query_go/v4 v4.2.0
+	github.com/pganalyze/pg_query_go/v4 v4.2.1
 	github.com/riza-io/grpc-go v0.2.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
 github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
-github.com/pganalyze/pg_query_go/v4 v4.2.0 h1:67hSBZXYfABNYisEu/Xfu6R2gupnQwaoRhQicy0HSnQ=
-github.com/pganalyze/pg_query_go/v4 v4.2.0/go.mod h1:aEkDNOXNM5j0YGzaAapwJ7LB3dLNj+bvbWcLv1hOVqA=
+github.com/pganalyze/pg_query_go/v4 v4.2.1 h1:id/vuyIQccb9f6Yx3pzH5l4QYrxE3v6/m8RPlgMrprc=
+github.com/pganalyze/pg_query_go/v4 v4.2.1/go.mod h1:aEkDNOXNM5j0YGzaAapwJ7LB3dLNj+bvbWcLv1hOVqA=
 github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63 h1:+FZIDR/D97YOPik4N4lPDaUcLDF/EQPogxtlHB2ZZRM=
 github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=

--- a/internal/endtoend/testdata/syntax_errors/postgresql/stderr.txt
+++ b/internal/endtoend/testdata/syntax_errors/postgresql/stderr.txt
@@ -1,4 +1,4 @@
 # package querytest
-query/from.sql:1:1: syntax error at or near "from"
-query/select.sql:1:1: syntax error at or near "select"
-query/typo.sql:1:1: syntax error at or near "selectt"
+query/from.sql:2:35: syntax error at or near "from"
+query/select.sql:2:29: syntax error at or near "select"
+query/typo.sql:2:2: syntax error at or near "selectt"


### PR DESCRIPTION
Fixes issue #263

Recently pg_query_go began to return the full structured error info instead of just error message in https://github.com/pganalyze/pg_query_go/pull/76 which has released this functionality in [v4.2.1](https://github.com/pganalyze/pg_query_go/releases/tag/v4.2.1). This sqlc PR #2288 updates to use v4.2.1 for pg_query_go.

After that PR is merged, sqlc will still not correctly display the line and column numbers, as pg_query_go  `parser.Error` type has an `Error()` method that **only** includes the **message**, even though that same `parser.Error` type has all the other fields public.


**_This_** PR attempts to normalize the pg_query_go  `parser.Error` type  to a sqlc `*sqlerr.Error`.

+ Parse [here](https://github.com/pganalyze/pg_query_go/blob/main/parser/parser.go#LL106C15-L106C38)
Appears to call:
+ ParseToProtobuf [here](https://github.com/pganalyze/pg_query_go/blob/910915bfda5eb7b51f330613c335842ecd0a67d0/parser/parser.go#L113)
+ Appears to call  https://github.com/pganalyze/pg_query_go/blob/7986455fd7e1752b8399930d49beac2e8a139bd5/parser/pg_query_parse.c#L110
+ Appears to call pg_query_parse_protobuf [here](
https://github.com/pganalyze/pg_query_go/blob/7986455fd7e1752b8399930d49beac2e8a139bd5/parser/pg_query_parse.c#L110)

So it looks like a PgQueryError error has:
```
		error = malloc(sizeof(PgQueryError));
		error->message   = strdup(error_data->message);
		error->filename  = strdup(error_data->filename);
		error->funcname  = strdup(error_data->funcname);
		error->context   = NULL;
		error->lineno    = error_data->lineno;
		error->cursorpos = error_data->cursorpos;

		result.error = error;	
```
Which then is read by 
```
func newPgQueryError(errC *C.PgQueryError) *Error {
	err := &Error{
		Message:   C.GoString(errC.message),
		Lineno:    int(errC.lineno),
		Cursorpos: int(errC.cursorpos),
	}
	if errC.funcname != nil {
		err.Funcname = C.GoString(errC.funcname)
	}
	if errC.filename != nil {
		err.Filename = C.GoString(errC.filename)
	}
	if errC.context != nil {
		err.Context = C.GoString(errC.context)
	}
	return err
}
```

So the pg_query_go `*parser.Error` should be fully populated:
```
type Error struct {
	Message   string // exception message
	Funcname  string // source function of exception (e.g. SearchSysCache)
	Filename  string // source of exception (e.g. parse.l)
	Lineno    int    // source of exception (e.g. 104)
	Cursorpos int    // char in query at which exception occurred
	Context   string // additional context (optional, can be NULL)
}
```

Which is not exactly the same as the sqlc `*sqlerror.Error` type:
```
type Error struct {
	Err      error
	Code     string
	Message  string
	Location int
	Line     int
	Column   int
	// Hint     string
}
```

I believe that:
+ pg_query_go`*parser.Error.Lineno` is equivalent to sqlc `*sqlerror.Error.Line`
+ pg_query_go `*parser.Error.Cursorpos` is equivalent to sqlc `*sqlerror.Error.Location`
+ pg_query_go `*parser.Error.Message` is equivalent to sqlc `*sqlerror.Error.Message`


