### PR TITLE
Fix: Update sqlc/db-prepare command name in docs

### DIFF
--- a/docs/howto/vet.md
+++ b/docs/howto/vet.md
@@ -85,7 +85,7 @@ rules:
 ### sqlc/db-prepare
 
 When a [database](../reference/config.html#database) connection is configured, you can
-run the built-in `sqlc/db-preapre` rule. This rule will attempt to prepare
+run the built-in `sqlc/db-prepare` rule. This rule will attempt to prepare
 each of your queries against the connected database and report any failures.
 
 ```yaml


### PR DESCRIPTION
`sqlc/db-prepare` was misspelled, updating to match the rule name properly