### PR TITLE
Support unbounded parameter limit

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -124,8 +124,8 @@ The `gen` mapping supports the following keys:
 - `output_files_suffix`:
   - If specified the suffix will be added to the name of the generated files.
 - `query_parameter_limit`:
-  - Positional arguments that will be generated in Go functions (>= `1` or `-1`). To always emit a parameter struct, you would need to set it to `-1`. `0` is invalid. Defaults to `1`.
-`rename`:
+  - Positional arguments that will be generated in Go functions (>= `1` or `-1`). To always emit a parameter struct, you would need to set it to `1`. While `-1` is used to always generate all positional arguments. `0` is invalid. Defaults to `1`.
+- `rename`:
   - Customize the name of generated struct fields. Explained in detail on the `Renaming fields` section.
 - `overrides`:
   - It is a collection of definitions that dictates which types are used to map a database types. Explained in detail on the  `Type overriding` section.

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -241,7 +241,7 @@ func buildQueries(req *plugin.CodeGenRequest, structs []Struct) ([]Query, error)
 				EmitPointer: req.Settings.Go.EmitParamsStructPointers,
 			}
 
-			if len(query.Params) <= qpl {
+			if len(query.Params) <= qpl || qpl == -1 {
 				gq.Arg.Emit = false
 			}
 		}

--- a/internal/config/v_two.go
+++ b/internal/config/v_two.go
@@ -75,7 +75,8 @@ func v2ParseConfig(rd io.Reader) (Config, error) {
 				conf.SQL[j].Gen.Go.Package = filepath.Base(conf.SQL[j].Gen.Go.Out)
 			}
 
-			if conf.SQL[j].Gen.Go.QueryParameterLimit != nil && (*conf.SQL[j].Gen.Go.QueryParameterLimit < 0) {
+			if conf.SQL[j].Gen.Go.QueryParameterLimit != nil && (*conf.SQL[j].Gen.Go.QueryParameterLimit == 0 ||
+				*conf.SQL[j].Gen.Go.QueryParameterLimit < -1) {
 				return conf, ErrInvalidQueryParameterLimit
 			}
 


### PR DESCRIPTION
In version 2, setting up `query_parameter_limit` to `-1` is not working. As per explanation in [this reference](https://github.com/kyleconroy/sqlc/blob/8d365df161778947e36394838727ce68e40d1f69/docs/reference/config.md?plain=1#L127), it should accepts limit of positional arguments with value `-1`.

And I think there should be a correction of what value `-1` must behave. Instead of always emit struct (like value `1` does), it should generates the code with complete positional arguments.