### PR TITLE
Understand sqlc.slice() in more expression types

### DIFF
--- a/internal/compiler/resolve.go
+++ b/internal/compiler/resolve.go
@@ -153,6 +153,7 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 						DataType:     dataType,
 						IsNamedParam: isNamed,
 						NotNull:      p.NotNull(),
+						IsSqlcSlice:  p.IsSqlcSlice(),
 					},
 				})
 				continue
@@ -220,6 +221,7 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 								Length:       c.Length,
 								Table:        table,
 								IsNamedParam: isNamed,
+								IsSqlcSlice:  p.IsSqlcSlice(),
 							},
 						})
 					}
@@ -284,6 +286,7 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 							IsArray:      c.IsArray,
 							Table:        table,
 							IsNamedParam: isNamed,
+							IsSqlcSlice:  p.IsSqlcSlice(),
 						},
 					})
 				}
@@ -352,6 +355,7 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 							DataType:     "any",
 							IsNamedParam: isNamed,
 							NotNull:      p.NotNull(),
+							IsSqlcSlice:  p.IsSqlcSlice(),
 						},
 					})
 					continue
@@ -392,6 +396,7 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 						DataType:     dataType(paramType),
 						NotNull:      p.NotNull(),
 						IsNamedParam: isNamed,
+						IsSqlcSlice:  p.IsSqlcSlice(),
 					},
 				})
 			}
@@ -457,6 +462,7 @@ func (comp *Compiler) resolveCatalogRefs(qc *QueryCatalog, rvs []*ast.RangeVar, 
 						Table:        &ast.TableName{Schema: schema, Name: rel},
 						Length:       c.Length,
 						IsNamedParam: isNamed,
+						IsSqlcSlice:  p.IsSqlcSlice(),
 					},
 				})
 			} else {

--- a/internal/endtoend/testdata/sqlc_slice/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/sqlc_slice/postgresql/stdlib/go/query.sql.go
@@ -7,6 +7,7 @@ package querytest
 
 import (
 	"context"
+	"strings"
 )
 
 const funcParamIdent = `-- name: FuncParamIdent :many
@@ -17,11 +18,22 @@ WHERE name = $1
 
 type FuncParamIdentParams struct {
 	Slug       string
-	Favourites int32
+	Favourites []int32
 }
 
 func (q *Queries) FuncParamIdent(ctx context.Context, arg FuncParamIdentParams) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, funcParamIdent, arg.Slug, arg.Favourites)
+	query := funcParamIdent
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.Slug)
+	if len(arg.Favourites) > 0 {
+		for _, v := range arg.Favourites {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:favourites*/?", strings.Repeat(",?", len(arg.Favourites))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -51,11 +63,22 @@ WHERE name = $1
 
 type FuncParamStringParams struct {
 	Slug       string
-	Favourites int32
+	Favourites []int32
 }
 
 func (q *Queries) FuncParamString(ctx context.Context, arg FuncParamStringParams) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, funcParamString, arg.Slug, arg.Favourites)
+	query := funcParamString
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.Slug)
+	if len(arg.Favourites) > 0 {
+		for _, v := range arg.Favourites {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:favourites*/?", strings.Repeat(",?", len(arg.Favourites))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:favourites*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This was needed to understand PostgreSQL IN() which doens't surface as an *ast.In