### PR TITLE
feat: add basic parsing of boolean flag query metadata annotations

### DIFF
--- a/internal/compiler/parse.go
+++ b/internal/compiler/parse.go
@@ -70,7 +70,7 @@ func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query,
 	if err := validate.In(c.catalog, raw); err != nil {
 		return nil, err
 	}
-	name, cmd, err := metadata.Parse(strings.TrimSpace(rawSQL), c.parser.CommentSyntax())
+	name, cmd, err := metadata.ParseQueryNameAndType(strings.TrimSpace(rawSQL), c.parser.CommentSyntax())
 	if err != nil {
 		return nil, err
 	}
@@ -125,11 +125,18 @@ func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query,
 	if err != nil {
 		return nil, err
 	}
+
+	flags, err := metadata.ParseQueryFlags(comments)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Query{
 		RawStmt:         raw,
 		Cmd:             cmd,
 		Comments:        comments,
 		Name:            name,
+		Flags:           flags,
 		Params:          params,
 		Columns:         cols,
 		SQL:             trimmed,

--- a/internal/compiler/query.go
+++ b/internal/compiler/query.go
@@ -42,6 +42,7 @@ type Query struct {
 	SQL      string
 	Name     string
 	Cmd      string // TODO: Pick a better name. One of: one, many, exec, execrows, copyFrom
+	Flags    map[string]bool
 	Columns  []*Column
 	Params   []Parameter
 	Comments []string

--- a/internal/metadata/meta.go
+++ b/internal/metadata/meta.go
@@ -44,7 +44,7 @@ func validateQueryName(name string) error {
 	return nil
 }
 
-func Parse(t string, commentStyle CommentSyntax) (string, string, error) {
+func ParseQueryNameAndType(t string, commentStyle CommentSyntax) (string, string, error) {
 	for _, line := range strings.Split(t, "\n") {
 		var prefix string
 		if strings.HasPrefix(line, "--") {
@@ -102,4 +102,20 @@ func Parse(t string, commentStyle CommentSyntax) (string, string, error) {
 		return queryName, queryType, nil
 	}
 	return "", "", nil
+}
+
+func ParseQueryFlags(comments []string) (map[string]bool, error) {
+	flags := make(map[string]bool)
+	for _, line := range comments {
+		cleanLine := strings.TrimPrefix(line, "--")
+		cleanLine = strings.TrimPrefix(cleanLine, "/*")
+		cleanLine = strings.TrimPrefix(cleanLine, "#")
+		cleanLine = strings.TrimSuffix(cleanLine, "*/")
+		cleanLine = strings.TrimSpace(cleanLine)
+		if strings.HasPrefix(cleanLine, "@") {
+			flagName := strings.SplitN(cleanLine, " ", 2)[0]
+			flags[flagName] = true
+		}
+	}
+	return flags, nil
 }

--- a/internal/metadata/meta_test.go
+++ b/internal/metadata/meta_test.go
@@ -2,7 +2,7 @@ package metadata
 
 import "testing"
 
-func TestParseMetadata(t *testing.T) {
+func TestParseQueryNameAndType(t *testing.T) {
 
 	for _, query := range []string{
 		`-- name: CreateFoo, :one`,
@@ -17,7 +17,7 @@ func TestParseMetadata(t *testing.T) {
 		"-- name:CreateFoo",
 		`--name:CreateFoo :two`,
 	} {
-		if _, _, err := Parse(query, CommentSyntax{Dash: true}); err == nil {
+		if _, _, err := ParseQueryNameAndType(query, CommentSyntax{Dash: true}); err == nil {
 			t.Errorf("expected invalid metadata: %q", query)
 		}
 	}
@@ -27,13 +27,13 @@ func TestParseMetadata(t *testing.T) {
 		`-- name comment`,
 		`--name comment`,
 	} {
-		if _, _, err := Parse(query, CommentSyntax{Dash: true}); err != nil {
+		if _, _, err := ParseQueryNameAndType(query, CommentSyntax{Dash: true}); err != nil {
 			t.Errorf("expected valid comment: %q", query)
 		}
 	}
 
 	query := `-- name: CreateFoo :one`
-	queryName, queryType, err := Parse(query, CommentSyntax{Dash: true})
+	queryName, queryType, err := ParseQueryNameAndType(query, CommentSyntax{Dash: true})
 	if err != nil {
 		t.Errorf("expected valid metadata: %q", query)
 	}
@@ -44,4 +44,22 @@ func TestParseMetadata(t *testing.T) {
 		t.Errorf("incorrect queryType parsed: %q", query)
 	}
 
+}
+
+func TestParseQueryFlags(t *testing.T) {
+	for _, comments := range [][]string{
+		{
+			"-- name: CreateFoo :one",
+			"-- @flag-foo",
+		},
+	} {
+		flags, err := ParseQueryFlags(comments)
+		if err != nil {
+			t.Errorf("expected query flags to parse, got error: %s", err)
+		}
+
+		if !flags["@flag-foo"] {
+			t.Errorf("expected flag not found")
+		}
+	}
 }


### PR DESCRIPTION
This is just a starting point for implementing the proposal in https://github.com/kyleconroy/sqlc/issues/2454.

For now I just parse comment lines starting with `@<string>` as `true`-valued boolean flags associated with a query.

I have another PR coming that uses this for sqlc vet rule opt-out.