### PR TITLE
docs: Add a description to the document for cases when a query result has no rows

### DIFF
--- a/docs/howto/select.md
+++ b/docs/howto/select.md
@@ -133,6 +133,10 @@ When selecting multiple columns, a row record (method-specific struct) is
 returned. In this case, `GetInfoForAuthor` returns a struct with two fields:
 `Bio` and `BirthYear`.
 
+If a query result has no row records, a zero value and an `ErrNoRows` error are
+returned instead of a zero value and `nil`. For instance, when the `GetBioForAuthor`
+result has no rows, it will return `""` and `ErrNoRows`.
+
 ```go
 package db
 

--- a/internal/tools/sqlc-pg-gen/main.go
+++ b/internal/tools/sqlc-pg-gen/main.go
@@ -156,7 +156,7 @@ func clean(arg string) string {
 	return arg
 }
 
-// writeFormattedGo executes `tmpl` with `data` as its context to the the file `destPath`
+// writeFormattedGo executes `tmpl` with `data` as its context to the file `destPath`
 func writeFormattedGo(tmpl *template.Template, data any, destPath string) error {
 	out := bytes.NewBuffer([]byte{})
 	err := tmpl.Execute(out, data)


### PR DESCRIPTION
I added a description to the document for cases when a query result has no rows because I found it unclear what the query returns when reading the document.