### PR TITLE
feat(vet): Introduce a query annotation to opt out of sqlc vet rules

### DIFF
--- a/docs/howto/vet.md
+++ b/docs/howto/vet.md
@@ -7,10 +7,12 @@
 Rules are defined in the `sqlc` [configuration](../reference/config) file. They consist
 of a name, message, and a [Common Expression Language (CEL)](https://github.com/google/cel-spec)
 expression. Expressions are evaluated using [cel-go](https://github.com/google/cel-go).
-If an expression evaluates to `true`, an error is reported using the given message.
+If an expression evaluates to `true`, `sqlc vet` will report an error using the given message.
 
-Each expression has access to variables from your sqlc configuration and queries,
-defined in the following struct:
+## Defining lint rules
+
+Each lint rule's CEL expression has access to variables from your sqlc configuration and queries,
+defined in the following struct.
 
 ```proto
 message Config
@@ -109,4 +111,47 @@ example](https://github.com/kyleconroy/sqlc/blob/main/examples/authors/sqlc.yaml
 
 Please note that `sqlc` does not manage or migrate your database. Use your
 migration tool of choice to create the necessary database tables and objects
-before running `sqlc vet`.
+before running `sqlc vet` with the `sqlc/db-prepare` rule.
+
+## Running lint rules
+
+When you add the name of a defined rule to the rules list
+for a [sql package](https://docs.sqlc.dev/en/stable/reference/config.html#sql),
+`sqlc vet` will evaluate that rule against every query in the package.
+
+In the example below, two rules are defined but only one is enabled.
+
+```yaml
+version: 2
+sql:
+  - schema: "query.sql"
+    queries: "query.sql"
+    engine: "postgresql"
+    gen:
+      go:
+        package: "authors"
+        out: "db"
+    rules:
+      - no-delete
+rules:
+  - name: no-pg
+    message: "invalid engine: postgresql"
+    rule: |
+      config.engine == "postgresql"
+  - name: no-delete
+    message: "don't use delete statements"
+    rule: |
+      query.sql.contains("DELETE")
+```
+
+### Opting-out of lint rules
+
+For any query, you can tell `sqlc vet` not to evaluate lint rules using the
+`@sqlc-vet-disable` query annotation.
+
+```sql
+/* name: GetAuthor :one */
+/* @sqlc-vet-disable */
+SELECT * FROM authors
+WHERE id = ? LIMIT 1;
+```

--- a/examples/authors/mysql/query.sql
+++ b/examples/authors/mysql/query.sql
@@ -1,4 +1,5 @@
 /* name: GetAuthor :one */
+/* @sqlc-vet-disable */
 SELECT * FROM authors
 WHERE id = ? LIMIT 1;
 

--- a/internal/cmd/vet.go
+++ b/internal/cmd/vet.go
@@ -31,6 +31,7 @@ import (
 var ErrFailedChecks = errors.New("failed checks")
 
 const RuleDbPrepare = "sqlc/db-prepare"
+const QueryFlagSqlcVetDisable = "@sqlc-vet-disable"
 
 func NewCmdVet() *cobra.Command {
 	return &cobra.Command{
@@ -249,7 +250,6 @@ func (c *checker) checkSQL(ctx context.Context, s config.SQL) error {
 		return ErrFailedChecks
 	}
 
-	// TODO: Add MySQL support
 	var prep preparer
 	if s.Database != nil {
 		if c.NoDatabase {
@@ -299,6 +299,10 @@ func (c *checker) checkSQL(ctx context.Context, s config.SQL) error {
 	req := codeGenRequest(result, combo)
 	cfg := vetConfig(req)
 	for i, query := range req.Queries {
+		if result.Queries[i].Flags[QueryFlagSqlcVetDisable] {
+			fmt.Printf("Skipping vet rules for query %s", query.Name)
+			continue
+		}
 		q := vetQuery(query)
 		for _, name := range s.Rules {
 			// Built-in rule

--- a/internal/compiler/parse.go
+++ b/internal/compiler/parse.go
@@ -126,7 +126,7 @@ func (c *Compiler) parseQuery(stmt ast.Node, src string, o opts.Parser) (*Query,
 		return nil, err
 	}
 
-	flags, err := metadata.ParseQueryFlags(comments)
+	flags, comments, err := metadata.ParseQueryFlags(comments)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/metadata/meta.go
+++ b/internal/metadata/meta.go
@@ -104,8 +104,9 @@ func ParseQueryNameAndType(t string, commentStyle CommentSyntax) (string, string
 	return "", "", nil
 }
 
-func ParseQueryFlags(comments []string) (map[string]bool, error) {
+func ParseQueryFlags(comments []string) (map[string]bool, []string, error) {
 	flags := make(map[string]bool)
+	remainingComments := make([]string, 0, len(comments))
 	for _, line := range comments {
 		cleanLine := strings.TrimPrefix(line, "--")
 		cleanLine = strings.TrimPrefix(cleanLine, "/*")
@@ -115,7 +116,9 @@ func ParseQueryFlags(comments []string) (map[string]bool, error) {
 		if strings.HasPrefix(cleanLine, "@") {
 			flagName := strings.SplitN(cleanLine, " ", 2)[0]
 			flags[flagName] = true
+			continue
 		}
+		remainingComments = append(remainingComments, line)
 	}
-	return flags, nil
+	return flags, remainingComments, nil
 }

--- a/internal/metadata/meta_test.go
+++ b/internal/metadata/meta_test.go
@@ -53,7 +53,7 @@ func TestParseQueryFlags(t *testing.T) {
 			"-- @flag-foo",
 		},
 	} {
-		flags, err := ParseQueryFlags(comments)
+		flags, _, err := ParseQueryFlags(comments)
 		if err != nil {
 			t.Errorf("expected query flags to parse, got error: %s", err)
 		}


### PR DESCRIPTION
Introducing the `@sqlc-vet-disable` query annotation, to opt individual queries out of sqlc vet rules, based on https://github.com/kyleconroy/sqlc/issues/2454.

I'm not sure that printing a message to stdout when skipping a query is ideal, but I didn't want to skip silently or return an error and I couldn't use stderr obviously. If skipping silently is better for now I'm happy to remove that line.

Related to the above, I couldn't figure an easy way to test this new functionality without passing in an output stream separate from stderr where a test would expect the skip message to appear. I can do that, but I wasn't sure about the approach and I'm not a testing expert so maybe there's a better thing we could do. Anyway please advise if there's something I should add regarding testing.