### PR TITLE
feat(cmd/vet): Add built-in db-prepare rule

### DIFF
--- a/examples/authors/sqlc.json
+++ b/examples/authors/sqlc.json
@@ -8,6 +8,9 @@
       "database": {
         "url": "postgresql://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/authors"
       },
+      "rules": [
+        "db-prepare"
+      ],
       "gen": {
         "go": {
           "package": "authors",
@@ -22,6 +25,9 @@
       "database": {
         "url": "root:${MYSQL_ROOT_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/authors?multiStatements=true&parseTime=true"
       },
+      "rules": [
+        "db-prepare"
+      ],
       "gen": {
         "go": {
           "package": "authors",
@@ -36,6 +42,9 @@
       "database": {
         "url": "file:authors?mode=memory&cache=shared"
       },
+      "rules": [
+        "db-prepare"
+      ],
       "gen": {
         "go": {
           "package": "authors",

--- a/examples/batch/sqlc.json
+++ b/examples/batch/sqlc.json
@@ -10,6 +10,9 @@
       "database": {
         "url": "postgresql://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/batch"
       },
+      "rules": [
+        "db-prepare"
+      ],
       "sql_package": "pgx/v4",
       "emit_json_tags": true,
       "emit_prepared_queries": true,

--- a/examples/booktest/sqlc.json
+++ b/examples/booktest/sqlc.json
@@ -9,7 +9,10 @@
       "engine": "postgresql",
       "database": {
         "url": "postgresql://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/booktest"
-      }
+      },
+      "rules": [
+        "db-prepare"
+      ]
     },
     {
       "name": "booktest",
@@ -19,7 +22,10 @@
       "engine": "mysql",
       "database": {
         "url": "root:${MYSQL_ROOT_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/booktest?multiStatements=true&parseTime=true"
-      }
+      },
+      "rules": [
+        "db-prepare"
+      ]
     },
     {
       "name": "booktest",
@@ -29,7 +35,10 @@
       "engine": "sqlite",
       "database": {
         "url": "file:booktest?mode=memory&cache=shared"
-      }
+      },
+      "rules": [
+        "db-prepare"
+      ]
     }
   ]
 }

--- a/examples/jets/sqlc.json
+++ b/examples/jets/sqlc.json
@@ -9,7 +9,10 @@
       "engine": "postgresql",
       "database": {
         "url": "postgresql://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/jets"
-      }
+      },
+      "rules": [
+        "db-prepare"
+      ]
     }
   ]
 }

--- a/examples/ondeck/sqlc.json
+++ b/examples/ondeck/sqlc.json
@@ -10,6 +10,9 @@
       "database": {
         "url": "postgresql://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/ondeck"
       },
+      "rules": [
+        "db-prepare"
+      ],
       "emit_json_tags": true,
       "emit_prepared_queries": true,
       "emit_interface": true
@@ -23,6 +26,9 @@
       "database": {
         "url": "root:${MYSQL_ROOT_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/ondeck?multiStatements=true&parseTime=true"
       },
+      "rules": [
+        "db-prepare"
+      ],
       "emit_json_tags": true,
       "emit_prepared_queries": true,
       "emit_interface": true
@@ -36,6 +42,9 @@
       "database": {
         "url": "file:ondeck?mode=memory&cache=shared"
       },
+      "rules": [
+        "db-prepare"
+      ],
       "emit_json_tags": true,
       "emit_prepared_queries": true,
       "emit_interface": true

--- a/internal/cmd/vet.go
+++ b/internal/cmd/vet.go
@@ -14,6 +14,7 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/ext"
 	"github.com/jackc/pgx/v5"
 	_ "github.com/mattn/go-sqlite3"
@@ -28,6 +29,8 @@ import (
 )
 
 var ErrFailedChecks = errors.New("failed checks")
+
+const RuleDbPrepare = "db-prepare"
 
 func NewCmdVet() *cobra.Command {
 	return &cobra.Command{
@@ -46,6 +49,17 @@ func NewCmdVet() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+type emptyProgram struct {
+}
+
+func (e *emptyProgram) Eval(any) (ref.Val, *cel.EvalDetails, error) {
+	return nil, nil, fmt.Errorf("unimplemented")
+}
+
+func (e *emptyProgram) ContextEval(ctx context.Context, a any) (ref.Val, *cel.EvalDetails, error) {
+	return e.Eval(a)
 }
 
 func Vet(ctx context.Context, e Env, dir, filename string, stderr io.Writer) error {
@@ -83,7 +97,9 @@ func Vet(ctx context.Context, e Env, dir, filename string, stderr io.Writer) err
 		return fmt.Errorf("new env: %s", err)
 	}
 
-	checks := map[string]cel.Program{}
+	checks := map[string]cel.Program{
+		RuleDbPrepare: &emptyProgram{},
+	}
 	msgs := map[string]string{}
 
 	for _, c := range conf.Rules {
@@ -278,16 +294,21 @@ func (c *checker) checkSQL(ctx context.Context, s config.SQL) error {
 	req := codeGenRequest(result, combo)
 	cfg := vetConfig(req)
 	for i, query := range req.Queries {
-		original := result.Queries[i]
-		if prep != nil && prepareable(s, original.RawStmt) {
-			name := fmt.Sprintf("sqlc_vet_%d_%d", time.Now().Unix(), i)
-			if err := prep.Prepare(ctx, name, query.Text); err != nil {
-				fmt.Fprintf(c.Stderr, "%s: error preparing %s on %s: %s\n", query.Filename, query.Name, s.Engine, err)
-				errored = true
-			}
-		}
 		q := vetQuery(query)
 		for _, name := range s.Rules {
+			// Built-in rule
+			if name == RuleDbPrepare {
+				original := result.Queries[i]
+				if prep != nil && prepareable(s, original.RawStmt) {
+					name := fmt.Sprintf("sqlc_vet_%d_%d", time.Now().Unix(), i)
+					if err := prep.Prepare(ctx, name, query.Text); err != nil {
+						fmt.Fprintf(c.Stderr, "%s: %s: %s: error preparing query: %s\n", query.Filename, q.Name, name, err)
+						errored = true
+					}
+				}
+				continue
+			}
+
 			prg, ok := c.Checks[name]
 			if !ok {
 				return fmt.Errorf("type-check error: a check with the name '%s' does not exist", name)

--- a/internal/cmd/vet.go
+++ b/internal/cmd/vet.go
@@ -298,8 +298,13 @@ func (c *checker) checkSQL(ctx context.Context, s config.SQL) error {
 		for _, name := range s.Rules {
 			// Built-in rule
 			if name == RuleDbPrepare {
+				if prep == nil {
+					fmt.Fprintf(c.Stderr, "%s: %s: %s: error preparing query: database connection required\n", query.Filename, q.Name, name)
+					errored = true
+					continue
+				}
 				original := result.Queries[i]
-				if prep != nil && prepareable(s, original.RawStmt) {
+				if prepareable(s, original.RawStmt) {
 					name := fmt.Sprintf("sqlc_vet_%d_%d", time.Now().Unix(), i)
 					if err := prep.Prepare(ctx, name, query.Text); err != nil {
 						fmt.Fprintf(c.Stderr, "%s: %s: %s: error preparing query: %s\n", query.Filename, q.Name, name, err)

--- a/internal/config/v_one.go
+++ b/internal/config/v_one.go
@@ -15,6 +15,7 @@ type V1GenerateSettings struct {
 	Packages  []v1PackageSettings `json:"packages" yaml:"packages"`
 	Overrides []Override          `json:"overrides,omitempty" yaml:"overrides,omitempty"`
 	Rename    map[string]string   `json:"rename,omitempty" yaml:"rename,omitempty"`
+	Rules     []Rule              `json:"rules" yaml:"rules"`
 }
 
 type v1PackageSettings struct {
@@ -51,6 +52,7 @@ type v1PackageSettings struct {
 	StrictOrderBy             *bool      `json:"strict_order_by" yaml:"strict_order_by"`
 	QueryParameterLimit       *int32     `json:"query_parameter_limit,omitempty" yaml:"query_parameter_limit"`
 	OmitUnusedStructs         bool       `json:"omit_unused_structs,omitempty" yaml:"omit_unused_structs"`
+	Rules                     []string   `json:"rules" yaml:"rules"`
 }
 
 func v1ParseConfig(rd io.Reader) (Config, error) {
@@ -131,6 +133,7 @@ func (c *V1GenerateSettings) Translate() Config {
 		Version: c.Version,
 		Project: c.Project,
 		Cloud:   c.Cloud,
+		Rules:   c.Rules,
 	}
 
 	for _, pkg := range c.Packages {
@@ -143,6 +146,7 @@ func (c *V1GenerateSettings) Translate() Config {
 			Database: pkg.Database,
 			Schema:   pkg.Schema,
 			Queries:  pkg.Queries,
+			Rules:    pkg.Rules,
 			Gen: SQLGen{
 				Go: &SQLGo{
 					EmitInterface:             pkg.EmitInterface,


### PR DESCRIPTION
Instead of always preparing a query when running vet, opt-in to doing it with the `db-prepare` rule.