### PR TITLE
Don't defer rows.Close() if pgx.BatchResults.Query() failed 

### DIFF
--- a/examples/batch/postgresql/batch.go
+++ b/examples/batch/postgresql/batch.go
@@ -53,10 +53,10 @@ func (b *BooksByYearBatchResults) Query(f func(int, []Book, error)) {
 		}
 		err := func() error {
 			rows, err := b.br.Query()
-			defer rows.Close()
 			if err != nil {
 				return err
 			}
+			defer rows.Close()
 			for rows.Next() {
 				var i Book
 				if err := rows.Scan(

--- a/internal/codegen/golang/templates/pgx/batchCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/batchCode.tmpl
@@ -84,7 +84,7 @@ func (b *{{.MethodName}}BatchResults) Query(f func(int, []{{.Ret.DefineType}}, e
         continue
      }
      err := func() error {
-	    rows, err := b.br.Query()
+       rows, err := b.br.Query()
        defer rows.Close()
        if err != nil {
          return err

--- a/internal/codegen/golang/templates/pgx/batchCode.tmpl
+++ b/internal/codegen/golang/templates/pgx/batchCode.tmpl
@@ -85,10 +85,10 @@ func (b *{{.MethodName}}BatchResults) Query(f func(int, []{{.Ret.DefineType}}, e
      }
      err := func() error {
        rows, err := b.br.Query()
-       defer rows.Close()
        if err != nil {
          return err
        }
+       defer rows.Close()
        for rows.Next() {
            var {{.Ret.Name}} {{.Ret.Type}}
            if err := rows.Scan({{.Ret.Scan}}); err != nil {

--- a/internal/endtoend/testdata/batch/postgresql/pgx/v4/go/batch.go
+++ b/internal/endtoend/testdata/batch/postgresql/pgx/v4/go/batch.go
@@ -53,10 +53,10 @@ func (b *GetValuesBatchResults) Query(f func(int, []MyschemaFoo, error)) {
 		}
 		err := func() error {
 			rows, err := b.br.Query()
-			defer rows.Close()
 			if err != nil {
 				return err
 			}
+			defer rows.Close()
 			for rows.Next() {
 				var i MyschemaFoo
 				if err := rows.Scan(&i.A, &i.B); err != nil {

--- a/internal/endtoend/testdata/batch/postgresql/pgx/v5/go/batch.go
+++ b/internal/endtoend/testdata/batch/postgresql/pgx/v5/go/batch.go
@@ -53,10 +53,10 @@ func (b *GetValuesBatchResults) Query(f func(int, []MyschemaFoo, error)) {
 		}
 		err := func() error {
 			rows, err := b.br.Query()
-			defer rows.Close()
 			if err != nil {
 				return err
 			}
+			defer rows.Close()
 			for rows.Next() {
 				var i MyschemaFoo
 				if err := rows.Scan(&i.A, &i.B); err != nil {

--- a/internal/endtoend/testdata/batch_imports/postgresql/pgx/v4/go/batch.go
+++ b/internal/endtoend/testdata/batch_imports/postgresql/pgx/v4/go/batch.go
@@ -53,10 +53,10 @@ func (b *GetValuesBatchResults) Query(f func(int, []MyschemaFoo, error)) {
 		}
 		err := func() error {
 			rows, err := b.br.Query()
-			defer rows.Close()
 			if err != nil {
 				return err
 			}
+			defer rows.Close()
 			for rows.Next() {
 				var i MyschemaFoo
 				if err := rows.Scan(&i.A, &i.B); err != nil {

--- a/internal/endtoend/testdata/batch_imports/postgresql/pgx/v5/go/batch.go
+++ b/internal/endtoend/testdata/batch_imports/postgresql/pgx/v5/go/batch.go
@@ -53,10 +53,10 @@ func (b *GetValuesBatchResults) Query(f func(int, []MyschemaFoo, error)) {
 		}
 		err := func() error {
 			rows, err := b.br.Query()
-			defer rows.Close()
 			if err != nil {
 				return err
 			}
+			defer rows.Close()
 			for rows.Next() {
 				var i MyschemaFoo
 				if err := rows.Scan(&i.A, &i.B); err != nil {

--- a/internal/endtoend/testdata/output_file_names/pgx/v4/go/batch_gen.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v4/go/batch_gen.go
@@ -51,10 +51,10 @@ func (b *UsersBBatchResults) Query(f func(int, []int64, error)) {
 		}
 		err := func() error {
 			rows, err := b.br.Query()
-			defer rows.Close()
 			if err != nil {
 				return err
 			}
+			defer rows.Close()
 			for rows.Next() {
 				var id int64
 				if err := rows.Scan(&id); err != nil {

--- a/internal/endtoend/testdata/output_file_names/pgx/v5/go/batch_gen.go
+++ b/internal/endtoend/testdata/output_file_names/pgx/v5/go/batch_gen.go
@@ -51,10 +51,10 @@ func (b *UsersBBatchResults) Query(f func(int, []int64, error)) {
 		}
 		err := func() error {
 			rows, err := b.br.Query()
-			defer rows.Close()
 			if err != nil {
 				return err
 			}
+			defer rows.Close()
 			for rows.Next() {
 				var id int64
 				if err := rows.Scan(&id); err != nil {


### PR DESCRIPTION
To appease staticcheck