### PR TITLE
fix(postgres): prevent panics when encountering unexpected ast nodes in range function lists

### DIFF
--- a/internal/compiler/output_columns.go
+++ b/internal/compiler/output_columns.go
@@ -502,18 +502,25 @@ func (c *Compiler) sourceTables(qc *QueryCatalog, node ast.Node) ([]*Table, erro
 		switch n := item.(type) {
 
 		case *ast.RangeFunction:
-			// If the function or table can't be found, don't error out.  There
-			// are many queries that depend on functions unknown to sqlc.
 			var funcCall *ast.FuncCall
 			switch f := n.Functions.Items[0].(type) {
 			case *ast.List:
-				funcCall = f.Items[0].(*ast.FuncCall)
+				switch fi := f.Items[0].(type) {
+				case *ast.FuncCall:
+					funcCall = fi
+				case *ast.SQLValueFunction:
+					continue // TODO handle this correctly
+				default:
+					continue
+			}
 			case *ast.FuncCall:
 				funcCall = f
 			default:
 				return nil, fmt.Errorf("sourceTables: unsupported function call type %T", n.Functions.Items[0])
 			}
 
+			// If the function or table can't be found, don't error out.  There
+			// are many queries that depend on functions unknown to sqlc.
 			fn, err := qc.GetFunc(funcCall.Func)
 			if err != nil {
 				continue

--- a/internal/endtoend/testdata/func_return/postgresql/pgx/v4/go/query.sql.go
+++ b/internal/endtoend/testdata/func_return/postgresql/pgx/v4/go/query.sql.go
@@ -42,6 +42,20 @@ func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams) 
 	return items, nil
 }
 
+const getDate = `-- name: GetDate :one
+SELECT  from CURRENT_DATE
+`
+
+type GetDateRow struct {
+}
+
+func (q *Queries) GetDate(ctx context.Context) (GetDateRow, error) {
+	row := q.db.QueryRow(ctx, getDate)
+	var i GetDateRow
+	err := row.Scan()
+	return i, err
+}
+
 const getUsers = `-- name: GetUsers :many
 SELECT id, first_name
 FROM users_func()

--- a/internal/endtoend/testdata/func_return/postgresql/pgx/v4/query.sql
+++ b/internal/endtoend/testdata/func_return/postgresql/pgx/v4/query.sql
@@ -8,3 +8,6 @@ WHERE first_name != '';
 SELECT ($1::inet) + i
 FROM generate_series(0, $2::int) AS i
 LIMIT 1;
+
+/* name: GetDate :one */
+SELECT * from CURRENT_DATE;

--- a/internal/endtoend/testdata/func_return/postgresql/pgx/v5/go/query.sql.go
+++ b/internal/endtoend/testdata/func_return/postgresql/pgx/v5/go/query.sql.go
@@ -41,6 +41,20 @@ func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams) 
 	return items, nil
 }
 
+const getDate = `-- name: GetDate :one
+SELECT  from CURRENT_DATE
+`
+
+type GetDateRow struct {
+}
+
+func (q *Queries) GetDate(ctx context.Context) (GetDateRow, error) {
+	row := q.db.QueryRow(ctx, getDate)
+	var i GetDateRow
+	err := row.Scan()
+	return i, err
+}
+
 const getUsers = `-- name: GetUsers :many
 SELECT id, first_name
 FROM users_func()

--- a/internal/endtoend/testdata/func_return/postgresql/pgx/v5/query.sql
+++ b/internal/endtoend/testdata/func_return/postgresql/pgx/v5/query.sql
@@ -8,3 +8,6 @@ WHERE first_name != '';
 SELECT ($1::inet) + i
 FROM generate_series(0, $2::int) AS i
 LIMIT 1;
+
+/* name: GetDate :one */
+SELECT * from CURRENT_DATE;

--- a/internal/endtoend/testdata/func_return/postgresql/stdlib/go/query.sql.go
+++ b/internal/endtoend/testdata/func_return/postgresql/stdlib/go/query.sql.go
@@ -45,6 +45,20 @@ func (q *Queries) GenerateSeries(ctx context.Context, arg GenerateSeriesParams) 
 	return items, nil
 }
 
+const getDate = `-- name: GetDate :one
+SELECT  from CURRENT_DATE
+`
+
+type GetDateRow struct {
+}
+
+func (q *Queries) GetDate(ctx context.Context) (GetDateRow, error) {
+	row := q.db.QueryRowContext(ctx, getDate)
+	var i GetDateRow
+	err := row.Scan()
+	return i, err
+}
+
 const getUsers = `-- name: GetUsers :many
 SELECT id, first_name
 FROM users_func()

--- a/internal/endtoend/testdata/func_return/postgresql/stdlib/query.sql
+++ b/internal/endtoend/testdata/func_return/postgresql/stdlib/query.sql
@@ -8,3 +8,6 @@ WHERE first_name != '';
 SELECT ($1::inet) + i
 FROM generate_series(0, $2::int) AS i
 LIMIT 1;
+
+/* name: GetDate :one */
+SELECT * from CURRENT_DATE;


### PR DESCRIPTION
This is a fix for the issue causing a panic in https://github.com/kyleconroy/sqlc/issues/2416, but sqlc doesn't correctly handle cases where so-called SQL "value" functions appear in FROM clauses. I'm doubtful that sqlc ever supported this correctly.

The query in the test-case I added (`SELECT * from CURRENT_DATE;`) is valid, but as you can see from the generated output it won't actually produce the desired result. I will open a new issue for this.