### PR TITLE
fix(vet): query.cmd was always set to ":"

### DIFF
--- a/docs/howto/vet.md
+++ b/docs/howto/vet.md
@@ -29,7 +29,7 @@ message Query
   string sql = 1;
   // Name of the query
   string name = 2; 
-  // One of :many, :one, :exec, etc.
+  // One of "many", "one", "exec", etc.
   string cmd = 3;
   // Query parameters, if any
   repeated Parameter params = 4;

--- a/internal/cmd/vet.go
+++ b/internal/cmd/vet.go
@@ -446,7 +446,7 @@ func vetQuery(q *plugin.Query) *vet.Query {
 	return &vet.Query{
 		Sql:    q.Text,
 		Name:   q.Name,
-		Cmd:    strings.TrimPrefix(":", q.Cmd),
+		Cmd:    strings.TrimPrefix(q.Cmd, ":"),
 		Params: params,
 	}
 }

--- a/internal/endtoend/testdata/vet_failures/stderr.txt
+++ b/internal/endtoend/testdata/vet_failures/stderr.txt
@@ -4,3 +4,4 @@ query.sql: CreateAuthor: no-pg: invalid engine: postgresql
 query.sql: CreateAuthor: only-one-param: too many parameters
 query.sql: DeleteAuthor: no-pg: invalid engine: postgresql
 query.sql: DeleteAuthor: no-delete: don't use delete statements
+query.sql: DeleteAuthor: no-exec: don't use exec


### PR DESCRIPTION
When trying to implement a rule using `query.cmd`, I was never able to make it match anything, including the examples provided.
So here's a fix for the small typo :) 

Also, as I was debugging, the comment on `messsage Query` made it a bit unclear if I should match `:cmd` or just `cmd`, so changed the examples to be without `:`