### PR TITLE
fix(sec): upgrade certifi to 2022.12.07

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 alabaster==0.7.12
 Babel==2.9.1
-certifi==2022.12.7
+certifi==2022.12.07
 chardet==4.0.0
 commonmark==0.9.1
 docutils==0.16


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2022.12.7
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2022.12.7 to 2022.12.07 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS