### PR TITLE
python: Use latest version of sqlc-gen-python

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,4 +1,5 @@
 version: v1
+name: buf.build/sqlc/sqlc
 breaking:
   use:
     - FILE

--- a/examples/python/sqlc.json
+++ b/examples/python/sqlc.json
@@ -4,8 +4,8 @@
     {
       "name": "py",
       "wasm": {
-        "url": "https://downloads.sqlc.dev/plugin/sqlc-gen-python_1.0.0.wasm",
-        "sha256": "aca83e1f59f8ffdc604774c2f6f9eb321a2b23e07dc83fc12289d25305fa065b"
+        "url": "https://downloads.sqlc.dev/plugin/sqlc-gen-python_1.1.0.wasm",
+        "sha256": "ef58f143a8c116781091441770c7166caaf361dd645f62b8f05f462e9f95c3b2"
       }
     }
   ],

--- a/internal/endtoend/testdata/emit_pydantic_models/sqlc.json
+++ b/internal/endtoend/testdata/emit_pydantic_models/sqlc.json
@@ -4,8 +4,8 @@
     {
       "name": "py",
       "wasm": {
-        "url": "https://downloads.sqlc.dev/plugin/sqlc-gen-python_1.0.0.wasm",
-        "sha256": "aca83e1f59f8ffdc604774c2f6f9eb321a2b23e07dc83fc12289d25305fa065b"
+        "url": "https://downloads.sqlc.dev/plugin/sqlc-gen-python_1.1.0.wasm",
+        "sha256": "ef58f143a8c116781091441770c7166caaf361dd645f62b8f05f462e9f95c3b2"
       }
     }
   ],

--- a/internal/endtoend/testdata/exec_result/python_postgresql/sqlc.json
+++ b/internal/endtoend/testdata/exec_result/python_postgresql/sqlc.json
@@ -4,8 +4,8 @@
     {
       "name": "py",
       "wasm": {
-        "url": "https://downloads.sqlc.dev/plugin/sqlc-gen-python_1.0.0.wasm",
-        "sha256": "aca83e1f59f8ffdc604774c2f6f9eb321a2b23e07dc83fc12289d25305fa065b"
+        "url": "https://downloads.sqlc.dev/plugin/sqlc-gen-python_1.1.0.wasm",
+        "sha256": "ef58f143a8c116781091441770c7166caaf361dd645f62b8f05f462e9f95c3b2"
       }
     }
   ],

--- a/internal/endtoend/testdata/exec_rows/python_postgresql/sqlc.json
+++ b/internal/endtoend/testdata/exec_rows/python_postgresql/sqlc.json
@@ -4,8 +4,8 @@
     {
       "name": "py",
       "wasm": {
-        "url": "https://downloads.sqlc.dev/plugin/sqlc-gen-python_1.0.0.wasm",
-        "sha256": "aca83e1f59f8ffdc604774c2f6f9eb321a2b23e07dc83fc12289d25305fa065b"
+        "url": "https://downloads.sqlc.dev/plugin/sqlc-gen-python_1.1.0.wasm",
+        "sha256": "ef58f143a8c116781091441770c7166caaf361dd645f62b8f05f462e9f95c3b2"
       }
     }
   ],

--- a/internal/endtoend/testdata/query_parameter_limit/-1/python_postgresql/sqlc.json
+++ b/internal/endtoend/testdata/query_parameter_limit/-1/python_postgresql/sqlc.json
@@ -4,8 +4,8 @@
     {
       "name": "py",
       "wasm": {
-        "url": "https://downloads.sqlc.dev/plugin/sqlc-gen-python_1.0.0.wasm",
-        "sha256": "aca83e1f59f8ffdc604774c2f6f9eb321a2b23e07dc83fc12289d25305fa065b"
+        "url": "https://downloads.sqlc.dev/plugin/sqlc-gen-python_1.1.0.wasm",
+        "sha256": "ef58f143a8c116781091441770c7166caaf361dd645f62b8f05f462e9f95c3b2"
       }
     }
   ],

--- a/internal/endtoend/testdata/query_parameter_limit/0/python_postgresql/sqlc.json
+++ b/internal/endtoend/testdata/query_parameter_limit/0/python_postgresql/sqlc.json
@@ -4,8 +4,8 @@
     {
       "name": "py",
       "wasm": {
-        "url": "https://downloads.sqlc.dev/plugin/sqlc-gen-python_1.0.0.wasm",
-        "sha256": "aca83e1f59f8ffdc604774c2f6f9eb321a2b23e07dc83fc12289d25305fa065b"
+        "url": "https://downloads.sqlc.dev/plugin/sqlc-gen-python_1.1.0.wasm",
+        "sha256": "ef58f143a8c116781091441770c7166caaf361dd645f62b8f05f462e9f95c3b2"
       }
     }
   ],

--- a/internal/endtoend/testdata/query_parameter_limit/2/python_postgresql/sqlc.json
+++ b/internal/endtoend/testdata/query_parameter_limit/2/python_postgresql/sqlc.json
@@ -4,8 +4,8 @@
     {
       "name": "py",
       "wasm": {
-        "url": "https://downloads.sqlc.dev/plugin/sqlc-gen-python_1.0.0.wasm",
-        "sha256": "aca83e1f59f8ffdc604774c2f6f9eb321a2b23e07dc83fc12289d25305fa065b"
+        "url": "https://downloads.sqlc.dev/plugin/sqlc-gen-python_1.1.0.wasm",
+        "sha256": "ef58f143a8c116781091441770c7166caaf361dd645f62b8f05f462e9f95c3b2"
       }
     }
   ],


### PR DESCRIPTION
This version is build using the upcoming WASI support in Go 1.21.