### PR TITLE
build: Add psql and mysqlsh to devenv

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -9,6 +9,8 @@
     pkgs.git-cliff
     pkgs.govulncheck
     pkgs.gopls
+    pkgs.mysql-shell
+    pkgs.postgresql_15
     pkgs.python311
   ];
 }


### PR DESCRIPTION
`psql` and `mysqlsh` will now be installed if using devenv.sh