### PR TITLE
Clarify option package support

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -502,7 +502,7 @@ Each mapping in the `packages` collection has the following keys:
 - `emit_methods_with_db_argument`:
   - If true, generated methods will accept a DBTX argument instead of storing a DBTX on the `*Queries` struct. Defaults to `false`.
 - `emit_pointers_for_null_types`:
-  - If true and `sql_package` is set to `pgx/v4`, generated types for nullable columns are emitted as pointers (ie. `*string`) instead of `database/sql` null types (ie. `NullString`). Defaults to `false`.
+  - If true and `sql_package` is set to `pgx/v4` or `pgx/v5`, generated types for nullable columns are emitted as pointers (ie. `*string`) instead of `database/sql` null types (ie. `NullString`). Defaults to `false`.
 - `emit_enum_valid_method`:
   - If true, generate a Valid method on enum types,
     indicating whether a string is a valid enum value.


### PR DESCRIPTION
The emit_pointers_for_null_types option supports both pgx/v4 and pgx/v5 according to the tests:

https://github.com/kyleconroy/sqlc/tree/main/internal/endtoend/testdata/emit_pointers_for_null_types

Ensure that this is clear in the documentation.